### PR TITLE
feat(signup): add forest signup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The Lumberjacks' toolbelt is the Forest Admin CLI which makes easy to manage you
 ### General
 
 - `user` display the current logged in user.
+- `signup` create a new Forest Admin account.
 - `login` sign in to your Forest Admin account.
 - `logout` sign out of your Forest Admin account.
 - `help [cmd]` display help for [cmd].

--- a/src/commands/signup.js
+++ b/src/commands/signup.js
@@ -1,0 +1,42 @@
+const { Flags } = require('@oclif/core');
+const AbstractCommand = require('../abstract-command').default;
+
+class SignupCommand extends AbstractCommand {
+  constructor(argv, config, plan) {
+    super(argv, config, plan);
+    const { assertPresent, authenticator } = this.context;
+    assertPresent({ authenticator });
+    this.authenticator = authenticator;
+  }
+
+  async run() {
+    const { flags } = await this.parse(SignupCommand);
+    await this.authenticator.trySignup({
+      email: flags.email,
+      password: flags.password,
+      firstName: flags['first-name'],
+      lastName: flags['last-name'],
+    });
+  }
+}
+
+SignupCommand.description = 'Create a new Forest Admin account.';
+
+SignupCommand.flags = {
+  email: Flags.string({
+    char: 'e',
+    description: 'Your Forest Admin account email.',
+  }),
+  password: Flags.string({
+    char: 'P',
+    description: 'Your Forest Admin account password.',
+  }),
+  'first-name': Flags.string({
+    description: 'Your first name.',
+  }),
+  'last-name': Flags.string({
+    description: 'Your last name.',
+  }),
+};
+
+module.exports = SignupCommand;

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -34,6 +34,32 @@ function Api({
       .then(response => response.body.token);
 
   /**
+   * @param {{
+   *  email: string;
+   *  password: string;
+   *  firstName: string;
+   *  lastName: string;
+   * }} params
+   * @returns {Promise<object>} the created user
+   */
+  this.signup = async ({ email, password, firstName, lastName }) =>
+    agent
+      .post(`${this.endpoint()}/api/users`)
+      .set(headers)
+      .send({
+        data: {
+          type: 'users',
+          attributes: {
+            email,
+            first_name: firstName,
+            last_name: lastName,
+            password,
+          },
+        },
+      })
+      .then(response => response.body);
+
+  /**
    * @param {import('../serializers/application-token').InputApplicationToken} applicationToken
    * @param {string} sessionToken
    * @returns {Promise<import('../deserializers/application-token').ApplicationToken>}

--- a/src/services/authenticator.js
+++ b/src/services/authenticator.js
@@ -122,6 +122,91 @@ function Authenticator({
    * }} params
    * @returns {Promise<string>}
    */
+  this.trySignup = async config => {
+    await this.logout({ log: false });
+    try {
+      const token = await this.signup(config);
+      await this.saveToken(token);
+      logger.info('Account created. You are now logged in.');
+    } catch (error) {
+      const message =
+        error instanceof ApplicationError
+          ? error.message
+          : `${ERROR_UNEXPECTED} ${chalk.red(error)}`;
+      logger.error(message);
+    }
+  };
+
+  /**
+   * Create a new account, then open a session and return its token.
+   * @param {{
+   *  email: string;
+   *  password: string;
+   *  firstName: string;
+   *  lastName: string;
+   * }} params
+   * @returns {Promise<string>}
+   */
+  this.signup = async ({ email, password, firstName, lastName }) => {
+    if (email) {
+      const validationResult = await this.validateEmail(email);
+      if (validationResult !== true) {
+        throw new ApplicationError(validationResult);
+      }
+    } else email = await this.promptEmail();
+
+    if (!firstName) firstName = await this.promptRequired('firstName', 'What is your first name?');
+    if (!lastName) lastName = await this.promptRequired('lastName', 'What is your last name?');
+    if (!password) {
+      ({ password } = await inquirer.prompt([
+        {
+          type: 'password',
+          name: 'password',
+          message: 'Choose a password:',
+          validate: input => !!input || 'Please enter a password.',
+        },
+      ]));
+    }
+
+    try {
+      await api.signup({ email, password, firstName, lastName });
+    } catch (error) {
+      throw this.toSignupError(error);
+    }
+
+    return api.login(email, password);
+  };
+
+  this.promptRequired = async (name, message) => {
+    const answer = await inquirer.prompt([
+      {
+        type: 'input',
+        name,
+        message,
+        validate: input => !!input || 'This field is required.',
+      },
+    ]);
+    return answer[name];
+  };
+
+  this.toSignupError = error => {
+    const status = error.status || (error.response && error.response.status);
+    const detail =
+      error.response && error.response.body && error.response.body.errors
+        ? error.response.body.errors[0] && error.response.body.errors[0].detail
+        : null;
+
+    // Relay the server message verbatim: it intentionally returns a generic
+    // message when the email already exists (anti user-enumeration) and a
+    // specific one for validation errors (e.g. weak password). We surface
+    // whatever it chose to say rather than inferring from the status code.
+    if (detail) return new ApplicationError(detail);
+    if (status === 429) {
+      return new ApplicationError('Too many attempts. Please wait a moment and try again.');
+    }
+    return error;
+  };
+
   this.login = async ({ email, password, token }) => {
     if (token !== undefined && typeof token === 'string' && !token.trim()) {
       throw new ApplicationError('The provided token is empty. Please provide a valid token.');

--- a/test/commands/signup.test.js
+++ b/test/commands/signup.test.js
@@ -1,0 +1,70 @@
+const testCli = require('./test-cli-helper/test-cli');
+const SignupCommand = require('../../src/commands/signup');
+
+const { signupValid, signupEmailTaken, signupWeakPassword } = require('../fixtures/api');
+const { testEnvWithoutSecret } = require('../fixtures/env');
+
+const allArgs = [
+  '-e',
+  'john@mail.com',
+  '-P',
+  'valid_pwd',
+  '--first-name',
+  'John',
+  '--last-name',
+  'Doe',
+];
+
+describe('signup', () => {
+  describe('with all args provided', () => {
+    it('should create the account and log in', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        commandClass: SignupCommand,
+        commandArgs: allArgs,
+        api: () => signupValid(),
+        std: [{ out: '> Account created. You are now logged in.' }],
+      }));
+  });
+
+  describe('when the email is already in use (409)', () => {
+    it('should relay the generic server message (no enumeration)', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        commandClass: SignupCommand,
+        commandArgs: allArgs,
+        api: () => signupEmailTaken(),
+        std: [{ err: '× Unable to create account. Please try again or contact support.' }],
+      }));
+  });
+
+  describe('with an invalid email', () => {
+    it('should fail validation before calling the API', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        commandClass: SignupCommand,
+        commandArgs: [
+          '-e',
+          'not-an-email',
+          '-P',
+          'Password123',
+          '--first-name',
+          'John',
+          '--last-name',
+          'Doe',
+        ],
+        std: [{ err: '× Invalid email' }],
+      }));
+  });
+
+  describe('when the password is too weak (422)', () => {
+    it('should surface the specific server message', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        commandClass: SignupCommand,
+        commandArgs: allArgs,
+        api: () => signupWeakPassword(),
+        std: [{ err: '× Your password security is too weak.' }],
+      }));
+  });
+});

