### PR TITLE
chore(security): patch 2 Dependabot alerts (fast-uri)

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
   },
   "resolutions": {
     "semantic-release-slack-bot/**/micromatch": "^4.0.8",
-    "socks": "^2.8.7",
     "@azure/core-auth": "1.8.0",
     "@azure/core-client": "1.7.3",
     "@azure/core-rest-pipeline": "1.18.0",
@@ -146,19 +145,11 @@
     "@azure/identity": "4.2.1",
     "@azure/keyvault-keys": "4.4.0",
     "@azure/logger": "1.0.4",
-    "@paralleldrive/cuid2": "2.2.2",
-    "@aws-sdk/credential-providers": "^3.758.0",
-    "@aws-sdk/client-cloudfront": "^3.758.0",
-    "validator": ">=13.15.22",
-    "tar": ">=7.5.8",
-    "@isaacs/brace-expansion": ">=5.0.1",
     "jws": ">=4.0.1",
     "js-yaml": "3.14.2",
-    "lodash": ">=4.18.0",
-    "lodash-es": ">=4.18.0",
     "fast-xml-parser": ">=5.7.0",
-    "socks/ip-address": ">=10.1.1",
-    "uuid": "^11.1.1"
+    "uuid": "^11.1.1",
+    "fast-uri": ">=3.1.2"
   },
   "overrides": {
     "@paralleldrive/cuid2": "2.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -98,7 +98,7 @@
     "@smithy/util-utf8" "^2.0.0"
     tslib "^2.6.2"
 
-"@aws-sdk/client-cloudfront@^3.758.0", "@aws-sdk/client-cloudfront@^3.995.0":
+"@aws-sdk/client-cloudfront@^3.995.0":
   version "3.995.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/client-cloudfront/-/client-cloudfront-3.995.0.tgz#23988798493a55ea9a01b5167e93b571eb3dc5ad"
   integrity sha512-hTyUaVs0hKPSlQyreyxmj6g9sPRs9XWNzDCozYfU5rbAcqS1E0AVTFAjbgNvKIOEbY5iL4UuiIFdFG7m5z9SAQ==
@@ -677,7 +677,7 @@
     "@smithy/types" "^4.12.0"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-providers@^3.186.0", "@aws-sdk/credential-providers@^3.758.0":
+"@aws-sdk/credential-providers@^3.186.0":
   version "3.995.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/credential-providers/-/credential-providers-3.995.0.tgz#67ecf73920a13911b4297cea4014dfd2775fe5b9"
   integrity sha512-ezDBjl3Z+IDAz6WjP6b4Vr0kfGJGmkOSOBkFZRoEpRr3uWNDJ4f9ZajRW1mfmnT6eR5HX2UF9F+9fvH/4jSJIw==
@@ -2231,18 +2231,6 @@
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-3.0.9.tgz#f7f9696e9276e4e1ae9332767afb9199992e31d9"
   integrity sha512-QPaNt/nmE2bLGQa9b7wwyRJoLZ7pN6rcyXvzU0YCmivmJyq1BVo94G98tStRWkoD1RgDX5C+dPlhhHzNdu/W/w==
-
-"@isaacs/balanced-match@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz#3081dadbc3460661b751e7591d7faea5df39dd29"
-  integrity sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==
-
-"@isaacs/brace-expansion@>=5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz#0ef5a92d91f2fff2a37646ce54da9e5f599f6eff"
-  integrity sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==
-  dependencies:
-    "@isaacs/balanced-match" "^4.0.1"
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
@@ -6588,10 +6576,10 @@ fast-safe-stringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
-fast-uri@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
-  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
+fast-uri@>=3.1.2, fast-uri@^3.0.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
+  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
 fast-xml-builder@^1.2.0:
   version "1.2.0"
@@ -7499,7 +7487,7 @@ into-stream@^7.0.0:
     from2 "^2.3.0"
     p-is-promise "^3.0.0"
 
-ip-address@>=10.1.1, ip-address@^10.0.1:
+ip-address@^10.0.1:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
   integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
@@ -8771,7 +8759,7 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@>=4.18.0, lodash-es@^4.17.21:
+lodash-es@^4.17.21:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
   integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
@@ -8886,7 +8874,7 @@ lodash@4.18.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.0.tgz#dfd726f07ab2e39dd763de28fcf66e395c03e440"
   integrity sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==
 
-lodash@>=4.18.0, lodash@^4.16.3, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.23, lodash@^4.17.4:
+lodash@^4.16.3, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.23, lodash@^4.17.4:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
@@ -11398,7 +11386,7 @@ socks-proxy-agent@^8.0.3:
     debug "^4.3.4"
     socks "^2.8.3"
 
-socks@^2.7.1, socks@^2.8.3, socks@^2.8.4, socks@^2.8.7:
+socks@^2.7.1, socks@^2.8.3, socks@^2.8.4:
   version "2.8.7"
   resolved "https://registry.yarnpkg.com/socks/-/socks-2.8.7.tgz#e2fb1d9a603add75050a2067db8c381a0b5669ea"
   integrity sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==
@@ -11867,7 +11855,7 @@ synckit@^0.11.8:
   dependencies:
     "@pkgr/core" "^0.2.9"
 
-tar@>=7.5.8, tar@^7.4.3, tar@^7.5.1:
+tar@^7.4.3, tar@^7.5.1:
   version "7.5.9"
   resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.9.tgz#817ac12a54bc4362c51340875b8985d7dc9724b8"
   integrity sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==
@@ -12514,7 +12502,7 @@ validate-npm-package-name@^6.0.0, validate-npm-package-name@^6.0.2:
   resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-6.0.2.tgz#4e8d2c4d939975a73dd1b7a65e8f08d44c85df96"
   integrity sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==
 
-validator@>=13.15.22, validator@^13.9.0:
+validator@^13.9.0:
   version "13.15.26"
   resolved "https://registry.yarnpkg.com/validator/-/validator-13.15.26.tgz#36c3deeab30e97806a658728a155c66fcaa5b944"
   integrity sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==


### PR DESCRIPTION
## Summary
2 fixed, 0 ignored, 1 deferred, 1 resolution added, 9 resolutions removed. | label: :lock: security applied

## Fixed
| Alert | Package | Ecosystem | From → To | Severity | What was bumped |
|---|---|---|---|---|---|
| #214 | `fast-uri` | npm | 3.1.0 → 3.1.2 | high | Added root `resolutions["fast-uri"]: ">=3.1.2"` (transitive via `@commitlint/cli` → `@commitlint/load` → `@commitlint/config-validator` → `ajv@^8.11.0` → `fast-uri`) |
| #213 | `fast-uri` | npm | 3.1.0 → 3.1.2 | high | Same bump as #214 — patched 3.1.2 covers both advisories |

## Ignored
None.

## Deferred
- #215 — `brace-expansion >= 5.0.0, < 5.0.6` (medium). Created 2026-05-18 (3 days old); under the 7-day gate. Will be picked up by the next run.

## Resolutions added
- **#213/#214 → `fast-uri`** pinned `">=3.1.2"` in **root `package.json`**. Parent chain tried: `ajv/fast-uri` (scoped Yarn 1 resolution); the lockfile reported `Already up-to-date` and `yarn why fast-uri` still showed 3.1.0 — Yarn 1 didn't propagate the scoped form, likely because the lockfile entry `fast-uri@^3.0.1` was already satisfied by 3.1.0 and the scoped key didn't force re-resolution. Fell back to an **unconditional root entry** (`"fast-uri": ">=3.1.2"`), which is acceptable here because there's only one `fast-uri` chain in the tree (`@commitlint/...` only).

## Resolutions removed
| File | Resolution | Reason |
|---|---|---|
| `package.json` | `"@isaacs/brace-expansion": ">=5.0.1"` | **Stale.** `yarn why @isaacs/brace-expansion` reports `We couldn't find a match!` — the lockfile entry only existed because the resolution itself was loading the package as a virtual dep. Nothing in the dependency graph requires it. |
| `package.json` | `"validator": ">=13.15.22"` | **Redundant.** Only consumer is `sequelize` which requests `validator ^13.9.0`; natural resolution selects 13.15.26 (≥ 13.15.22). |
| `package.json` | `"tar": ">=7.5.8"` | **Redundant.** Natural resolution selects `tar@7.5.9` (≥ 7.5.8). |
| `package.json` | `"lodash": ">=4.18.0"` | **Redundant.** Direct dep pins `lodash@4.18.0`; transitive deps requesting `^4.17.x` dedupe to `4.18.1`. All ≥ 4.18.0 without the pin. |
| `package.json` | `"lodash-es": ">=4.18.0"` | **Redundant.** Natural resolution selects `lodash-es@4.18.1` (≥ 4.18.0). |
| `package.json` | `"@aws-sdk/credential-providers": "^3.758.0"` | **Redundant.** Natural resolution selects 3.995.0 (≥ 3.758.0). |
| `package.json` | `"@aws-sdk/client-cloudfront": "^3.758.0"` | **Redundant.** Natural resolution selects 3.995.0 (≥ 3.758.0). |
| `package.json` | `"socks": "^2.8.7"` | **Redundant.** Natural resolution selects `socks@2.8.7` (matches pin). |
| `package.json` | `"socks/ip-address": ">=10.1.1"` | **Redundant.** Natural resolution selects `ip-address@10.2.0` (≥ 10.1.1). |
| `package.json` | `"@paralleldrive/cuid2": "2.2.2"` (resolutions field) | **Redundant.** Direct dep already pins exact `2.2.2`; the resolution adds nothing. (The npm-style `overrides` entry was left in place since it targets a different package manager.) |

Resolutions audited but **kept** because removal would regress:
- `semantic-release-slack-bot/**/micromatch` — without it, `semantic-release-slack-bot` pulls `micromatch@4.0.2` (CVE GHSA-952p-6rrq-rcjv).
- `fast-xml-parser` — natural selects `5.3.6`, below pinned `>=5.7.0`.
- `jws` — without it, `@azure/msal-node` pulls `jws@3.2.3` (downgrade).
- `uuid` — without it, several chains drop to `uuid@8.3.2` / `uuid@11.0.2`, below pinned `^11.1.1`.
- `js-yaml` — exact pin to `3.14.2`, deliberate version lock (some deps want `^4.1.0`).
- `@azure/*` — exact version pins, deliberate version locks; not touched.

## Risks
- **`fast-uri` 3.1.0 → 3.1.2:** patches CVE-2025-XXXX (path traversal via percent-encoded dot segments, 3.1.1) and CVE-2025-YYYY (host confusion via percent-encoded authority delimiters, 3.1.2). Only consumer is `ajv@^8.11.0` (used by `@commitlint/config-validator`). No public-facing surface change; the lib is used internally by ajv to parse `$ref` URIs in JSON Schema. No expected behavior change beyond the patched vulnerabilities.
- **Resolution removals:** strictly hygiene — each removal was verified via `yarn install --force` + `yarn why <pkg>` to confirm the natural resolution still satisfies the original pin. No new CVE exposure.

## Manual testing
Covered by CI.

## Validation
✅ CI green
