### PR TITLE
chore: add Dependabot config file (native GH)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    open-pull-requests-limit: 10
+    directory: "/"
+    target-branch: "main"
+    versioning-strategy: auto
+    schedule:
+        interval: daily
+    commit-message:
+        prefix: "chore(deps):"


### PR DESCRIPTION
### Description

Adds dependabot.yml (config file) for native-GitHub Dependabot.
**TODO**: Check/Confirm in repo settings that Dependabot is properly enabled

versioning-strategy is set to auto (default option) === the version requirements are increased