### PR TITLE
chore(security): patch 3 Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "stdout-stderr": "0.1.13",
     "superagent": "^10.3.0",
     "tedious": "18.6.1",
-    "uuid": "8.0.0",
+    "uuid": "^11.1.1",
     "validate-npm-package-name": "3.0.0"
   },
   "devDependencies": {
@@ -156,7 +156,9 @@
     "js-yaml": "3.14.2",
     "lodash": ">=4.18.0",
     "lodash-es": ">=4.18.0",
-    "fast-xml-parser": ">=5.5.7"
+    "fast-xml-parser": ">=5.7.0",
+    "socks/ip-address": ">=10.1.1",
+    "uuid": "^11.1.1"
   },
   "overrides": {
     "@paralleldrive/cuid2": "2.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2610,6 +2610,11 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
 
+"@nodable/entities@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@nodable/entities/-/entities-2.1.0.tgz#f543e5c6446720d4cf9e498a83019dd159973bc2"
+  integrity sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -6588,21 +6593,24 @@ fast-uri@^3.0.1:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
   integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
 
-fast-xml-builder@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz#0c407a1d9d5996336c0cd76f7ff785cac6413017"
-  integrity sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==
+fast-xml-builder@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz#abd2363145a7625d9789ad96da375fabe3cff28c"
+  integrity sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==
   dependencies:
-    path-expression-matcher "^1.1.3"
+    path-expression-matcher "^1.5.0"
+    xml-naming "^0.1.0"
 
-fast-xml-parser@5.3.6, fast-xml-parser@>=5.5.7:
-  version "5.5.9"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz#e59637abebec3dbfbb4053b532d787af6ea11527"
-  integrity sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==
+fast-xml-parser@5.3.6, fast-xml-parser@>=5.7.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz#64d71f0f8d4bf23621dffd762aef7e98c1884fc1"
+  integrity sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==
   dependencies:
-    fast-xml-builder "^1.1.4"
-    path-expression-matcher "^1.2.0"
-    strnum "^2.2.2"
+    "@nodable/entities" "^2.1.0"
+    fast-xml-builder "^1.2.0"
+    path-expression-matcher "^1.5.0"
+    strnum "^2.3.0"
+    xml-naming "^0.1.0"
 
 fastest-levenshtein@^1.0.16, fastest-levenshtein@^1.0.7:
   version "1.0.16"
@@ -7491,10 +7499,10 @@ into-stream@^7.0.0:
     from2 "^2.3.0"
     p-is-promise "^3.0.0"
 
-ip-address@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.0.1.tgz#a8180b783ce7788777d796286d61bce4276818ed"
-  integrity sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==
+ip-address@>=10.1.1, ip-address@^10.0.1:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
+  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
 
 ip-regex@5.0.0:
   version "5.0.0"
@@ -10292,10 +10300,10 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
-path-expression-matcher@^1.1.3, path-expression-matcher@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz#9bdae3787f43b0857b0269e9caaa586c12c8abee"
-  integrity sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==
+path-expression-matcher@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz#3b98545dc88ffebb593e2d8458d0929da9275f4a"
+  integrity sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -11772,10 +11780,10 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
-strnum@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.2.2.tgz#f11fd94ab62b536ba2ecc615858f3747c2881b3f"
-  integrity sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==
+strnum@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.3.0.tgz#81bfbfef53db8c3217ea62a98c026886ec4a2761"
+  integrity sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==
 
 super-regex@^1.0.0:
   version "1.0.0"
@@ -12462,20 +12470,10 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-uuid@11.0.2:
-  version "11.0.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.2.tgz#a8d68ba7347d051e7ea716cc8dcbbab634d66875"
-  integrity sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==
-
-uuid@8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
-  integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
-
-uuid@^8.3.0, uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@11.0.2, uuid@^11.1.1, uuid@^8.3.0, uuid@^8.3.2:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
@@ -12740,6 +12738,11 @@ write-file-atomic@^6.0.0:
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
+
+xml-naming@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/xml-naming/-/xml-naming-0.1.0.tgz#8ab7106c5b8d23caa2fabac1cadf17136379fbd8"
+  integrity sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==
 
 xml2js@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
## Summary

3 fixed, 0 ignored, 3 deferred, 1 resolution added, 0 resolutions removed. | label: :lock: security applied

## Fixed

| Alert | Package | Ecosystem | From → To | Severity | What was bumped |
|-------|---------|-----------|-----------|----------|------|
| #208 | `fast-xml-parser` | npm | 5.5.9 → 5.8.0 | medium | Existing root resolution `fast-xml-parser` bumped `>=5.5.7` → `>=5.7.0` (transitive via `@aws-sdk/xml-builder`) |
| #210 | `uuid` | npm | 11.0.2 (transitive) and 8.0.0 (direct) → 11.1.1 | medium | Direct dep `uuid` bumped `8.0.0` → `^11.1.1`; added unconditional root resolution `uuid: ^11.1.1` to lift the exact-pin transitive at `@forestadmin/datasource-toolkit@1.53.0` |
| #211 | `ip-address` | npm | 10.0.1 → 10.2.0 | medium | Added scoped root resolution `socks/ip-address: ">=10.1.1"` (only consumer of `ip-address` is `socks`) |

## Ignored

None.

## Deferred

Three alerts opened less than 7 days ago — will be picked up on the next run:
- **#212** `fast-xml-builder` (high, opened 2026-05-08, ~5.8 days ago)
- **#213** `fast-uri` (high, opened 2026-05-08, ~5.5 days ago)
- **#214** `fast-uri` (high, opened 2026-05-09, ~5.4 days ago)

## Resolutions added

- **#210 `uuid: ^11.1.1`** — Parent chain tried: `@forestadmin/datasource-toolkit@1.53.0` directly pins `uuid: "11.0.2"` (exact). Latest upstream `@forestadmin/datasource-toolkit@1.53.1` still pins `uuid: "11.0.2"` — no parent bump closes the alert. Attempted scoped `@forestadmin/datasource-toolkit/uuid: ">=11.1.1"` first, but Yarn 1.x has a known bug with scoped-package path resolutions (the override registered as a standalone require resolving to `uuid@14.0.0`, while the nested `uuid@11.0.2` was left untouched). Placed in root `package.json` as **unconditional** root entry (last resort tier). Blast radius is acceptable: our only direct use of `uuid` is `{ v4 }` from `src/services/spinner.js` and one test file — `v4` is API-stable across uuid 8 → 11. Direct dep `uuid` also bumped from `8.0.0` → `^11.1.1` to keep `package.json` consistent with the resolved tree.
- **#211 `socks/ip-address: ">=10.1.1"`** — Parent chain tried: `socks@2.8.7` (already pinned via existing root resolution `"socks": "^2.8.7"`) directly depends on `ip-address: "^10.0.1"` which natural-resolves to `10.0.1` (vulnerable). Could have used unconditional `"ip-address"`, but `socks` is the only consumer in the tree, so a **scoped root entry** narrows the blast radius. Placed in root `package.json`.
- **#208 `fast-xml-parser: ">=5.7.0"`** — Pre-existing root resolution was at `>=5.5.7` (resolved to `5.5.9`). Bumped to `>=5.7.0`. Only consumer is `@aws-sdk/xml-builder` (pinned via `@aws-sdk/credential-providers` / `@aws-sdk/client-cloudfront` resolutions). Form: **unconditional** root entry (in-place modification of existing pin).

## Resolutions removed

None. A targeted audit of high-suspicion entries (`lodash`, `@paralleldrive/cuid2`) showed they're not redundant — the `lodash: ">=4.18.0"` pin actively lifts multiple older `^4.16.x` / `^4.17.x` requesters to ≥4.18.0, and `@paralleldrive/cuid2: 2.2.2` actively holds downward while upstream is at 2.3.1. Did not exhaustively iterate the remaining 20+ entries.

## Risks

- **`fast-xml-parser` 5.5.9 → 5.8.0** — minor bump within the 5.x line, used only inside `@aws-sdk/xml-builder` for AWS SDK XML serialization. The 5.7.0 patch tightened CDATA/comment escaping (the vuln); 5.8.0 is a non-breaking minor. No public API surface we use.
- **`ip-address` 10.0.1 → 10.2.0** — minor bumps within the 10.x line, used only inside `socks` for parsing SOCKS proxy addresses. `Address6` HTML-emit methods (the XSS surface) are not called by our code path through `socks`. Non-breaking.
- **`uuid` 8.0.0 / 11.0.2 → 11.1.1** — major bump for the direct dep (`8.0.0` → `^11.1.1`). uuid v9 dropped the default CJS export, but our code uses `const { v4: uuidv4 } = require('uuid')` (named import) in `src/services/spinner.js:1` and `test/commands/test-cli-helper/test-cli-fs.js:3`, which has been API-stable across all uuid versions 8 through 14. uuid 11 ships proper dual CJS/ESM exports. No other uuid APIs are used in the repo.

## Manual testing

Covered by CI.

## Validation

✅ CI green

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Patch 3 Dependabot security alerts in package dependencies
> - Upgrades `uuid` from `8.0.0` to `^11.1.1` in [package.json](https://github.com/ForestAdmin/toolbelt/pull/763/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)
> - Raises the `fast-xml-parser` minimum version from `>=5.5.7` to `>=5.7.0`
> - Adds `socks/ip-address` at `>=10.1.1` as a new dependency constraint
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d85f8bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->