### PR TITLE
chore: replace forked codecliamte action by the original

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
         if: ${{ !matrix.withCoverage }}
         run: yarn test
       - name: Test with Node ${{ matrix.node }} & Send coverage
-        uses: ForestAdmin/codeclimate-action@master
+        uses: paambaati/codeclimate-action@84cea27117a473d605400ca3a97fcef7e433e2d6
         if: matrix.withCoverage && matrix.node == 14
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}


### PR DESCRIPTION
No use of `ForestAdmin/codeclimate-action@master` anymore: Can get rid of it