### PR TITLE
chore(security): patch 6 Dependabot alerts (lodash, lodash-es)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "jsonapi-serializer": "3.6.2",
     "jsonwebtoken": "9.0.3",
     "jwt-decode": "2.2.0",
-    "lodash": "4.17.23",
+    "lodash": "4.18.0",
     "mkdirp": "1.0.4",
     "mongodb": "4.17.2",
     "mysql2": "3.9.8",
@@ -154,8 +154,8 @@
     "@isaacs/brace-expansion": ">=5.0.1",
     "jws": ">=4.0.1",
     "js-yaml": "3.14.2",
-    "lodash": ">=4.17.23",
-    "lodash-es": ">=4.17.23",
+    "lodash": ">=4.18.0",
+    "lodash-es": ">=4.18.0",
     "fast-xml-parser": ">=5.5.7"
   },
   "overrides": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8763,10 +8763,10 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@>=4.17.23, lodash-es@^4.17.21:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.23.tgz#58c4360fd1b5d33afc6c0bbd3d1149349b1138e0"
-  integrity sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==
+lodash-es@>=4.18.0, lodash-es@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
 
 lodash.camelcase@^4.1.1, lodash.camelcase@^4.3.0:
   version "4.3.0"
@@ -8873,10 +8873,15 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==
 
-lodash@4.17.23, lodash@>=4.17.23, lodash@^4.16.3, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.23, lodash@^4.17.4:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
-  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
+lodash@4.18.0:
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.0.tgz#dfd726f07ab2e39dd763de28fcf66e395c03e440"
+  integrity sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==
+
+lodash@>=4.18.0, lodash@^4.16.3, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.23, lodash@^4.17.4:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-update@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Summary
6 fixed, 0 ignored, 0 deferred, 0 resolutions added, 0 resolutions removed.

## Fixed

| # | Package | Ecosystem | From → To | Severity | Bump |
|---|---------|-----------|-----------|----------|------|
| 204 | lodash | npm | 4.17.23 → 4.18.0 | high | direct dep `lodash` 4.17.23 → 4.18.0 |
| 203 | lodash | npm | 4.17.23 → 4.18.0 | high | direct dep `lodash` 4.17.23 → 4.18.0 (duplicate of #204, same advisory, yarn.lock manifest) |
| 206 | lodash | npm | 4.17.23 → 4.18.0 | medium | direct dep `lodash` 4.17.23 → 4.18.0 |
| 205 | lodash | npm | 4.17.23 → 4.18.0 | medium | direct dep `lodash` 4.17.23 → 4.18.0 (duplicate of #206, same advisory, yarn.lock manifest) |
| 201 | lodash-es | npm | 4.17.23 → 4.18.1 | high | tightened existing `resolutions["lodash-es"]` from `>=4.17.23` to `>=4.18.0` (transitive, no direct dep) |
| 202 | lodash-es | npm | 4.17.23 → 4.18.1 | medium | tightened existing `resolutions["lodash-es"]` from `>=4.17.23` to `>=4.18.0` (duplicate of #201) |

Also tightened the existing `resolutions["lodash"]` entry from `>=4.17.23` to `>=4.18.0` so any transitive requests (e.g. `lodash@^4.17.10`, `^4.17.21`) resolve to a patched version — they now resolve to 4.18.1 in `yarn.lock`.

Verification from `yarn.lock` after install:
- `lodash@4.18.0` → 4.18.0 (direct pin)
- `lodash@>=4.18.0, ^4.16.3, ^4.17.10, ^4.17.15, ^4.17.21, ^4.17.23, ^4.17.4` → 4.18.1
- `lodash-es@>=4.18.0, ^4.17.21` → 4.18.1

## Ignored
None.

## Deferred
None. All 6 alerts were created 11–19 days ago, past the 7-day gate.

## Resolutions added
None. The existing `resolutions` already had `lodash` and `lodash-es` entries — only the version bound was tightened, no new entry added.

## Resolutions removed
None. A presence sweep of the 20 existing `resolutions` entries against `yarn.lock` showed all pinned packages still appear in the resolved tree (not stale). A full redundancy audit (each entry tested by removing, reinstalling, and verifying the natural resolution still satisfies the pin) was not performed in this PR — worth a dedicated follow-up pass since each test requires a fresh `yarn install`.

## Risks
- `lodash` 4.17.23 → 4.18.0 / 4.18.1: per the advisories, 4.18.0 is the patch release for the `_.unset`/`_.omit` prototype-pollution bypass and the `_.template` code-injection CVE. No other behavior change is expected beyond the patched vulns. We use lodash widely but call the affected APIs (`_.template`, `_.unset`, `_.omit`) only with trusted internal inputs; the bump closes the advisories without changing public API shape.
- `lodash-es` 4.17.23 → 4.18.1: transitive only — no direct imports of `lodash-es` in this repo; pulled in via upstream deps. Same semantic patch as lodash.
- No peer-dep bumps. No CHANGELOG-breaking changes affecting APIs we consume.

## Manual testing
Covered by CI.

## Validation
✅ CI green


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `lodash` to 4.18.0 to patch 6 Dependabot security alerts
> Updates `lodash` from 4.17.23 to 4.18.0 in [package.json](https://github.com/ForestAdmin/toolbelt/pull/758/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and raises the peer dependency minimum for `lodash` and `lodash-es` to `>=4.18.0`. The lockfile is regenerated to reflect the new resolved version.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 215c86c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->