### PR TITLE
chore: re-add node_modules as a docker volume to prevent override

### DIFF
--- a/src/services/dumpers/templates/agent-nodejs/docker-compose.hbs
+++ b/src/services/dumpers/templates/agent-nodejs/docker-compose.hbs
@@ -21,3 +21,4 @@ services:
       - "${APPLICATION_PORT}:${APPLICATION_PORT}"
     volumes:
       - ./:/usr/src/app
+      - /usr/src/app/node_modules

--- a/test/services/dumpers/agent-nodejs/expected/mariadb/docker-compose.yml
+++ b/test/services/dumpers/agent-nodejs/expected/mariadb/docker-compose.yml
@@ -11,3 +11,4 @@ services:
       - "${APPLICATION_PORT}:${APPLICATION_PORT}"
     volumes:
       - ./:/usr/src/app
+      - /usr/src/app/node_modules

--- a/test/services/dumpers/agent-nodejs/expected/mongodb/docker-compose.yml
+++ b/test/services/dumpers/agent-nodejs/expected/mongodb/docker-compose.yml
@@ -11,3 +11,4 @@ services:
       - "${APPLICATION_PORT}:${APPLICATION_PORT}"
     volumes:
       - ./:/usr/src/app
+      - /usr/src/app/node_modules

--- a/test/services/dumpers/agent-nodejs/expected/mssql/docker-compose.yml
+++ b/test/services/dumpers/agent-nodejs/expected/mssql/docker-compose.yml
@@ -11,3 +11,4 @@ services:
       - "${APPLICATION_PORT}:${APPLICATION_PORT}"
     volumes:
       - ./:/usr/src/app
+      - /usr/src/app/node_modules

--- a/test/services/dumpers/agent-nodejs/expected/mysql/docker-compose.yml
+++ b/test/services/dumpers/agent-nodejs/expected/mysql/docker-compose.yml
@@ -11,3 +11,4 @@ services:
       - "${APPLICATION_PORT}:${APPLICATION_PORT}"
     volumes:
       - ./:/usr/src/app
+      - /usr/src/app/node_modules

--- a/test/services/dumpers/agent-nodejs/expected/postgres/docker-compose.yml
+++ b/test/services/dumpers/agent-nodejs/expected/postgres/docker-compose.yml
@@ -11,3 +11,4 @@ services:
       - "${APPLICATION_PORT}:${APPLICATION_PORT}"
     volumes:
       - ./:/usr/src/app
+      - /usr/src/app/node_modules


### PR DESCRIPTION
I asked for this to be removed, as after further investigation, it did not seems needed.
However ... it was.
Copying `./:/usr/src/app` overrides the existing folder(s), thus erases the `node_modules` folder

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
