### PR TITLE
chore: add TO on workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Cancel previous running workflows
         uses: fkirc/skip-duplicate-actions@9da67cec51d21092667038f0f4fda73099a3a451
@@ -43,6 +44,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [lint]
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - name: Cancel previous running workflows
         uses: fkirc/skip-duplicate-actions@9da67cec51d21092667038f0f4fda73099a3a451
@@ -44,7 +44,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 15
     needs: [lint]
     strategy:
       matrix:


### PR DESCRIPTION
With the latest 'bricolage', some steps can be infinite. One reason is: the step cannot find a host to start.. (is it even related ?)
To prevent this issue to become an economic wormhole, timeout-minutes is added

Issue1: https://github.com/ForestAdmin/toolbelt/actions/runs/1417190894
Issue2: https://github.com/ForestAdmin/toolbelt/runs/4091624674?check_suite_focus=true