### PR TITLE
fix(ci): mark beta as a prerelease delivery channel

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  branches: ['main', 'beta'],
+  branches: ['main', { name:'beta', prerelease: true }],
   plugins: [
     [
       '@semantic-release/commit-analyzer', {


### PR DESCRIPTION
I'm not sure that marking this commit as `chore(force-release)` will re-trigger a new (beta) release, so marking it as a fix should do the trick.

I don't want to introduce any side effect by completely removing the 3.0.0 release, so I kept `3.0.0` as the base version.

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
