### PR TITLE
fix(apply:shema)!: require authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test/services/tokens
 # IDE
 /*.iml
 .idea
+/.vscode

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "Arnaud Valensi <arnaud.valensi@gmail.com>",
     "Vincent Molinié <molinie.vincent@gmail.com>",
     "David Routhieau <rootio@protonmail.com>",
-    "Arnaud Besnier <arnaudibesnier@gmail.com>"
+    "Arnaud Besnier <arnaudibesnier@gmail.com>",
+    "Guillaume Gautreau <guillaume@ghusse.com>"
   ],
   "bin": {
     "forest": "./bin/run"

--- a/src/services/authenticator.js
+++ b/src/services/authenticator.js
@@ -8,7 +8,14 @@ const api = require('./api');
 const logger = require('./logger');
 const { ERROR_UNEXPECTED } = require('../utils/messages');
 
+/**
+ * @class
+ */
 function Authenticator() {
+  /**
+   * @param {string?} path
+   * @returns {string}
+   */
   this.getAuthToken = (path = process.env.TOKEN_PATH || os.homedir()) => {
     const forestrcToken = this.getVerifiedToken(`${path}/.forestrc`);
     return forestrcToken || this.getVerifiedToken(`${path}/.lumberrc`);

--- a/src/services/schema-sender.js
+++ b/src/services/schema-sender.js
@@ -3,11 +3,23 @@ const agent = require('superagent-promise')(require('superagent'), P);
 const config = require('../config');
 const logger = require('../services/logger');
 
-function SchemaSender(serializedSchema, secret, oclifExit) {
+/**
+ * @class
+ * @param {string} serializedSchema
+ * @param {string} secret
+ * @param {(code: number) => void} oclifExit
+ * @param {string} authToken
+ */
+function SchemaSender(serializedSchema, secret, oclifExit, authToken) {
+  /**
+   * @function
+   * @returns {Promise<number | undefined>}
+   */
   this.perform = () =>
     agent
       .post(`${config.serverHost()}/forest/apimaps`)
       .set('forest-secret-key', secret)
+      .set('Authorization', `Bearer ${authToken}`)
       .send(serializedSchema)
       .then(({ body }) => {
         if (body && body.meta) {

--- a/test/commands/schema/apply.test.js
+++ b/test/commands/schema/apply.test.js
@@ -2,133 +2,164 @@ const testCli = require('./../test-cli');
 const ApplySchemaCommand = require('../../../src/commands/schema/apply');
 const { testEnv, testEnv2 } = require('../../fixtures/env');
 const {
+  loginValid,
   postSchema,
   postSchema404,
   postSchema500,
   postSchema503,
 } = require('../../fixtures/api');
+const { loginPasswordDialog } = require('../../fixtures/std');
 
 const {
   forestadminSchema,
   forestadminSchemaSnake,
 } = require('../../fixtures/files');
 
-describe('schema:apply', () => {
-  describe('with no environment secret', () => {
-    it('should exist with code 2', () => testCli({
-      file: {
-        chdir: '/tmp',
-        name: './.forestadmin-schema.json',
-        content: forestadminSchema,
+function postSchemaMatch(body) {
+  expect(body).toMatchObject({
+    meta: {
+      liana: 'forest-express-sequelize',
+      orm_version: '3.24.8',
+      database_type: 'postgres',
+      liana_version: '2.16.9',
+    },
+    data: [
+      {
+        type: 'collections',
+        id: 'Users',
+        attributes: {
+          name: 'Users',
+        },
       },
-      env: testEnv,
-      token: 'any',
-      command: () => ApplySchemaCommand.run([]),
-      std: [{
-        err: 'Cannot find your forest environment secret in the environment variable "FOREST_ENV_SECRET".\n'
-      + 'Please set the "FOREST_ENV_SECRET" variable or pass the secret in parameter using --secret.',
-      }],
-      exitCode: 2,
-    }));
+    ],
   });
+  return true;
+}
 
-  describe('with an environment secret set in "FOREST_ENV_SECRET" environment variable', () => {
-    describe('with forest server returning 404', () => {
-      it('should exit with exit code 4', () => testCli({
+describe('schema:apply', () => {
+  describe('when the user is logged in', () => {
+    describe('with no environment secret', () => {
+      it('should exist with code 2', () => testCli({
         file: {
           chdir: '/tmp',
           name: './.forestadmin-schema.json',
           content: forestadminSchema,
         },
-        env: testEnv2,
+        env: testEnv,
+        token: 'any',
         command: () => ApplySchemaCommand.run([]),
-        api: [postSchema404()],
-        std: [{ err: 'Cannot find the project related to the environment secret you configured.' }],
-        exitCode: 4,
+        std: [{
+          err: 'Cannot find your forest environment secret in the environment variable "FOREST_ENV_SECRET".\n'
+      + 'Please set the "FOREST_ENV_SECRET" variable or pass the secret in parameter using --secret.',
+        }],
+        exitCode: 2,
       }));
     });
 
-    describe('with forest server returning 503', () => {
-      it('should exit with exit code 5', () => testCli({
-        file: {
-          chdir: '/tmp',
-          name: './.forestadmin-schema.json',
-          content: forestadminSchema,
-        },
-        env: testEnv2,
-        api: [postSchema503()],
-        command: () => ApplySchemaCommand.run([]),
-        std: [{ err: 'Forest is in maintenance for a few minutes. We are upgrading your experience in the forest. We just need a few more minutes to get it right.' }],
-        exitCode: 5,
-      }));
-    });
-
-    describe('with forest server returning 200', () => {
-      const postSchemaMatch = (body) => {
-        expect(body).toMatchObject({
-          meta: {
-            liana: 'forest-express-sequelize',
-            orm_version: '3.24.8',
-            database_type: 'postgres',
-            liana_version: '2.16.9',
+    describe('with an environment secret set in "FOREST_ENV_SECRET" environment variable', () => {
+      describe('with forest server returning 404', () => {
+        it('should exit with exit code 4', () => testCli({
+          file: {
+            chdir: '/tmp',
+            name: './.forestadmin-schema.json',
+            content: forestadminSchema,
           },
-          data: [
-            {
-              type: 'collections',
-              id: 'Users',
-              attributes: {
-                name: 'Users',
-              },
-            },
-          ],
-        });
-        return true;
-      };
+          token: 'any',
+          env: testEnv2,
+          command: () => ApplySchemaCommand.run([]),
+          api: [postSchema404()],
+          std: [{ err: 'Cannot find the project related to the environment secret you configured.' }],
+          exitCode: 4,
+        }));
+      });
 
-      describe('with a schema with camelcased keys', () => {
-        it('should send the schema', () => testCli({
+      describe('with forest server returning 503', () => {
+        it('should exit with exit code 5', () => testCli({
           file: {
             chdir: '/tmp',
             name: './.forestadmin-schema.json',
             content: forestadminSchema,
           },
           env: testEnv2,
-          token: 'any',
-          api: [postSchema(postSchemaMatch)],
+          api: [postSchema503()],
           command: () => ApplySchemaCommand.run([]),
-          std: [
-            { out: 'Reading "./.forestadmin-schema.json"...' },
-            {
-              out: 'Using the forest environment secret found in the environment variable "FOREST_ENV_SECRET"',
-            },
-            { out: 'Sending "./.forestadmin-schema.json"...' },
-            { out: 'The schema is the same as before, nothing changed.' },
-          ],
+          std: [{ err: 'Forest is in maintenance for a few minutes. We are upgrading your experience in the forest. We just need a few more minutes to get it right.' }],
+          exitCode: 5,
+          token: 'any',
         }));
       });
 
-      describe('with a schema with snakecased keys', () => {
-        it('should send the schema', () => testCli({
-          file: {
-            chdir: '/tmp',
-            name: './.forestadmin-schema.json',
-            content: forestadminSchemaSnake,
-          },
-          env: testEnv2,
-          token: 'any',
-          api: [postSchema(postSchemaMatch)],
-          command: () => ApplySchemaCommand.run([]),
-          std: [
-            { out: 'Reading "./.forestadmin-schema.json"...' },
-            {
-              out: 'Using the forest environment secret found in the environment variable "FOREST_ENV_SECRET"',
+      describe('with forest server returning 200', () => {
+        describe('with a schema with camelcased keys', () => {
+          it('should send the schema', () => testCli({
+            file: {
+              chdir: '/tmp',
+              name: './.forestadmin-schema.json',
+              content: forestadminSchema,
             },
-            { out: 'Sending "./.forestadmin-schema.json"...' },
-            { out: 'The schema is the same as before, nothing changed.' },
-          ],
-        }));
+            env: testEnv2,
+            token: 'any',
+            api: [postSchema(postSchemaMatch)],
+            command: () => ApplySchemaCommand.run([]),
+            std: [
+              { out: 'Reading "./.forestadmin-schema.json"...' },
+              {
+                out: 'Using the forest environment secret found in the environment variable "FOREST_ENV_SECRET"',
+              },
+              { out: 'Sending "./.forestadmin-schema.json"...' },
+              { out: 'The schema is the same as before, nothing changed.' },
+            ],
+          }));
+        });
+
+        describe('with a schema with snakecased keys', () => {
+          it('should send the schema', () => testCli({
+            file: {
+              chdir: '/tmp',
+              name: './.forestadmin-schema.json',
+              content: forestadminSchemaSnake,
+            },
+            env: testEnv2,
+            token: 'any',
+            api: [postSchema(postSchemaMatch)],
+            command: () => ApplySchemaCommand.run([]),
+            std: [
+              { out: 'Reading "./.forestadmin-schema.json"...' },
+              {
+                out: 'Using the forest environment secret found in the environment variable "FOREST_ENV_SECRET"',
+              },
+              { out: 'Sending "./.forestadmin-schema.json"...' },
+              { out: 'The schema is the same as before, nothing changed.' },
+            ],
+          }));
+        });
       });
     });
+  });
+
+  describe('when the user is not logged in', () => {
+    it('should as for the login/password and then send the schema', () => testCli({
+      file: {
+        chdir: '/tmp',
+        name: './.forestadmin-schema.json',
+        content: forestadminSchema,
+      },
+      env: testEnv2,
+      api: [
+        loginValid(),
+        postSchema(postSchemaMatch),
+      ],
+      command: () => ApplySchemaCommand.run([]),
+      std: [
+        ...loginPasswordDialog,
+        { out: 'Reading "./.forestadmin-schema.json"...' },
+        {
+          out: 'Using the forest environment secret found in the environment variable "FOREST_ENV_SECRET"',
+        },
+        { out: 'Sending "./.forestadmin-schema.json"...' },
+        { out: 'The schema is the same as before, nothing changed.' },
+      ],
+    }));
   });
 });
 


### PR DESCRIPTION
Linked to CU-6jpyjv

Command schema:apply now requires authentication, to avoid 401 errors.

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Create automatic tests
- [ ] No automatic tests failures
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
