### PR TITLE
feat(users): add forest users:invite command

### DIFF
--- a/src/commands/users/invite.ts
+++ b/src/commands/users/invite.ts
@@ -1,0 +1,143 @@
+import type { Config } from '@oclif/core';
+
+import { Flags } from '@oclif/core';
+
+import AbstractAuthenticatedCommand from '../../abstract-authenticated-command';
+import InvitationManager from '../../services/invitation-manager';
+import RoleManager from '../../services/role-manager';
+import TeamManager from '../../services/team-manager';
+import withCurrentProject from '../../services/with-current-project';
+
+const PERMISSION_LEVELS = ['admin', 'editor', 'user', 'developer', 'manager'];
+
+type NamedEntity = { id: number | string; name: string };
+
+export default class UsersInviteCommand extends AbstractAuthenticatedCommand {
+  private env: Record<string, string>;
+
+  private inquirer: { prompt: (questions: unknown[]) => Promise<Record<string, unknown>> };
+
+  static override description = 'Invite users to a project.';
+
+  static override flags = {
+    email: Flags.string({
+      char: 'e',
+      description: 'Email of the user to invite (repeat the flag to invite several users).',
+      required: true,
+      multiple: true,
+    }),
+    team: Flags.string({
+      char: 't',
+      description: 'Team name to add the invited users to (prompted if omitted and several exist).',
+    }),
+    role: Flags.string({
+      char: 'r',
+      description: 'Role name to assign (prompted if omitted and several exist).',
+    }),
+    'permission-level': Flags.string({
+      char: 'l',
+      description: 'Permission level of the invited users.',
+      options: PERMISSION_LEVELS,
+      required: true,
+    }),
+    projectId: Flags.integer({
+      char: 'p',
+      description: 'Forest project ID.',
+    }),
+    format: Flags.string({
+      char: 'f',
+      description: 'Output format.',
+      options: ['table', 'json'],
+      default: 'table',
+    }),
+  };
+
+  constructor(argv: string[], config: Config, plan?) {
+    super(argv, config, plan);
+    const { assertPresent, env, inquirer } = this.context;
+    assertPresent({ env, inquirer });
+    this.env = env;
+    this.inquirer = inquirer;
+  }
+
+  // Resolve a team/role by name (headless when passed as a flag), with the
+  // same UX as project selection: auto-pick when there is only one, prompt
+  // when several and none provided, clear error listing the valid names.
+  private async resolveByName(
+    entities: NamedEntity[],
+    providedName: string | undefined,
+    label: string,
+  ): Promise<NamedEntity> {
+    if (providedName) {
+      const match = entities.find(entity => entity.name === providedName);
+      if (match) return match;
+      const available = entities.map(entity => entity.name).join(', ') || '(none)';
+      this.logger.error(
+        `${label} "${providedName}" not found in this project. Available: ${available}.`,
+      );
+      this.exit(1);
+    }
+
+    if (!entities.length) {
+      this.logger.error(`No ${label} found in this project.`);
+      this.exit(1);
+    }
+    if (entities.length === 1) return entities[0];
+
+    const { choice } = await this.inquirer.prompt([
+      {
+        name: 'choice',
+        message: `Select a ${label}:`,
+        type: 'list',
+        choices: entities.map(entity => ({ name: entity.name, value: entity.id })),
+      },
+    ]);
+    return entities.find(entity => entity.id === choice) as NamedEntity;
+  }
+
+  async runAuthenticated() {
+    const { flags } = await this.parse(UsersInviteCommand);
+    const config = await withCurrentProject({ ...this.env, projectId: flags.projectId });
+
+    try {
+      const teams = await new TeamManager(config).listForProject();
+      const team = await this.resolveByName(teams, flags.team, 'team');
+
+      const roles = await new RoleManager(config).listForProject();
+      const role = await this.resolveByName(roles, flags.role, 'role');
+
+      const invitations = flags.email.map((email: string) => ({
+        email,
+        teamId: team.id,
+        roleId: role.id,
+        permissionLevel: flags['permission-level'],
+      }));
+
+      const result = await new InvitationManager(config).inviteUsers(invitations);
+
+      if (flags.format === 'json') {
+        this.logger.info(JSON.stringify(result, null, 2));
+        return;
+      }
+
+      this.logger.info(
+        `Invited ${invitations.length} user(s) to team "${team.name}" (${
+          flags['permission-level']
+        }) on project ${config.projectId}: ${flags.email.join(', ')}.`,
+      );
+    } catch (error) {
+      const { response, status } = error as {
+        status?: number;
+        response?: { text?: string };
+      };
+      if (response && status !== 403 && response.text) {
+        const errorData = JSON.parse(response.text);
+        if (errorData?.errors?.[0]?.detail) {
+          this.logger.error(errorData.errors[0].detail);
+          this.exit(1);
+        }
+      }
+      throw error;
+    }
+  }
+}

