### PR TITLE
feat(switch-command): add branch:switch alias

### DIFF
--- a/src/commands/switch.js
+++ b/src/commands/switch.js
@@ -112,4 +112,6 @@ SwitchCommand.args = [{
   name: 'BRANCH_NAME', required: false, description: 'The name of the local branch to set as current.',
 }];
 
+SwitchCommand.aliases = ['branch:switch'];
+
 module.exports = SwitchCommand;


### PR DESCRIPTION
## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Create automatic tests
- [x] Test manually the implemented changes
- [x] Review my own code (syntax, style, simplicity, readability)

It is actually impossible to test because of the test format we currently have

I couldn't decide whether to alias the command with `forest branch:switch` or to make the command to actually be `forest branch:switch` and add `forest switch` as an alias. What would you suggest ? My bet is that other commands related to DWO don't use the entity:action pattern, so let's keep it as it is and add the `forest branch:switch` as an alias. 