### PR TITLE
chore: use forked action to report coverage status on pr_target event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,14 +70,13 @@ jobs:
         if: ${{ !matrix.withCoverage }}
         run: yarn test
       - name: Test with Node ${{ matrix.node }} & Send coverage
-        uses: paambaati/codeclimate-action@84cea27117a473d605400ca3a97fcef7e433e2d6
+        uses: ForestAdmin/codeclimate-action@master
         if: matrix.withCoverage && matrix.node == 14
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-          GIT_COMMIT_SHA: ${{ env.CHECKOUT_REFERENCE }}
-          GIT_BRANCH: ${{ github.head_ref || github.ref }}
         with:
           coverageCommand: yarn test:coverage
+          ref: ${{ env.CHECKOUT_REFERENCE }}
       - name: Test prepack
         run: yarn prepack
       - name: Test postpack


### PR DESCRIPTION
### Description

CC Action is using `github` context to retrieve current commit SHA and branch. Unfortunately, it is not compatible with `pull_request_target` event which run in a 'sanitize/secure' context i.e. default branch.

I forked the action and resolved the issue by adding an input: the explicit SHA that references the PR (head)
https://github.com/ForestAdmin/codeclimate-action/commit/8cbd8e9d97fb915351c7ee5b3f216914644095fb