### PR TITLE
chore: attempt to rebase coverage upload on current targeted branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,8 @@ jobs:
         if: matrix.withCoverage && matrix.node == 14
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+          GIT_COMMIT_SHA: ${{ env.CHECKOUT_REFERENCE }}
+          GIT_BRANCH: ${{ github.head_ref || github.ref }}
         with:
           coverageCommand: yarn test:coverage
       - name: Test prepack


### PR DESCRIPTION
### Description

CodeClimate GH action is using default context to upload coverage reports and return a response via its app.
On pull requesttarget event, this context corresponds to main's for security reasons

First solution: attempting to bypass this rule by providing env variables to the action directly (like CC REPORTER ID)
Second solution: raise an issue and fork the repository