### PR TITLE
fix(login): exit any process if the authentication fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - Technical - Use Jest instead of Mocha for the test base.
 - Technical - Rename the class of the environments update command.
 
+### Fixed
+- Authentication - Exit any process if the authentication fails.
+
 ## RELEASE 1.1.0 - 2020-03-20
 ### Added
 - Environments - Add environments:update command.

--- a/src/abstract-authenticated-command.js
+++ b/src/abstract-authenticated-command.js
@@ -10,21 +10,25 @@ class AbstractAuthenticatedCommand extends Command {
       await authenticator.tryLogin({});
     }
 
-    try {
-      return await this.runIfAuthenticated();
-    } catch (error) {
-      // NOTICE: Due to ip-whitelist, 404 will never be thrown for a project
-      if (error.status === 403) {
-        return this.error('You do not have the right to execute this action on this project');
-      }
+    // NOTICE: Check if really authenticated before executing runIfAuthenticated() function.
+    if (authenticator.getAuthToken()) {
+      try {
+        return await this.runIfAuthenticated();
+      } catch (error) {
+        // NOTICE: Due to ip-whitelist, 404 will never be thrown for a project
+        if (error.status === 403) {
+          return this.error('You do not have the right to execute this action on this project');
+        }
 
-      if (error.status === 401) {
-        await authenticator.logout();
-        return this.displayLoginMessageAndQuit();
-      }
+        if (error.status === 401) {
+          await authenticator.logout();
+          return this.displayLoginMessageAndQuit();
+        }
 
-      throw error;
+        throw error;
+      }
     }
+    return process.exit();
   }
 
   async runIfAuthenticated() {


### PR DESCRIPTION
The current behaviour is not correct: if the login fails, the runIfAuthenticated() function is called anyway.
It ends up with ongoing process after a login failure:
<img width="766" alt="Capture d’écran 2020-04-30 à 11 07 06" src="https://user-images.githubusercontent.com/48474636/80693050-be60c680-8ad2-11ea-89de-7ada27300e67.png">