--- a/src/services/invitation-manager.js
+++ b/src/services/invitation-manager.js
@@ -1,0 +1,43 @@
+const agent = require('superagent');
+const Context = require('@forestadmin/context');
+
+/**
+ * @param {{ projectId: number | string }} config
+ */
+function InvitationManager(config) {
+  const { assertPresent, authenticator, env } = Context.inject();
+  assertPresent({ authenticator, env });
+
+  /**
+   * @param {Array<{
+   *  email: string;
+   *  teamId: number | string;
+   *  roleId: number | string;
+   *  permissionLevel: string;
+   * }>} invitations
+   */
+  this.inviteUsers = async invitations => {
+    const authToken = authenticator.getAuthToken();
+
+    const data = invitations.map(invitation => ({
+      type: 'invitations',
+      attributes: {
+        email: invitation.email,
+        'permission-level': invitation.permissionLevel,
+      },
+      relationships: {
+        team: { data: { type: 'teams', id: String(invitation.teamId) } },
+        role: { data: { type: 'roles', id: String(invitation.roleId) } },
+      },
+    }));
+
+    return agent
+      .post(`${env.FOREST_SERVER_URL}/api/invitations`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .set('forest-project-id', config.projectId)
+      .send({ data })
+      .then(response => response.body);
+  };
+}
+
+module.exports = InvitationManager;

--- a/src/services/role-manager.js
+++ b/src/services/role-manager.js
@@ -1,0 +1,30 @@
+const agent = require('superagent');
+const Context = require('@forestadmin/context');
+
+/**
+ * Read access to a project's roles.
+ * Future `forest roles:*` commands (PRD-528/529) should extend this manager
+ * with write operations rather than re-implementing the HTTP calls.
+ * @param {{ projectId: number | string }} config
+ */
+function RoleManager(config) {
+  const { assertPresent, authenticator, env } = Context.inject();
+  assertPresent({ authenticator, env });
+
+  this.listForProject = async () => {
+    const authToken = authenticator.getAuthToken();
+
+    const response = await agent
+      .get(`${env.FOREST_SERVER_URL}/api/projects/${config.projectId}/roles`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .set('forest-project-id', config.projectId)
+      .send();
+
+    return (response.body.data || []).map(role => ({
+      id: role.id,
+      name: role.attributes.name,
+    }));
+  };
+}
+
+module.exports = RoleManager;

--- a/src/services/team-manager.js
+++ b/src/services/team-manager.js
@@ -1,0 +1,30 @@
+const agent = require('superagent');
+const Context = require('@forestadmin/context');
+
+/**
+ * Read access to a project's teams.
+ * Future `forest teams:*` commands (PRD-528/529) should extend this manager
+ * with write operations rather than re-implementing the HTTP calls.
+ * @param {{ projectId: number | string }} config
+ */
+function TeamManager(config) {
+  const { assertPresent, authenticator, env } = Context.inject();
+  assertPresent({ authenticator, env });
+
+  this.listForProject = async () => {
+    const authToken = authenticator.getAuthToken();
+
+    const response = await agent
+      .get(`${env.FOREST_SERVER_URL}/api/projects/${config.projectId}/teams`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .set('forest-project-id', config.projectId)
+      .send();
+
+    return (response.body.data || []).map(team => ({
+      id: team.id,
+      name: team.attributes.name,
+    }));
+  };
+}
+
+module.exports = TeamManager;

--- a/test/commands/users/invite.test.js
+++ b/test/commands/users/invite.test.js
@@ -1,0 +1,76 @@
+const testCli = require('../test-cli-helper/test-cli');
+const UsersInviteCommand = require('../../../src/commands/users/invite').default;
+
+const {
+  getTeamsValid,
+  getRolesValid,
+  inviteUsersValid,
+  inviteUsersDetailedError,
+} = require('../../fixtures/api');
+const { testEnvWithoutSecret } = require('../../fixtures/env');
+
+describe('users:invite', () => {
+  describe('with team and role names', () => {
+    it('should resolve names to ids, invite the user and confirm', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersInviteCommand,
+        commandArgs: [
+          '-p',
+          '2',
+          '-e',
+          'new@user.com',
+          '-t',
+          'Operations',
+          '-r',
+          'Admin',
+          '-l',
+          'editor',
+        ],
+        api: [() => getTeamsValid(), () => getRolesValid(), () => inviteUsersValid()],
+        std: [
+          {
+            out: 'Invited 1 user(s) to team "Operations" (editor) on project 2: new@user.com.',
+          },
+        ],
+      }));
+  });
+
+  describe('with an unknown team name', () => {
+    it('should error and list the available teams', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersInviteCommand,
+        commandArgs: ['-p', '2', '-e', 'new@user.com', '-t', 'Nope', '-r', 'Admin', '-l', 'editor'],
+        api: [() => getTeamsValid()],
+        std: [{ err: '× team "Nope" not found in this project. Available: Operations, Support.' }],
+        exitCode: 1,
+      }));
+  });
+
+  describe('when the server rejects the invitation', () => {
+    it('should display the server error and exit 1', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersInviteCommand,
+        commandArgs: [
+          '-p',
+          '2',
+          '-e',
+          'new@user.com',
+          '-t',
+          'Operations',
+          '-r',
+          'Admin',
+          '-l',
+          'editor',
+        ],
+        api: [() => getTeamsValid(), () => getRolesValid(), () => inviteUsersDetailedError()],
+        std: [{ err: '× Role project does not match team project.' }],
+        exitCode: 1,
+      }));
+  });
+});

