### PR TITLE
feat(environments): support --type and optional URL on environments:create

### DIFF
--- a/src/commands/environments/create.js
+++ b/src/commands/environments/create.js
@@ -54,8 +54,12 @@ CreateCommand.flags = {
   }),
   url: Flags.string({
     char: 'u',
-    description: 'Application URL.',
-    required: true,
+    description: 'Application URL (optional for a production environment).',
+  }),
+  type: Flags.string({
+    char: 't',
+    description: 'Environment type. Use "production" to create the first production environment.',
+    options: ['production', 'remote'],
   }),
   format: Flags.string({
     char: 'format',

--- a/src/commands/environments/create.js
+++ b/src/commands/environments/create.js
@@ -54,11 +54,13 @@ CreateCommand.flags = {
   }),
   url: Flags.string({
     char: 'u',
-    description: 'Application URL (optional for a production environment).',
+    description:
+      'Application URL. Optional: the environment is created inactive until an apiEndpoint is set.',
   }),
   type: Flags.string({
     char: 't',
-    description: 'Environment type. Use "production" to create the first production environment.',
+    description:
+      'Environment type (defaults to "remote" when omitted). Use "production" to create the first production environment. Development environments are created with "forest init".',
     options: ['production', 'remote'],
   }),
   format: Flags.string({

--- a/src/services/environment-manager.js
+++ b/src/services/environment-manager.js
@@ -45,18 +45,21 @@ function EnvironmentManager(config) {
   this.createEnvironment = async () => {
     const authToken = authenticator.getAuthToken();
 
+    const attributes = {
+      name: config.name,
+      project: { id: config.projectId },
+      areRolesDisabled: config.disableRoles,
+    };
+    // A production environment can be created without a URL; only send one when provided.
+    if (config.url) attributes.apiEndpoint = config.url;
+    // Required to create the first production environment (e.g. `--type production`).
+    if (config.type) attributes.type = config.type;
+
     const response = await agent
       .post(`${env.FOREST_SERVER_URL}/api/environments`)
       .set('Authorization', `Bearer ${authToken}`)
       .set('forest-project-id', config.projectId)
-      .send(
-        EnvironmentSerializer.serialize({
-          name: config.name,
-          apiEndpoint: config.url,
-          project: { id: config.projectId },
-          areRolesDisabled: config.disableRoles,
-        }),
-      );
+      .send(EnvironmentSerializer.serialize(attributes));
     const environment = await environmentDeserializer.deserialize(response.body);
 
     environment.authSecret = keyGenerator.generate();

--- a/test/commands/environments/create.test.js
+++ b/test/commands/environments/create.test.js
@@ -3,6 +3,7 @@ const EnvironmentCreateCommand = require('../../../src/commands/environments/cre
 const {
   getProjectListValid,
   createEnvironmentValid,
+  createProductionEnvironmentValid,
   createEnvironmentForbidden,
   createEnvironmentDetailedError,
   loginValidOidc,
@@ -141,6 +142,28 @@ describe('environments:create', () => {
           { out: 'ENVIRONMENT' },
           { out: 'name                Test' },
           { out: 'url                 https://test.forestadmin.com' },
+          { out: 'FOREST_AUTH_SECRET  myAuthSecret' },
+          {
+            out: 'FOREST_ENV_SECRET   2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125',
+          },
+        ],
+      }));
+  });
+
+  describe('with --type production and no URL', () => {
+    it('should create the production environment without requiring a URL', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: EnvironmentCreateCommand,
+        commandArgs: ['-p', '2', '-n', 'Production', '-t', 'production'],
+        additionnalStep: plan =>
+          plan.replace('utils/keyGenerator', { generate: () => 'myAuthSecret' }),
+        api: [() => createProductionEnvironmentValid()],
+        std: [
+          { out: 'ENVIRONMENT' },
+          { out: 'name                Production' },
+          { out: 'type                production' },
           { out: 'FOREST_AUTH_SECRET  myAuthSecret' },
           {
             out: 'FOREST_ENV_SECRET   2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125',

--- a/test/fixtures/api.js
+++ b/test/fixtures/api.js
@@ -479,6 +479,29 @@ module.exports = {
         }),
       ),
 
+  createProductionEnvironmentValid: () =>
+    nock('http://localhost:3001')
+      .post('/api/environments', {
+        data: {
+          type: 'environments',
+          attributes: {
+            name: 'Production',
+            'are-roles-disabled': false,
+            type: 'production',
+          },
+          relationships: { project: { data: { type: 'projects', id: '2' } } },
+        },
+      })
+      .reply(
+        200,
+        EnvironmentSerializer.serialize({
+          name: 'Production',
+          secretKey: '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125',
+          type: 'production',
+          areRolesDisabled: false,
+        }),
+      ),
+
   createEnvironmentForbidden: () =>
     nock('http://localhost:3001').post('/api/environments').reply(403),
 


### PR DESCRIPTION
## What

Lets `forest environments:create` create the **first production environment** headlessly:

- new `--type` flag (`production` | `remote`);
- `--url/-u` is now **optional**.

The request payload only includes `apiEndpoint` when a URL is given and `type` when provided; `projectId` keeps being sent via the `forest-project-id` header (IP-whitelist). Existing remote-environment creation is unchanged.

## Why / backend alignment

Verified against `forestadmin-server` (`environment-model.ts`, `environment-service.ts`):

- `EnvironmentType` = `development | production | remote`.
- **`apiEndpoint` is nullable for every type** (format/HTTPS validation only runs when a value is given) → making `--url` optional matches the server contract; an env without a URL is simply created **inactive** (`isActive = apimapVersionId && apiEndpoint`) until one is set.
- On creation, a missing `type` **defaults to `remote`** server-side; creating a `production` env when one already exists **returns the existing one** (idempotent); ordering rules (e.g. *"A production environment must be created before any other environment"*) are **enforced and messaged by the server** — the command relays `errors[0].detail`.
- `--type` is intentionally scoped to **`production | remote`**: development environments have their own command (`forest init` -> per-user `development-environment-for-user` endpoint), so exposing `development` here would be a confusing duplicate.

## Tests

- New command test: `--type production` with no URL.
- Existing `environments:create` suite unchanged and green.
- `yarn build` OK, full lint 0 errors, touched suites green.

Refs PRD-524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
