### PR TITLE
chore(security): patch 1 Dependabot alert (fast-xml-parser)

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "js-yaml": "3.14.2",
     "lodash": ">=4.18.0",
     "lodash-es": ">=4.18.0",
-    "fast-xml-parser": ">=5.5.7"
+    "fast-xml-parser": ">=5.7.0"
   },
   "overrides": {
     "@paralleldrive/cuid2": "2.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2610,6 +2610,11 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
 
+"@nodable/entities@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@nodable/entities/-/entities-2.1.0.tgz#f543e5c6446720d4cf9e498a83019dd159973bc2"
+  integrity sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -6588,21 +6593,22 @@ fast-uri@^3.0.1:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
   integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
 
-fast-xml-builder@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz#0c407a1d9d5996336c0cd76f7ff785cac6413017"
-  integrity sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==
+fast-xml-builder@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz#50188e1452a5fa095f415d3e63dcac0a1dbcbf11"
+  integrity sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==
   dependencies:
     path-expression-matcher "^1.1.3"
 
-fast-xml-parser@5.3.6, fast-xml-parser@>=5.5.7:
-  version "5.5.9"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz#e59637abebec3dbfbb4053b532d787af6ea11527"
-  integrity sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==
+fast-xml-parser@5.3.6, fast-xml-parser@>=5.7.0:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz#fecd0b054c6c132fc03dab994a413da781e0eb9f"
+  integrity sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==
   dependencies:
-    fast-xml-builder "^1.1.4"
-    path-expression-matcher "^1.2.0"
-    strnum "^2.2.2"
+    "@nodable/entities" "^2.1.0"
+    fast-xml-builder "^1.1.5"
+    path-expression-matcher "^1.5.0"
+    strnum "^2.2.3"
 
 fastest-levenshtein@^1.0.16, fastest-levenshtein@^1.0.7:
   version "1.0.16"
@@ -10292,10 +10298,15 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
-path-expression-matcher@^1.1.3, path-expression-matcher@^1.2.0:
+path-expression-matcher@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz#9bdae3787f43b0857b0269e9caaa586c12c8abee"
   integrity sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==
+
+path-expression-matcher@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz#3b98545dc88ffebb593e2d8458d0929da9275f4a"
+  integrity sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -11772,10 +11783,10 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
-strnum@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.2.2.tgz#f11fd94ab62b536ba2ecc615858f3747c2881b3f"
-  integrity sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==
+strnum@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.2.3.tgz#0119fce02749a11bb126a4d686ac5dbdf6e57586"
+  integrity sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==
 
 super-regex@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary
1 fixed, 1 ignored, 0 deferred, 0 resolutions added, 0 resolutions removed. | label: :lock: security applied

## Fixed
| Alert | Package | Ecosystem | From → To | Severity | What was bumped |
|-------|---------|-----------|-----------|----------|-----------------|
| #208 | `fast-xml-parser` | npm | 5.5.9 → 5.7.2 | medium | bumped existing root `resolutions` entry from `>=5.5.7` to `>=5.7.0`; transitive (pulled in by `@aws-sdk/*` chains under `@forestadmin/datasource-sql`) |

## Ignored
- **#207 `uuid` < 14.0.0 (medium — Missing buffer bounds check in v3/v5/v6 when `buf` is provided)** — *Reason: vulnerable code path is unreachable from our code.* The advisory affects only `uuid.v3`, `uuid.v5`, `uuid.v6` when a `buf` argument is provided. A repo-wide grep for `from 'uuid'` and `require('uuid')` across `src/` and `test/` shows the only callers are `src/services/spinner.js` and `test/commands/test-cli-helper/test-cli-fs.js`, both of which import `{ v4: uuidv4 }` only and never pass a `buf` parameter. No call to `v3`/`v5`/`v6` exists in our code, so the vulnerable API is unreachable. Bumping `uuid` 8.x → 14.x would be a six-major-version jump for no security benefit on our usage.

## Deferred
None. (Both open alerts were created on 2026-04-23 and are 7 days old today, so they pass the age gate.)

## Resolutions added
None — the existing root `resolutions["fast-xml-parser"]` entry was already in place, so this was an in-place bump rather than a new entry. Form: unconditional root entry (pre-existing). Workspace-level placement N/A — this repo is single-package.

## Resolutions removed
None. Audited every entry in root `resolutions` and root `overrides`:
- All 21 pinned packages still appear in the resolved dependency tree (none stale).
- Spot-checked candidates for redundancy and found each is still doing real work — e.g. `js-yaml@3.14.2` is actively forcing a downgrade over deps requesting `^4.1.0` (yarn warns about this on every install, confirming the resolution is being applied), and `lodash: >=4.18.0` is forcing transitive deps requesting `^4.16.3 / ^4.17.x` up to 4.18.1. Removing either would change resolved versions, so they are not redundant.
- Did not exhaustively bisect the remaining `>=`-range pins (`socks`, `validator`, `tar`, `@isaacs/brace-expansion`, `jws`, `lodash-es`, `semantic-release-slack-bot/**/micromatch`) one-by-one; nothing surfaced as obviously redundant on inspection. Worth a follow-up hygiene pass but not blocking this security fix.

## Risks
- **`fast-xml-parser` 5.5.9 → 5.7.2** — minor version bumps within the 5.x line. The advisory fix is the only behavior change relevant to us: stricter escaping of XML comment / CDATA delimiters in `XMLBuilder` output. We do not call `XMLBuilder` ourselves; the package is pulled in transitively via `@aws-sdk/*` (used by `@forestadmin/datasource-sql` for S3-backed schema operations). No other 5.6 / 5.7 changelog item touches APIs we depend on. No peer-dep churn.

## Manual testing
Covered by CI.

## Validation
✅ CI green
