### PR TITLE
chore(ci): add Slack notification for security-labeled PRs

### DIFF
--- a/.github/workflows/security-slack-notify.yml
+++ b/.github/workflows/security-slack-notify.yml
@@ -1,0 +1,27 @@
+# Notify #tech_all on Slack when a security PR is opened.
+# Mentions @first_level_support so the team can prioritize review.
+#
+# Thin caller workflow — all logic lives in forestadmin/.github
+
+name: Notify Slack on security PR
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    if: "github.event.label.name == ':lock: security'"
+    uses: forestadmin/.github/.github/workflows/notify-slack-security-pr.yml@main
+    with:
+      slack_channel_id: GAZF5Q5RV
+      slack_usergroup_id: S09SUAY74TD
+      pr_title: ${{ github.event.pull_request.title }}
+      pr_url: ${{ github.event.pull_request.html_url }}
+      pr_author: ${{ github.event.pull_request.user.login }}
+      repo: ${{ github.repository }}
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Summary

Adds \`security-slack-notify.yml\` — thin caller workflow that posts to #tech_all when a PR is labeled \`:lock: security\`. Mirrors what is in place on forestadmin-server and other repos.

This repo had no other security/vulnerability workflows to remove.

## Test plan

- [x] End-to-end Slack notification flow verified in forestadmin-server (test PR closed)
- [ ] After merge, label a PR with \`:lock: security\` to confirm the workflow fires in this repo too

Note: needs the org-level \`SLACK_BOT_TOKEN\` secret to be accessible by this repo, and the corresponding Slack bot to be a member of #tech_all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Slack notification workflow for PRs labeled ':lock: security'
> Adds [security-slack-notify.yml](.github/workflows/security-slack-notify.yml), a GitHub Actions workflow that triggers when a PR is labeled with `:lock: security`. It calls a reusable workflow from `forestadmin/.github` to post a Slack message with the PR title, URL, author, and repository to a configured channel and usergroup using `SLACK_BOT_TOKEN`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2bf30ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->