### PR TITLE
chore(security): patch 1 Dependabot alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,8 +148,7 @@
     "jws": ">=4.0.1",
     "js-yaml": "3.14.2",
     "fast-xml-parser": ">=5.7.0",
-    "uuid": "^11.1.1",
-    "fast-uri": ">=3.1.2"
+    "uuid": "^11.1.1"
   },
   "overrides": {
     "@paralleldrive/cuid2": "2.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4850,9 +4850,9 @@ brace-expansion@^2.0.1:
     balanced-match "^1.0.0"
 
 brace-expansion@^5.0.2:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
-  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
+  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
   dependencies:
     balanced-match "^4.0.2"
 
@@ -6576,7 +6576,7 @@ fast-safe-stringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
-fast-uri@>=3.1.2, fast-uri@^3.0.1:
+fast-uri@^3.0.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
   integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==


### PR DESCRIPTION
> 👋 First-level support: see [Handling automated security PRs](https://forest.slite.com/app/docs/rmjdwFgmV2RzUp) for how to triage and merge this PR.

## Summary
1 fixed, 0 ignored, 2 deferred, 0 resolutions added, 1 resolution removed. | label: :lock: security applied

## Fixed
| Done | Alert | Package | Ecosystem | From → To | Severity | What was bumped |
|---|---|---|---|---|---|---|
| - [x] | [#215](https://github.com/ForestAdmin/toolbelt/security/dependabot/215) | `brace-expansion` | npm | 5.0.5 → 5.0.6 | medium | Refreshed transitive `brace-expansion@^5.0.2` (pulled in by `minimatch@^9` / `^10` under `@oclif/*`) by re-resolving the lockfile entry against the existing `^5.0.2` constraint. No `package.json` change required. |

## Ignored
None.

## Deferred
Skipped by the 7-day age gate, will be picked up in the next run:
- [#216](https://github.com/ForestAdmin/toolbelt/security/dependabot/216) — `qs` (created 2026-05-23, 5 days old)
- [#217](https://github.com/ForestAdmin/toolbelt/security/dependabot/217) — `tmp` (created 2026-05-27, 1 day old)

## Resolutions added
None — the alert was closeable via a parent re-resolution alone.

## Resolutions removed
| File | Package + pinned version | Reason |
|---|---|---|
| `package.json` | `fast-uri: >=3.1.2` | Redundant — natural resolution already lands on `fast-uri@3.1.2` (the latest 3.x). Verified by removing the entry, deleting its lockfile entries, and re-running `yarn install`: `npm ls fast-uri` reports `fast-uri@3.1.2`, which satisfies `>=3.1.2`. The upstream parent (ajv) now pulls in the patched version on its own. |

The full resolution audit was performed against every entry in `resolutions` and `overrides`. The remaining entries were KEPT because removal would either reintroduce a vulnerable version (the natural resolution dipped below the pinned floor — `semantic-release-slack-bot/**/micromatch`, `jws`, `fast-xml-parser`, `uuid`, `@azure/core-tracing`, `@paralleldrive/cuid2`) or because removal would cascade-bump the whole `@azure/*` SDK stack out of band of this security PR (`@azure/core-auth`, `@azure/core-client`, `@azure/core-rest-pipeline`, `@azure/core-util`, `@azure/identity`, `@azure/keyvault-keys`, `@azure/logger`) — those are worth revisiting on their own, not folded into a Dependabot patch PR. `js-yaml@3.14.2` was also KEPT: removing it lets some consumers naturally pull `js-yaml@4.x`, which is a behavior change beyond resolution hygiene.

## Risks
- **`brace-expansion` 5.0.5 → 5.0.6**: patch release that adds DoS protection for large numeric ranges. No public API change. The only consumers in our tree are various `minimatch` versions under `@oclif/*`, which are exercised by `oclif`'s glob matching. Covered by CI.
- **`fast-uri` resolution removed**: no version change — natural resolution lands on `fast-uri@3.1.2`, same as the pin was forcing. Pure cleanup.

## Manual testing
Covered by CI.

## Validation
✅ CI green