### PR TITLE
feat: remove environment option in push command

### DIFF
--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -2,7 +2,6 @@ const AbstractAuthenticatedCommand = require('../abstract-authenticated-command'
 const BranchManager = require('../services/branch-manager');
 const ProjectManager = require('../services/project-manager');
 const withCurrentProject = require('../services/with-current-project');
-const askForEnvironment = require('../services/ask-for-environment');
 
 class PushCommand extends AbstractAuthenticatedCommand {
   init(plan) {
@@ -32,11 +31,6 @@ class PushCommand extends AbstractAuthenticatedCommand {
 
       if (!currentBranch) {
         throw new Error('No current branch.');
-      }
-
-      // TODO: DWO EP17 remove destination environemnt handle
-      if (!config.environment) {
-        config.environment = await askForEnvironment(config, 'Select the remote environment you want to push onto', ['remote']);
       }
 
       if (!config.force) {

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -44,13 +44,13 @@ class PushCommand extends AbstractAuthenticatedCommand {
           .prompt([{
             type: 'confirm',
             name: 'confirm',
-            message: `Push branch ${currentBranch.name} onto ${config.environment}`,
+            message: `Push branch ${currentBranch.name} onto branch origin`,
           }]);
         if (!response.confirm) return;
       }
 
-      await BranchManager.pushBranch(config.environment, config.envSecret);
-      this.logger.success(`Branch ${currentBranch.name} successfully pushed onto ${config.environment}.`);
+      await BranchManager.pushBranch(config.envSecret);
+      this.logger.success(`Branch ${currentBranch.name} successfully pushed onto branch origin.`);
     } catch (error) {
       const customError = BranchManager.handleBranchError(error);
       this.logger.error(customError);
@@ -61,14 +61,9 @@ class PushCommand extends AbstractAuthenticatedCommand {
 
 PushCommand.aliases = ['branches:push'];
 
-PushCommand.description = 'Push layout changes of your current branch to a remote environment.';
+PushCommand.description = 'Push layout changes of your current branch to the branch origin.';
 
 PushCommand.flags = {
-  // TODO: DWO EP17 remove environment option
-  environment: AbstractAuthenticatedCommand.flags.string({
-    char: 'e',
-    description: 'The remote environment name to push onto.',
-  }),
   force: AbstractAuthenticatedCommand.flags.boolean({
     description: 'Skip push changes confirmation.',
   }),

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -44,15 +44,16 @@ class PushCommand extends AbstractAuthenticatedCommand {
           .prompt([{
             type: 'confirm',
             name: 'confirm',
-            message: `Push branch ${currentBranch.name} onto branch origin`,
+            message: `Push branch ${currentBranch.name} onto ${currentBranch.originEnvironment.name}`,
           }]);
         if (!response.confirm) return;
       }
 
       await BranchManager.pushBranch(config.envSecret);
-      this.logger.success(`Branch ${currentBranch.name} successfully pushed onto branch origin.`);
+      this.logger.success(`Branch ${currentBranch.name} successfully pushed onto ${currentBranch.originEnvironment.name}.`);
     } catch (error) {
       const customError = BranchManager.handleBranchError(error);
+      console.log('florian ', error);
       this.logger.error(customError);
       this.exit(2);
     }

--- a/src/commands/push.js
+++ b/src/commands/push.js
@@ -53,7 +53,6 @@ class PushCommand extends AbstractAuthenticatedCommand {
       this.logger.success(`Branch ${currentBranch.name} successfully pushed onto ${currentBranch.originEnvironment.name}.`);
     } catch (error) {
       const customError = BranchManager.handleBranchError(error);
-      console.log('florian ', error);
       this.logger.error(customError);
       this.exit(2);
     }

--- a/src/services/branch-manager.js
+++ b/src/services/branch-manager.js
@@ -70,7 +70,7 @@ function createBranch(branchName, environmentSecret) {
 }
 
 // TODO: DWO EP17 remove destinationEnvironmentName handle
-function pushBranch(destinationEnvironmentName, environmentSecret) {
+function pushBranch(environmentSecret) {
   const {
     assertPresent,
     authenticator,
@@ -84,7 +84,7 @@ function pushBranch(destinationEnvironmentName, environmentSecret) {
     .post(`${env.FOREST_URL}/api/branches/push`)
     .set('Authorization', `Bearer ${authToken}`)
     .set('forest-secret-key', `${environmentSecret}`)
-    .send({ destinationEnvironmentName: encodeURIComponent(destinationEnvironmentName) });
+    .send();
 }
 
 function switchBranch({ id }, environmentSecret) {

--- a/src/services/branch-manager.js
+++ b/src/services/branch-manager.js
@@ -69,7 +69,6 @@ function createBranch(branchName, environmentSecret) {
     .send({ branchName: encodeURIComponent(branchName) });
 }
 
-// TODO: DWO EP17 remove destinationEnvironmentName handle
 function pushBranch(environmentSecret) {
   const {
     assertPresent,

--- a/test/commands/push.test.js
+++ b/test/commands/push.test.js
@@ -26,7 +26,7 @@ describe('push', () => {
     const branchName = 'feature/second';
     const environmentName = 'Staging';
 
-    it("shouldn't the push if user cancel the confirmation", () => testCli({
+    it("shouldn't push if user cancel the confirmation", () => testCli({
       env: testEnvWithSecret,
       token: 'any',
       commandClass: PushCommand,

--- a/test/commands/push.test.js
+++ b/test/commands/push.test.js
@@ -4,7 +4,10 @@ const {
   getBranchListValid,
   getDevelopmentEnvironmentValid,
   getInAppProjectForDevWorkflow,
+  getNoBranchListValid,
   getProjectByEnv,
+  getV1ProjectForDevWorkflow,
+  pushBranchInvalidDestinationBranch,
   pushBranchValid,
   invalidPushBranchToReference,
 } = require('../fixtures/api');
@@ -140,8 +143,85 @@ describe('push', () => {
         },
       ],
       std: [
-        { out: '× Failed to push branch: cannot "push" to reference environment, please use "deploy"' },
+        { err: '× Failed to push branch: cannot "push" to reference environment, please use "deploy"' },
       ],
+      exitCode: 2,
+    }));
+  });
+
+  describe('when development environment doesn\'t have branch', () => {
+    const projectId = 82;
+    const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
+    it('should throw an error', () => testCli({
+      env: testEnvWithSecret,
+      token: 'any',
+      commandClass: PushCommand,
+      api: [
+        () => getProjectByEnv(),
+        () => getInAppProjectForDevWorkflow(projectId),
+        () => getDevelopmentEnvironmentValid(projectId),
+        () => getNoBranchListValid(envSecret),
+      ],
+      std: [
+        { err: '× You don\'t have any branch to push. Use `forest branch` to create one or use `forest switch` to set your current branch.' },
+      ],
+      exitCode: 2,
+    }));
+  });
+
+  describe('when development environment doesn\'t have current branch', () => {
+    const projectId = 82;
+    const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
+    it('should throw an error', () => testCli({
+      env: testEnvWithSecret,
+      token: 'any',
+      commandClass: PushCommand,
+      api: [
+        () => getProjectByEnv(),
+        () => getInAppProjectForDevWorkflow(projectId),
+        () => getDevelopmentEnvironmentValid(projectId),
+        () => getBranchListValid(envSecret, false),
+      ],
+      std: [
+        { err: '× You don\'t have any branch to push. Use `forest branch` to create one or use `forest switch` to set your current branch.' },
+      ],
+      exitCode: 2,
+    }));
+  });
+
+  describe('when destination environment doesn\'t have branch', () => {
+    const projectId = 82;
+    const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
+    it('should throw an error', () => testCli({
+      env: testEnvWithSecret,
+      token: 'any',
+      commandClass: PushCommand,
+      commandArgs: ['--force'],
+      api: [
+        ...getValidProjectEnvironementAndBranch(projectId, envSecret),
+        () => pushBranchInvalidDestinationBranch(envSecret),
+      ],
+      std: [
+        { err: '× The environment on which you are trying to push your modifications doesn\'t have current branch.' },
+      ],
+      exitCode: 2,
+    }));
+  });
+
+  describe('when project is version 1', () => {
+    const projectId = 82;
+    it('should throw an error', () => testCli({
+      env: testEnvWithSecret,
+      token: 'any',
+      commandClass: PushCommand,
+      api: [
+        () => getProjectByEnv(),
+        () => getV1ProjectForDevWorkflow(projectId),
+      ],
+      std: [
+        { err: '× This project does not support branches yet. Please migrate your environments from your Project settings first.' },
+      ],
+      exitCode: 2,
     }));
   });
 });

--- a/test/commands/push.test.js
+++ b/test/commands/push.test.js
@@ -3,19 +3,12 @@ const PushCommand = require('../../src/commands/push');
 const {
   getBranchListValid,
   getDevelopmentEnvironmentValid,
-  getEnvironmentListValid,
   getInAppProjectForDevWorkflow,
-  getNoBranchListValid,
-  getNoEnvironmentListValid,
   getProjectByEnv,
-  getProjectListValid,
-  getV1ProjectForDevWorkflow,
-  pushBranchInvalidDestination,
-  pushBranchInvalidDestinationBranch,
-  pushBranchInvalidType,
   pushBranchValid,
+  invalidPushBranchToReference,
 } = require('../fixtures/api');
-const { testEnvWithoutSecret, testEnvWithSecret } = require('../fixtures/env');
+const { testEnvWithSecret } = require('../fixtures/env');
 
 const getValidProjectEnvironementAndBranch = (projectId, envSecret) => [
   () => getProjectByEnv(),
@@ -23,323 +16,132 @@ const getValidProjectEnvironementAndBranch = (projectId, envSecret) => [
   () => getDevelopmentEnvironmentValid(projectId),
   () => getBranchListValid(envSecret),
 ];
-
 describe('push', () => {
-  describe('when the user is logged in', () => {
-    describe('when no project was provided', () => {
-      const projectId = 1;
-      const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
-      const branchName = 'feature/second';
-      const environmentName = 'name1';
-      it('should display the list of projects', () => testCli({
-        env: testEnvWithoutSecret,
-        token: 'any',
-        commandClass: PushCommand,
-        api: [
-          () => getProjectListValid(),
-          () => getInAppProjectForDevWorkflow(projectId),
-          () => getDevelopmentEnvironmentValid(),
-          () => getBranchListValid(envSecret),
-          () => getEnvironmentListValid(projectId),
-          () => pushBranchValid(envSecret),
-        ],
-        prompts: [
-          {
-            in: [{
-              name: 'project',
-              message: 'Select your project',
-              type: 'list',
-              choices: [
-                { name: 'project1', value: 1 },
-                { name: 'project2', value: 2 },
-              ],
-            }],
-            out: { project: 1 },
+  describe('when the user use push command', () => {
+    const projectId = 82;
+    const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
+    const branchName = 'feature/second';
+    const environmentName = 'Staging';
+
+    it("shouldn't the push if user cancel the confirmation", () => testCli({
+      env: testEnvWithSecret,
+      token: 'any',
+      commandClass: PushCommand,
+      api: [
+        ...getValidProjectEnvironementAndBranch(projectId, envSecret),
+      ],
+      prompts: [
+        {
+          in: [{
+            name: 'confirm',
+            message: `Push branch ${branchName} onto ${environmentName}`,
+            type: 'confirm',
+          }],
+          out: {
+            confirm: false,
           },
-          {
-            in: [{
-              name: 'environment',
-              message: 'Select the remote environment you want to push onto',
-              type: 'list',
-              choices: ['name1'],
-            }],
-            out: {
-              environment: 'name1',
-            },
+        },
+      ],
+      std: [
+        { out: '' },
+      ],
+    }));
+
+    it('should push if user confirm', () => testCli({
+      env: testEnvWithSecret,
+      token: 'any',
+      commandClass: PushCommand,
+      api: [
+        ...getValidProjectEnvironementAndBranch(projectId, envSecret),
+        () => pushBranchValid(envSecret),
+      ],
+      prompts: [
+        {
+          in: [{
+            name: 'confirm',
+            message: `Push branch ${branchName} onto ${environmentName}`,
+            type: 'confirm',
+          }],
+          out: {
+            confirm: true,
           },
-          {
-            in: [{
-              name: 'confirm',
-              message: 'Push branch feature/second onto name1',
-              type: 'confirm',
-            }],
-            out: {
-              confirm: true,
-            },
+        },
+      ],
+      std: [
+        { out: `√ Branch ${branchName} successfully pushed onto ${environmentName}.` },
+      ],
+    }));
+
+    it('should not display the list of environments', () => testCli({
+      env: testEnvWithSecret,
+      token: 'any',
+      commandClass: PushCommand,
+      commandArgs: [],
+      api: [
+        ...getValidProjectEnvironementAndBranch(projectId, envSecret),
+        () => pushBranchValid(envSecret),
+      ],
+      prompts: [
+        {
+          in: [{
+            name: 'confirm',
+            message: `Push branch ${branchName} onto ${environmentName}`,
+            type: 'confirm',
+          }],
+          out: {
+            confirm: true,
           },
-        ],
-        std: [
-          { out: `√ Branch ${branchName} successfully pushed onto ${environmentName}.` },
-        ],
-      }));
-    });
+        },
+      ],
+      std: [
+        { out: `√ Branch ${branchName} successfully pushed onto ${environmentName}.` },
+      ],
+    }));
 
-    describe('when project was provided', () => {
-      const projectId = 82;
-      const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
-      const branchName = 'feature/second';
-      const environmentName = 'name1';
-      it('should not display the list of projects', () => testCli({
-        env: testEnvWithSecret,
-        token: 'any',
-        commandClass: PushCommand,
-        commandArgs: ['--projectId', '82'],
-        api: [
-          () => getInAppProjectForDevWorkflow(projectId),
-          () => getDevelopmentEnvironmentValid(projectId),
-          () => getBranchListValid(envSecret),
-          () => getEnvironmentListValid(projectId),
-          () => pushBranchValid(envSecret),
-        ],
-        prompts: [
-          {
-            in: [{
-              name: 'environment',
-              message: 'Select the remote environment you want to push onto',
-              type: 'list',
-              choices: ['name1'],
-            }],
-            out: {
-              environment: environmentName,
-            },
-          }, {
-            in: [{
-              name: 'confirm',
-              message: `Push branch ${branchName} onto ${environmentName}`,
-              type: 'confirm',
-            }],
-            out: {
-              confirm: true,
-            },
+    it('should skip confirm with --force option', () => testCli({
+      env: testEnvWithSecret,
+      token: 'any',
+      commandClass: PushCommand,
+      commandArgs: ['--force'],
+      api: [
+        ...getValidProjectEnvironementAndBranch(projectId, envSecret),
+        () => pushBranchValid(envSecret),
+      ],
+      std: [
+        { out: `√ Branch ${branchName} successfully pushed onto ${environmentName}.` },
+      ],
+    }));
+  });
+
+  describe('when the user try to push on production', () => {
+    const projectId = 82;
+    const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
+    const branchName = 'feature/second';
+    const environmentName = 'Staging';
+
+    it("should ask to use the command 'deploy'", () => testCli({
+      env: testEnvWithSecret,
+      token: 'any',
+      commandClass: PushCommand,
+      api: [
+        ...getValidProjectEnvironementAndBranch(projectId, envSecret),
+        () => invalidPushBranchToReference(envSecret),
+      ],
+      prompts: [
+        {
+          in: [{
+            name: 'confirm',
+            message: `Push branch ${branchName} onto ${environmentName}`,
+            type: 'confirm',
+          }],
+          out: {
+            confirm: true,
           },
-        ],
-        std: [
-          { out: `√ Branch ${branchName} successfully pushed onto ${environmentName}.` },
-        ],
-      }));
-    });
-
-    describe('when destination environment was provided', () => {
-      const projectId = 82;
-      const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
-      const branchName = 'feature/second';
-      const environmentName = 'name1';
-      it('should not display the list of environments', () => testCli({
-        env: testEnvWithSecret,
-        token: 'any',
-        commandClass: PushCommand,
-        commandArgs: ['-e', 'name1'],
-        api: [
-          ...getValidProjectEnvironementAndBranch(projectId, envSecret),
-          () => pushBranchValid(envSecret),
-        ],
-        prompts: [
-          {
-            in: [{
-              name: 'confirm',
-              message: `Push branch ${branchName} onto ${environmentName}`,
-              type: 'confirm',
-            }],
-            out: {
-              confirm: true,
-            },
-          },
-        ],
-        std: [
-          { out: `√ Branch ${branchName} successfully pushed onto ${environmentName}.` },
-        ],
-      }));
-    });
-
-    describe('when force option was provided', () => {
-      const projectId = 82;
-      const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
-      const branchName = 'feature/second';
-      const environmentName = 'name1';
-      it('should not display the list of environments', () => testCli({
-        env: testEnvWithSecret,
-        token: 'any',
-        commandClass: PushCommand,
-        commandArgs: ['-e', 'name1', '--force'],
-        api: [
-          ...getValidProjectEnvironementAndBranch(projectId, envSecret),
-          () => pushBranchValid(envSecret),
-        ],
-        std: [
-          { out: `√ Branch ${branchName} successfully pushed onto ${environmentName}.` },
-        ],
-      }));
-    });
-
-    describe('when answer no on confirm', () => {
-      const projectId = 82;
-      const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
-      const branchName = 'feature/second';
-      const environmentName = 'name1';
-      it('should not push branch', () => testCli({
-        env: testEnvWithSecret,
-        token: 'any',
-        commandClass: PushCommand,
-        commandArgs: ['-e', 'name1'],
-        api: [
-          ...getValidProjectEnvironementAndBranch(projectId, envSecret),
-        ],
-        prompts: [
-          {
-            in: [{
-              name: 'confirm',
-              message: `Push branch ${branchName} onto ${environmentName}`,
-              type: 'confirm',
-            }],
-            out: { confirm: false },
-          },
-        ],
-        exitCode: 0,
-      }));
-    });
-
-    describe('when development environment doesn\'t have branch', () => {
-      const projectId = 82;
-      const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
-      it('should throw an error', () => testCli({
-        env: testEnvWithSecret,
-        token: 'any',
-        commandClass: PushCommand,
-        commandArgs: ['-e', 'name1'],
-        api: [
-          () => getProjectByEnv(),
-          () => getInAppProjectForDevWorkflow(projectId),
-          () => getDevelopmentEnvironmentValid(projectId),
-          () => getNoBranchListValid(envSecret),
-        ],
-        std: [
-          { err: '× You don\'t have any branch to push. Use `forest branch` to create one or use `forest switch` to set your current branch.' },
-        ],
-        exitCode: 2,
-      }));
-    });
-
-    describe('when development environment doesn\'t have current branch', () => {
-      const projectId = 82;
-      const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
-      it('should throw an error', () => testCli({
-        env: testEnvWithSecret,
-        token: 'any',
-        commandClass: PushCommand,
-        commandArgs: ['-e', 'name1'],
-        api: [
-          () => getProjectByEnv(),
-          () => getInAppProjectForDevWorkflow(projectId),
-          () => getDevelopmentEnvironmentValid(projectId),
-          () => getBranchListValid(envSecret, false),
-        ],
-        std: [
-          { err: '× You don\'t have any branch to push. Use `forest branch` to create one or use `forest switch` to set your current branch.' },
-        ],
-        exitCode: 2,
-      }));
-    });
-
-    describe('when destination environment doesn\'t exist', () => {
-      const projectId = 82;
-      const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
-      it('should throw an error', () => testCli({
-        env: testEnvWithSecret,
-        token: 'any',
-        commandClass: PushCommand,
-        commandArgs: ['-e', 'notExist', '--force'],
-        api: [
-          ...getValidProjectEnvironementAndBranch(projectId, envSecret),
-          () => pushBranchInvalidDestination(envSecret),
-        ],
-        std: [
-          { err: '× The environment provided doesn\'t exist.' },
-        ],
-        exitCode: 2,
-      }));
-    });
-
-    describe('when destination environment doesn\'t have type remote', () => {
-      const projectId = 82;
-      const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
-      it('should throw an error', () => testCli({
-        env: testEnvWithSecret,
-        token: 'any',
-        commandClass: PushCommand,
-        commandArgs: ['-e', 'noRemote', '--force'],
-        api: [
-          ...getValidProjectEnvironementAndBranch(projectId, envSecret),
-          () => pushBranchInvalidType(envSecret),
-        ],
-        std: [
-          { err: '× The environment on which you are trying to push your modifications is not a remote environment.' },
-        ],
-        exitCode: 2,
-      }));
-    });
-
-    describe('when destination environment doesn\'t have branch', () => {
-      const projectId = 82;
-      const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
-      it('should throw an error', () => testCli({
-        env: testEnvWithSecret,
-        token: 'any',
-        commandClass: PushCommand,
-        commandArgs: ['-e', 'noRemote', '--force'],
-        api: [
-          ...getValidProjectEnvironementAndBranch(projectId, envSecret),
-          () => pushBranchInvalidDestinationBranch(envSecret),
-        ],
-        std: [
-          { err: '× The environment on which you are trying to push your modifications doesn\'t have current branch.' },
-        ],
-        exitCode: 2,
-      }));
-    });
-
-    describe('when project doesn\'t have remote environment', () => {
-      const projectId = 82;
-      const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
-      it('should throw an error', () => testCli({
-        env: testEnvWithSecret,
-        token: 'any',
-        commandClass: PushCommand,
-        api: [
-          ...getValidProjectEnvironementAndBranch(projectId, envSecret),
-          () => getNoEnvironmentListValid(projectId),
-        ],
-        std: [
-          { err: '× You cannot run this command until this project has a remote non-production environment.' },
-        ],
-        exitCode: 2,
-      }));
-    });
-
-    describe('when project is version 1', () => {
-      const projectId = 82;
-      it('should throw an error', () => testCli({
-        env: testEnvWithSecret,
-        token: 'any',
-        commandClass: PushCommand,
-        api: [
-          () => getProjectByEnv(),
-          () => getV1ProjectForDevWorkflow(projectId),
-        ],
-        std: [
-          { err: '× This project does not support branches yet. Please migrate your environments from your Project settings first.' },
-        ],
-        exitCode: 2,
-      }));
-    });
+        },
+      ],
+      std: [
+        { out: '× Failed to push branch: cannot "push" to reference environment, please use "deploy"' },
+      ],
+    }));
   });
 });

--- a/test/commands/push.test.js
+++ b/test/commands/push.test.js
@@ -2,11 +2,8 @@ const testCli = require('./test-cli-helper/test-cli');
 const PushCommand = require('../../src/commands/push');
 const {
   getBranchListValid,
-  getDevelopmentEnvironmentValid,
-  getInAppProjectForDevWorkflow,
   getNoBranchListValid,
   getProjectByEnv,
-  getV1ProjectForDevWorkflow,
   pushBranchInvalidDestinationBranch,
   pushBranchValid,
   invalidPushBranchToReference,
@@ -15,14 +12,13 @@ const { testEnvWithSecret } = require('../fixtures/env');
 
 const getValidProjectEnvironementAndBranch = (projectId, envSecret) => [
   () => getProjectByEnv(),
-  () => getInAppProjectForDevWorkflow(projectId),
-  () => getDevelopmentEnvironmentValid(projectId),
+
   () => getBranchListValid(envSecret),
 ];
 describe('push', () => {
   describe('when the user use push command', () => {
     const projectId = 82;
-    const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
+    const envSecret = 'forestEnvSecret';
     const branchName = 'feature/second';
     const environmentName = 'Staging';
 
@@ -118,7 +114,7 @@ describe('push', () => {
 
   describe('when the user try to push on production', () => {
     const projectId = 82;
-    const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
+    const envSecret = 'forestEnvSecret';
     const branchName = 'feature/second';
     const environmentName = 'Staging';
 
@@ -150,16 +146,13 @@ describe('push', () => {
   });
 
   describe('when development environment doesn\'t have branch', () => {
-    const projectId = 82;
-    const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
+    const envSecret = 'forestEnvSecret';
     it('should throw an error', () => testCli({
       env: testEnvWithSecret,
       token: 'any',
       commandClass: PushCommand,
       api: [
         () => getProjectByEnv(),
-        () => getInAppProjectForDevWorkflow(projectId),
-        () => getDevelopmentEnvironmentValid(projectId),
         () => getNoBranchListValid(envSecret),
       ],
       std: [
@@ -170,16 +163,13 @@ describe('push', () => {
   });
 
   describe('when development environment doesn\'t have current branch', () => {
-    const projectId = 82;
-    const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
+    const envSecret = 'forestEnvSecret';
     it('should throw an error', () => testCli({
       env: testEnvWithSecret,
       token: 'any',
       commandClass: PushCommand,
       api: [
         () => getProjectByEnv(),
-        () => getInAppProjectForDevWorkflow(projectId),
-        () => getDevelopmentEnvironmentValid(projectId),
         () => getBranchListValid(envSecret, false),
       ],
       std: [
@@ -191,7 +181,7 @@ describe('push', () => {
 
   describe('when destination environment doesn\'t have branch', () => {
     const projectId = 82;
-    const envSecret = '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125';
+    const envSecret = 'forestEnvSecret';
     it('should throw an error', () => testCli({
       env: testEnvWithSecret,
       token: 'any',
@@ -203,23 +193,6 @@ describe('push', () => {
       ],
       std: [
         { err: '× The environment on which you are trying to push your modifications doesn\'t have current branch.' },
-      ],
-      exitCode: 2,
-    }));
-  });
-
-  describe('when project is version 1', () => {
-    const projectId = 82;
-    it('should throw an error', () => testCli({
-      env: testEnvWithSecret,
-      token: 'any',
-      commandClass: PushCommand,
-      api: [
-        () => getProjectByEnv(),
-        () => getV1ProjectForDevWorkflow(projectId),
-      ],
-      std: [
-        { err: '× This project does not support branches yet. Please migrate your environments from your Project settings first.' },
       ],
       exitCode: 2,
     }));

--- a/test/fixtures/api.js
+++ b/test/fixtures/api.js
@@ -598,6 +598,15 @@ module.exports = {
       }],
     })),
 
+  invalidPushBranchToReference: (envSecret = 'forestEnvSecret') => nock('http://localhost:3001')
+    .matchHeader('forest-secret-key', envSecret)
+    .post('/api/branches/push')
+    .reply(400, JSON.stringify({
+      errors: [{
+        detail: 'Failed to push branch: cannot "push" to reference environment, please use "deploy"',
+      }],
+    })),
+
   pushBranchInvalidDestinationBranch: (envSecret = 'forestEnvSecret') => nock('http://localhost:3001')
     .matchHeader('forest-secret-key', envSecret)
     .post('/api/branches/push')


### PR DESCRIPTION
## Definition of Done

Users can now push a branch directly to its origin without passing an option to the command

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