--- a/test/fixtures/api.js
+++ b/test/fixtures/api.js
@@ -205,6 +205,25 @@ module.exports = {
       .post('/api/sessions', { email: 'some@mail.com', password: 'valid_pwd' })
       .reply(200, { token: jwt.sign({}, 'key', { expiresIn: '1day' }) }),
 
+  signupValid: () =>
+    nock('http://localhost:3001')
+      .post('/api/users', body => body?.data?.attributes?.email === 'john@mail.com')
+      .reply(201, { data: { type: 'users', id: '1', attributes: { email: 'john@mail.com' } } })
+      .post('/api/sessions', { email: 'john@mail.com', password: 'valid_pwd' })
+      .reply(200, { token: jwt.sign({}, 'key', { expiresIn: '1day' }) }),
+
+  signupEmailTaken: () =>
+    nock('http://localhost:3001')
+      .post('/api/users')
+      .reply(409, {
+        errors: [{ detail: 'Unable to create account. Please try again or contact support.' }],
+      }),
+
+  signupWeakPassword: () =>
+    nock('http://localhost:3001')
+      .post('/api/users')
+      .reply(422, { errors: [{ detail: 'Your password security is too weak.' }] }),
+
   loginInvalid: () =>
     nock('http://localhost:3001')
       .post('/api/sessions', { email: 'some@mail.com', password: 'pwd' })

--- a/test/services/api.unit.test.js
+++ b/test/services/api.unit.test.js
@@ -128,4 +128,34 @@ describe('services > API', () => {
       await expect(api.deleteApplicationToken('THE-TOKEN')).rejects.toBe(error);
     });
   });
