### PR TITLE
fix: upgrade semantic-release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
           VERSION=`node -p "require('./package.json').devDependencies['semantic-release']"`
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v21.1.2
+        uses: cycjimmy/semantic-release-action@v3.4.2
         id: semantic
         with:
           semantic_version: ${{ steps.semantic_version.outputs.version }}


### PR DESCRIPTION
## Definition of Done
#86bx9nxmd
BREAKING CHANGE: users will have to upgrade to Node.js version 18 or above to ensure a full compatibility
### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made