### PR TITLE
chore(tests): add unexpected error management in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Technical - Add sonar lint.
 - Technical - Make the CI lint the commit messages.
 - Readme - Add the test coverage badge.
+- Technical - Add unexpected error management in tests.
 
 ### Changed
 - Technical - Untrack IDE `.idea` folder.

--- a/test/commands/test-cli-errors.js
+++ b/test/commands/test-cli-errors.js
@@ -44,8 +44,11 @@ function errorIfBadCommand(command) {
 
 function errorIfNoStd(stds) {
   if (!stds || !Array.isArray(stds) || !stds.length > 0) {
-    throw new Error('testCli configuration error: "std" must be an not empty array ex.'
-      + ' [{in:\'john\'},{out:\'hello, john\'}]');
+    throw new Error('testCli configuration error: "std" or "exitCode" or "exitMessage" must be' +
+      ' defined.\n' +
+      ' "std" must be a not empty array like [{in:\'john\'},{out:\'hello, john\'}]\n' +
+      ' Define "exitCode" and/or "exitMessage" instead of "std" if you are testing an error' +
+      ' case.');
   }
 }
 
@@ -58,6 +61,16 @@ function validateInput(file, command, stds, expectedExitCode, expectedExitMessag
     errorIfNoStd(stds);
     errorIfStdRest(stds);
   }
+}
+
+// NOTICE: Assert that command did not throw an error if there is no expected error.
+function assertNoErrorThrown(actualError, expectedExitCode, expectedExitMessage) {
+  if (expectedExitCode || expectedExitMessage) return;
+
+  const noErrorMessage = 'Unexpected error thrown by command.\n' +
+    ' No "exitCode" and/or "exitMessage" is specified, so this error should not be thrown.';
+  const message = actualError || noErrorMessage;
+  expect(message).toStrictEqual(noErrorMessage);
 }
 
 function assertExitCode(actualError, expectedExitCode) {
@@ -84,4 +97,5 @@ module.exports = {
   validateInput,
   assertExitCode,
   assertExitMessage,
+  assertNoErrorThrown,
 };

--- a/test/commands/test-cli-errors.js
+++ b/test/commands/test-cli-errors.js
@@ -44,11 +44,11 @@ function errorIfBadCommand(command) {
 
 function errorIfNoStd(stds) {
   if (!stds || !Array.isArray(stds) || !stds.length > 0) {
-    throw new Error('testCli configuration error: "std" or "exitCode" or "exitMessage" must be' +
-      ' defined.\n' +
-      ' "std" must be a not empty array like [{in:\'john\'},{out:\'hello, john\'}]\n' +
-      ' Define "exitCode" and/or "exitMessage" instead of "std" if you are testing an error' +
-      ' case.');
+    throw new Error('testCli configuration error: "std" or "exitCode" or "exitMessage" must be'
+      + ' defined.\n'
+      + ' "std" must be a not empty array like [{in:\'john\'},{out:\'hello, john\'}]\n'
+      + ' Define "exitCode" and/or "exitMessage" instead of "std" if you are testing an error'
+      + ' case.');
   }
 }
 
@@ -67,8 +67,8 @@ function validateInput(file, command, stds, expectedExitCode, expectedExitMessag
 function assertNoErrorThrown(actualError, expectedExitCode, expectedExitMessage) {
   if (expectedExitCode || expectedExitMessage) return;
 
-  const noErrorMessage = 'Unexpected error thrown by command.\n' +
-    ' No "exitCode" and/or "exitMessage" is specified, so this error should not be thrown.';
+  const noErrorMessage = 'Unexpected error thrown by command.\n'
+    + ' No "exitCode" and/or "exitMessage" is specified, so this error should not be thrown.';
   const message = actualError || noErrorMessage;
   expect(message).toStrictEqual(noErrorMessage);
 }

--- a/test/commands/test-cli-errors.js
+++ b/test/commands/test-cli-errors.js
@@ -44,11 +44,14 @@ function errorIfBadCommand(command) {
 
 function errorIfNoStd(stds) {
   if (!stds || !Array.isArray(stds) || !stds.length > 0) {
-    throw new Error('testCli configuration error: "std" or "exitCode" or "exitMessage" must be'
-      + ' defined.\n'
-      + ' "std" must be a not empty array like [{in:\'john\'},{out:\'hello, john\'}]\n'
-      + ' Define "exitCode" and/or "exitMessage" instead of "std" if you are testing an error'
-      + ' case.');
+    throw new Error(
+      // eslint-disable-next-line no-multi-str
+      'testCli configuration error: "std" or "exitCode" or "exitMessage" must be \
+      defined.\n \
+      "std" must be a not empty array like [{in:\'john\'},{out:\'hello, john\'}]\n \
+      Define "exitCode" and/or "exitMessage" instead of "std" if you are testing an error \
+      case.',
+    );
   }
 }
 
@@ -67,8 +70,9 @@ function validateInput(file, command, stds, expectedExitCode, expectedExitMessag
 function assertNoErrorThrown(actualError, expectedExitCode, expectedExitMessage) {
   if (expectedExitCode || expectedExitMessage) return;
 
-  const noErrorMessage = 'Unexpected error thrown by command.\n'
-    + ' No "exitCode" and/or "exitMessage" is specified, so this error should not be thrown.';
+  // eslint-disable-next-line no-multi-str
+  const noErrorMessage = 'Unexpected error thrown by command.\n \
+   No "exitCode" and/or "exitMessage" is specified, so this error should not be thrown.';
   const message = actualError || noErrorMessage;
   expect(message).toStrictEqual(noErrorMessage);
 }

--- a/test/commands/test-cli.js
+++ b/test/commands/test-cli.js
@@ -1,4 +1,8 @@
-const { assertExitCode, assertExitMessage } = require('./test-cli-errors');
+const {
+  assertExitCode,
+  assertExitMessage,
+  assertNoErrorThrown,
+} = require('./test-cli-errors');
 const { mockEnv, rollbackEnv } = require('./test-cli-env');
 const { assertApi } = require('./test-cli-api');
 const { mockFile } = require('./test-cli-fs');
@@ -47,6 +51,7 @@ async function testCli({
     actualError = error;
   }
 
+  assertNoErrorThrown(actualError, expectedExitCode, expectedExitMessage);
   assertApi(nocks);
   assertExitCode(actualError, expectedExitCode);
   assertExitMessage(actualError, expectedExitMessage);


### PR DESCRIPTION
This PR allows to a better display in case of unexpected errors.

Given a test that should success (no error thrown)
When the test run but throw an error (unexpected)
Then a friendly message explains the situation (command throw this unexpected error: ...)

To test it:
-Take an existing error test (example l.31 of `delete.test.js`)
-Replace the expected `exitCode` by an expected output like std:[{out:"toto"}]
-The test should fail and display the reason.