### PR TITLE
chore(release-config): use a different place for the force-release tag

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -2,14 +2,14 @@ module.exports = {
   branches: ['main', { name:'beta', prerelease: true }],
   plugins: [
     [
-      '@semantic-release/commit-analyzer', {
-      'releaseRules': [
-        // This rule allow to force a release by adding "force-release" in scope.
-        // Example: `chore(force-release): support new feature`
-        // Source: https://github.com/semantic-release/commit-analyzer#releaserules
-        { scope: 'force-release', release: 'patch' },
-      ],
-    },
+      '@semantic-release/commit-analyzer',
+      {
+        preset: 'angular',
+        releaseRules: [
+          // Example: `type(scope): subject [force release]`
+          { subject: '*[force release]', release: 'patch' },
+        ],
+      },
     ],
     '@semantic-release/release-notes-generator',
     '@semantic-release/changelog',

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -7,7 +7,7 @@ module.exports = {
         preset: 'angular',
         releaseRules: [
           // Example: `type(scope): subject [force release]`
-          { subject: '*[force release]', release: 'patch' },
+          { subject: '*[force release]*', release: 'patch' },
         ],
       },
     ],


### PR DESCRIPTION
Instead of losing the scope of the commit with a CI-related instruction, move this instruction to the end of the commit, surrounded by squared brackets (like the `skip ci` GH Action instruction)

Example of usage : `type(scope): subject [force release]`

Sources:
- https://github.com/semantic-release/commit-analyzer#configuration
- https://github.com/semantic-release/commit-analyzer#release-rules
- https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular
- https://github.com/micromatch/micromatch#matching-features