### PR TITLE
chore(workflow): add timeouts to prevent accidental indefinite run of workflows/actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Cancel previous running workflows
         uses: fkirc/skip-duplicate-actions@9da67cec51d21092667038f0f4fda73099a3a451
@@ -43,6 +44,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [lint]
     strategy:
       matrix:
@@ -85,6 +87,7 @@ jobs:
   deploy:
     name: Release package
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [test]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta')
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   get-team:
     runs-on: ubuntu-latest
     continue-on-error: false
+    timeout-minutes: 10
     outputs:
       developers: |
         ${{ (github.actor != 'dependabot[bot]' && join(fromJSON(steps.get_devs.outputs.data).*.login, ', ')) 
@@ -31,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get-team]
     continue-on-error: false
+    timeout-minutes: 10
     steps:
       - if: ${{ !contains(needs.get-team.outputs.developers, github.actor) }}
         run: |


### PR DESCRIPTION
### Description

Given the latest issue raised by the update of the workflow ([here](https://github.com/ForestAdmin/toolbelt/pull/280)), I am adding `timeout-minutes` to prevent service degradation at GH to punch a hole in our economics with a never-ending Action run.