--- a/test/fixtures/api.js
+++ b/test/fixtures/api.js
@@ -487,6 +487,49 @@ module.exports = {
       .post('/api/environments')
       .reply(422, { errors: [{ detail: 'dummy test error' }] }),
 
+  getTeamsValid: () =>
+    nock('http://localhost:3001')
+      .get('/api/projects/2/teams')
+      .reply(200, {
+        data: [
+          { type: 'teams', id: '7', attributes: { name: 'Operations' } },
+          { type: 'teams', id: '8', attributes: { name: 'Support' } },
+        ],
+      }),
+
+  getRolesValid: () =>
+    nock('http://localhost:3001')
+      .get('/api/projects/2/roles')
+      .reply(200, {
+        data: [
+          { type: 'roles', id: '3', attributes: { name: 'Admin' } },
+          { type: 'roles', id: '4', attributes: { name: 'Viewer' } },
+        ],
+      }),
+
+  inviteUsersValid: () =>
+    nock('http://localhost:3001')
+      .post('/api/invitations', {
+        data: [
+          {
+            type: 'invitations',
+            attributes: { email: 'new@user.com', 'permission-level': 'editor' },
+            relationships: {
+              team: { data: { type: 'teams', id: '7' } },
+              role: { data: { type: 'roles', id: '3' } },
+            },
+          },
+        ],
+      })
+      .reply(200, {
+        data: [{ type: 'invitations', id: '1', attributes: { email: 'new@user.com' } }],
+      }),
+
+  inviteUsersDetailedError: () =>
+    nock('http://localhost:3001')
+      .post('/api/invitations')
+      .reply(422, { errors: [{ detail: 'Role project does not match team project.' }] }),
+
   getEnvironmentNotFound: (id = '3947') =>
     nock('http://localhost:3001')
       .matchHeader('forest-environment-id', id)


### PR DESCRIPTION
## What

Adds `forest users:invite` to invite users to a project from the CLI (`POST /api/invitations`).

```
forest users:invite -e <email> --team <name> --role <name> -l <permission-level> [-p <projectId>]
```

- `--email/-e` is repeatable (invite several users at once).
- `--permission-level/-l` ∈ `admin|editor|user|developer|manager`.

## Self-sufficient by design

No opaque IDs: **team and role are resolved by name** — auto-picked when a single one exists, prompted when several, with a clear error listing valid names when unknown. The project is resolved the usual way (`-p`, `FOREST_ENV_SECRET`, or prompt). So it works headlessly (names in flags) or interactively (pick from lists).

Resolution goes through two **new read-only managers** — `team-manager` / `role-manager` (`listForProject` → `GET /api/projects/:projectId/teams` and `/roles`). Future `teams:*` / `roles:*` (PRD-528/529) should **extend these** rather than re-implement the HTTP calls (coordination notes left on those issues).

## Validated end-to-end

Exercised on real prod as part of the full headless flow: signup → create project → boot dev agent → create prod env → deploy to Heroku → `users:invite` → invitation delivered. Note: a project's first role is created on production deployment, so invite requires the prod env to be deployed first (or a role created via `POST /api/roles`).

## Tests

- Command tests: success (name resolution), unknown team name (lists available), server error relayed.
- `yarn build` OK · full lint 0 errors · suites green.

Refs PRD-525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `users:invite` CLI command to invite users to a Forest project
> - Adds a new `users:invite` command in [`src/commands/users/invite.ts`](https://github.com/ForestAdmin/toolbelt/pull/770/files#diff-34d2442af9c1bf123dfd48ab0fd1d80a489770d114f82a536d7556ea9ddf6586) that accepts one or more `--email` addresses, a `--permission-level`, and optional `--team` and `--role` flags.
> - When `--team` or `--role` are omitted or ambiguous, the command fetches available teams/roles and prompts interactively; if a provided name is not found, it exits with an error listing valid options.
> - Introduces [`InvitationManager`](https://github.com/ForestAdmin/toolbelt/pull/770/files#diff-3f1db832a0d5b6850f1f157c140706742b2d5e1153f802934469d10bf47b5d19), [`TeamManager`](https://github.com/ForestAdmin/toolbelt/pull/770/files#diff-7083afebe926c101165a5a4bd58e5f3528e9eca5990974175bd3f4dbb6da1019), and [`RoleManager`](https://github.com/ForestAdmin/toolbelt/pull/770/files#diff-9a0caf92ffc6f1d4735786395cc30a13986ca93e439a2e374f466da135171ad0) to handle the corresponding API calls (`POST /api/invitations`, `GET /api/projects/:id/teams`, `GET /api/projects/:id/roles`).
> - Outputs a human-readable confirmation by default or JSON with `--format json`; surfaces JSON:API error details and exits with code 1 on server errors (except 403, which is rethrown).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3f6073.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->