+
+  describe('signup', () => {
+    it('should POST the account in JSON:API format and return the response body', async () => {
+      expect.assertions(3);
+      const { superagent, api } = setup();
+
+      superagent.send.mockResolvedValue({ body: { data: { id: '1', type: 'users' } } });
+
+      const result = await api.signup({
+        email: 'john@mail.com',
+        password: 'Password123',
+        firstName: 'John',
+        lastName: 'Doe',
+      });
+
+      expect(superagent.post).toHaveBeenCalledWith('https://api.test.forestadmin.com/api/users');
+      expect(superagent.send).toHaveBeenCalledWith({
+        data: {
+          type: 'users',
+          attributes: {
+            email: 'john@mail.com',
+            first_name: 'John',
+            last_name: 'Doe',
+            password: 'Password123',
+          },
+        },
+      });
+      expect(result).toStrictEqual({ data: { id: '1', type: 'users' } });
+    });
+  });
 });

--- a/test/services/authenticator.unit.test.js
+++ b/test/services/authenticator.unit.test.js
@@ -1,5 +1,6 @@
 const joi = require('joi');
 const Authenticator = require('../../src/services/authenticator');
+const ApplicationError = require('../../src/errors/application-error');
 
 describe('services > authenticator', () => {
   function setup() {
@@ -33,7 +34,17 @@ describe('services > authenticator', () => {
 
     const mkdirp = jest.fn();
 
+    const api = {
+      signup: jest.fn(),
+      login: jest.fn(),
+    };
+    const inquirer = {
+      prompt: jest.fn(),
+    };
+
     const context = {
+      api,
+      inquirer,
       env,
       oidcAuthenticator,
       applicationTokenService,
@@ -507,6 +518,130 @@ describe('services > authenticator', () => {
           'You cannot be logged out with this command. Please use "lumber logout" command.',
         );
       });
+    });
+  });
+
+  describe('trySignup', () => {
+    describe('when signup succeeds', () => {
+      it('saves the token and logs success', async () => {
+        expect.assertions(2);
+        const { authenticator, logger } = setup();
+
+        jest.spyOn(authenticator, 'logout').mockResolvedValue();
+        const token = Symbol('token');
+        jest.spyOn(authenticator, 'signup').mockResolvedValue(token);
+        jest.spyOn(authenticator, 'saveToken').mockResolvedValue();
+
+        await authenticator.trySignup({});
+
+        expect(authenticator.saveToken).toHaveBeenCalledWith(token);
+        expect(logger.info).toHaveBeenCalledWith('Account created. You are now logged in.');
+      });
+    });
+
+    describe('when signup fails', () => {
+      it('logs the error message and does not save a token', async () => {
+        expect.assertions(2);
+        const { authenticator, logger } = setup();
+
+        jest.spyOn(authenticator, 'logout').mockResolvedValue();
+        jest.spyOn(authenticator, 'signup').mockRejectedValue(new ApplicationError('boom'));
+        jest.spyOn(authenticator, 'saveToken');
+
+        await authenticator.trySignup({});
+
+        expect(authenticator.saveToken).not.toHaveBeenCalled();
+        expect(logger.error).toHaveBeenCalledWith('boom');
+      });
+    });
+  });
+
+  describe('signup', () => {
+    it('creates the account then opens a session and returns its token', async () => {
+      expect.assertions(3);
+      const { authenticator, api } = setup();
+
+      api.signup.mockResolvedValue({});
+      api.login.mockResolvedValue('SESSION-TOKEN');
+
+      const token = await authenticator.signup({
+        email: 'john@mail.com',
+        password: 'Password123',
+        firstName: 'John',
+        lastName: 'Doe',
+      });
+
+      expect(api.signup).toHaveBeenCalledWith({
+        email: 'john@mail.com',
+        password: 'Password123',
+        firstName: 'John',
+        lastName: 'Doe',
+      });
+      expect(api.login).toHaveBeenCalledWith('john@mail.com', 'Password123');
+      expect(token).toBe('SESSION-TOKEN');
+    });
+
+    it('maps a server failure through toSignupError', async () => {
+      expect.assertions(1);
+      const { authenticator, api } = setup();
+
+      api.signup.mockRejectedValue({
+        status: 409,
+        response: {
+          body: {
+            errors: [{ detail: 'Unable to create account. Please try again or contact support.' }],
+          },
+        },
+      });
+
+      await expect(
+        authenticator.signup({
+          email: 'john@mail.com',
+          password: 'Password123',
+          firstName: 'John',
+          lastName: 'Doe',
+        }),
+      ).rejects.toThrow('Unable to create account');
+    });
+  });
+
+  describe('toSignupError', () => {
+    it('relays the generic server message on an existing email (anti-enumeration)', () => {
+      expect.assertions(2);
+      const { authenticator } = setup();
+      const result = authenticator.toSignupError({
+        status: 409,
+        response: {
+          body: {
+            errors: [{ detail: 'Unable to create account. Please try again or contact support.' }],
+          },
+        },
+      });
+      expect(result).toBeInstanceOf(ApplicationError);
+      expect(result.message).toBe('Unable to create account. Please try again or contact support.');
+    });
+
+    it('relays the specific server message for a validation error', () => {
+      expect.assertions(1);
+      const { authenticator } = setup();
+      const result = authenticator.toSignupError({
+        status: 422,
+        response: { body: { errors: [{ detail: 'Your password security is too weak.' }] } },
+      });
+      expect(result.message).toBe('Your password security is too weak.');
+    });
+
+    it('returns a rate-limit message on 429 with no detail', () => {
+      expect.assertions(1);
+      const { authenticator } = setup();
+      expect(authenticator.toSignupError({ status: 429 }).message).toContain('Too many attempts');
+    });
+
+    it('returns the raw error when there is no recognizable signal', () => {
+      expect.assertions(1);
+      const { authenticator } = setup();
+      const raw = new Error('weird');
+      expect(authenticator.toSignupError(raw)).toBe(raw);
     });
   });
 });


### PR DESCRIPTION
## What

Adds a headless `forest signup` command: creates a Forest Admin account (`POST /api/users`) then opens a session (`POST /api/sessions`), persisting the token in the same place as `forest login` (`~/.forest.d/.forestrc`). Flags: `--email`, `--password`, `--first-name`, `--last-name` (missing fields are prompted).

Mirrors the existing `login` structure (`command → authenticator → api`). Server errors are relayed verbatim — generic on an existing email (respecting the server's anti-enumeration), specific on validation (e.g. weak password).

## Why

First CLI primitive of the headless Standalone onboarding. Refs PRD-523.

## Tests

- Command-level: success, existing-email (409), invalid email, weak password (422).
- Unit (`authenticator`, `api`): `signup` / `trySignup` / `toSignupError` + `api.signup`.
- `yarn build` OK · full lint 0 errors · touched suites green (48 tests). DB-dependent integration suites need Mongo/Postgres (run in CI).

## Deferred / out of scope

- Compliance & marketing consent (ToS, `--no-marketing`, email verification, anti-bot) tracked in PRD-530.
- Kept in JS to mirror `login.js`; can move to TS if preferred.
- No non-interactive/CI fail-fast mode yet (prompts on missing fields, like `login`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `forest signup` CLI command to create a Forest Admin account
> - Adds a new `signup` oclif command in [`src/commands/signup.js`](https://github.com/ForestAdmin/toolbelt/pull/768/files#diff-9745da2aa3abd54c60d5071b2bc47450fdbc3e0259925b39d1ba5a754a1e44e6) with optional `--email`, `--password`, `--first-name`, and `--last-name` flags; missing values are collected interactively via prompts.
> - Adds `Api.signup` in [`src/services/api.js`](https://github.com/ForestAdmin/toolbelt/pull/768/files#diff-64e6a6dc6ddee0b3b28d21c6b2bf6a5b1933a1a0a0f3284c9a3df46fea8bbf2e) that POSTs a JSON:API payload to `/api/users` to create the account, then logs in immediately via `/api/sessions` and persists the session token.
> - Error mapping in `Authenticator.toSignupError` surfaces server-provided messages for known failures (e.g. 409 email taken, 422 weak password) and a standard rate-limit message on 429.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 507eb8b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->