### PR TITLE
feat(environments): support --type and optional URL on environments:create

### DIFF
--- a/src/commands/environments/create.js
+++ b/src/commands/environments/create.js
@@ -15,6 +15,23 @@ class CreateCommand extends AbstractAuthenticatedCommand {
   async runAuthenticated() {
     const parsed = await this.parse(CreateCommand);
     const config = await withCurrentProject({ ...this.env, ...parsed.flags });
+
+    const isProduction = config.type === 'production';
+
+    // Only production environments may be created without a URL; a remote env
+    // without an apiEndpoint would be created permanently inactive.
+    if (!isProduction && !config.url) {
+      this.logger.error('The --url option is required unless --type production is set.');
+      this.exit(1);
+    }
+
+    // Roles cannot be disabled on production: the server skips role creation entirely
+    // when areRolesDisabled is true, which would leave the project without its default roles.
+    if (isProduction && config.disableRoles) {
+      this.logger.error('The --disableRoles option cannot be used with --type production.');
+      this.exit(1);
+    }
+
     const manager = new EnvironmentManager(config);
 
     try {
@@ -55,7 +72,7 @@ CreateCommand.flags = {
   url: Flags.string({
     char: 'u',
     description:
-      'Application URL. Optional: the environment is created inactive until an apiEndpoint is set.',
+      'Application URL. Required, except with --type production where it may be omitted.',
   }),
   type: Flags.string({
     char: 't',

--- a/src/commands/environments/create.js
+++ b/src/commands/environments/create.js
@@ -54,8 +54,12 @@ CreateCommand.flags = {
   }),
   url: Flags.string({
     char: 'u',
-    description: 'Application URL.',
-    required: true,
+    description: 'Application URL (optional for a production environment).',
+  }),
+  type: Flags.string({
+    char: 't',
+    description: 'Environment type. Use "production" to create the first production environment.',
+    options: ['production', 'remote'],
   }),
   format: Flags.string({
     char: 'format',

--- a/src/commands/environments/create.js
+++ b/src/commands/environments/create.js
@@ -54,11 +54,13 @@ CreateCommand.flags = {
   }),
   url: Flags.string({
     char: 'u',
-    description: 'Application URL (optional for a production environment).',
+    description:
+      'Application URL. Optional: the environment is created inactive until an apiEndpoint is set.',
   }),
   type: Flags.string({
     char: 't',
-    description: 'Environment type. Use "production" to create the first production environment.',
+    description:
+      'Environment type (defaults to "remote" when omitted). Use "production" to create the first production environment. Development environments are created with "forest init".',
     options: ['production', 'remote'],
   }),
   format: Flags.string({

--- a/src/services/environment-manager.js
+++ b/src/services/environment-manager.js
@@ -45,18 +45,21 @@ function EnvironmentManager(config) {
   this.createEnvironment = async () => {
     const authToken = authenticator.getAuthToken();
 
+    const attributes = {
+      name: config.name,
+      project: { id: config.projectId },
+      areRolesDisabled: config.disableRoles,
+    };
+    // A production environment can be created without a URL; only send one when provided.
+    if (config.url) attributes.apiEndpoint = config.url;
+    // Required to create the first production environment (e.g. `--type production`).
+    if (config.type) attributes.type = config.type;
+
     const response = await agent
       .post(`${env.FOREST_SERVER_URL}/api/environments`)
       .set('Authorization', `Bearer ${authToken}`)
       .set('forest-project-id', config.projectId)
-      .send(
-        EnvironmentSerializer.serialize({
-          name: config.name,
-          apiEndpoint: config.url,
-          project: { id: config.projectId },
-          areRolesDisabled: config.disableRoles,
-        }),
-      );
+      .send(EnvironmentSerializer.serialize(attributes));
     const environment = await environmentDeserializer.deserialize(response.body);
 
     environment.authSecret = keyGenerator.generate();

--- a/src/services/environment-manager.js
+++ b/src/services/environment-manager.js
@@ -53,6 +53,7 @@ function EnvironmentManager(config) {
     // A production environment can be created without a URL; only send one when provided.
     if (config.url) attributes.apiEndpoint = config.url;
     // Required to create the first production environment (e.g. `--type production`).
+    // When omitted, the server defaults the type to "remote" (see environment-service).
     if (config.type) attributes.type = config.type;
 
     const response = await agent

--- a/test/commands/environments/create.test.js
+++ b/test/commands/environments/create.test.js
@@ -3,6 +3,7 @@ const EnvironmentCreateCommand = require('../../../src/commands/environments/cre
 const {
   getProjectListValid,
   createEnvironmentValid,
+  createProductionEnvironmentValid,
   createEnvironmentForbidden,
   createEnvironmentDetailedError,
   loginValidOidc,
@@ -141,6 +142,28 @@ describe('environments:create', () => {
           { out: 'ENVIRONMENT' },
           { out: 'name                Test' },
           { out: 'url                 https://test.forestadmin.com' },
+          { out: 'FOREST_AUTH_SECRET  myAuthSecret' },
+          {
+            out: 'FOREST_ENV_SECRET   2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125',
+          },
+        ],
+      }));
+  });
+
+  describe('with --type production and no URL', () => {
+    it('should create the production environment without requiring a URL', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: EnvironmentCreateCommand,
+        commandArgs: ['-p', '2', '-n', 'Production', '-t', 'production'],
+        additionnalStep: plan =>
+          plan.replace('utils/keyGenerator', { generate: () => 'myAuthSecret' }),
+        api: [() => createProductionEnvironmentValid()],
+        std: [
+          { out: 'ENVIRONMENT' },
+          { out: 'name                Production' },
+          { out: 'type                production' },
           { out: 'FOREST_AUTH_SECRET  myAuthSecret' },
           {
             out: 'FOREST_ENV_SECRET   2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125',

--- a/test/commands/environments/create.test.js
+++ b/test/commands/environments/create.test.js
@@ -4,6 +4,7 @@ const {
   getProjectListValid,
   createEnvironmentValid,
   createProductionEnvironmentValid,
+  createProductionEnvironmentWithUrlValid,
   createEnvironmentForbidden,
   createEnvironmentDetailedError,
   loginValidOidc,
@@ -169,6 +170,59 @@ describe('environments:create', () => {
             out: 'FOREST_ENV_SECRET   2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125',
           },
         ],
+      }));
+  });
+
+  describe('with --type production and a URL', () => {
+    it('should send the apiEndpoint alongside the production type', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: EnvironmentCreateCommand,
+        commandArgs: [
+          '-p',
+          '2',
+          '-n',
+          'Production',
+          '-t',
+          'production',
+          '-u',
+          'https://prod.forestadmin.com',
+        ],
+        additionnalStep: plan =>
+          plan.replace('utils/keyGenerator', { generate: () => 'myAuthSecret' }),
+        api: [() => createProductionEnvironmentWithUrlValid()],
+        std: [
+          { out: 'ENVIRONMENT' },
+          { out: 'name                Production' },
+          { out: 'url                 https://prod.forestadmin.com' },
+          { out: 'type                production' },
+          { out: 'FOREST_AUTH_SECRET  myAuthSecret' },
+        ],
+      }));
+  });
+
+  describe('with a remote type and no URL', () => {
+    it('should reject creation and exit 1', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: EnvironmentCreateCommand,
+        commandArgs: ['-p', '2', '-n', 'Test'],
+        std: [{ err: '× The --url option is required unless --type production is set.' }],
+        exitCode: 1,
+      }));
+  });
+
+  describe('with --type production and --disableRoles', () => {
+    it('should reject creation and exit 1', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: EnvironmentCreateCommand,
+        commandArgs: ['-p', '2', '-n', 'Production', '-t', 'production', '--disableRoles'],
+        std: [{ err: '× The --disableRoles option cannot be used with --type production.' }],
+        exitCode: 1,
       }));
   });
 

--- a/test/fixtures/api.js
+++ b/test/fixtures/api.js
@@ -479,6 +479,29 @@ module.exports = {
         }),
       ),
 
+  createProductionEnvironmentValid: () =>
+    nock('http://localhost:3001')
+      .post('/api/environments', {
+        data: {
+          type: 'environments',
+          attributes: {
+            name: 'Production',
+            'are-roles-disabled': false,
+            type: 'production',
+          },
+          relationships: { project: { data: { type: 'projects', id: '2' } } },
+        },
+      })
+      .reply(
+        200,
+        EnvironmentSerializer.serialize({
+          name: 'Production',
+          secretKey: '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125',
+          type: 'production',
+          areRolesDisabled: false,
+        }),
+      ),
+
   createEnvironmentForbidden: () =>
     nock('http://localhost:3001').post('/api/environments').reply(403),
 

--- a/test/fixtures/api.js
+++ b/test/fixtures/api.js
@@ -502,6 +502,31 @@ module.exports = {
         }),
       ),
 
+  createProductionEnvironmentWithUrlValid: () =>
+    nock('http://localhost:3001')
+      .post('/api/environments', {
+        data: {
+          type: 'environments',
+          attributes: {
+            name: 'Production',
+            'api-endpoint': 'https://prod.forestadmin.com',
+            'are-roles-disabled': false,
+            type: 'production',
+          },
+          relationships: { project: { data: { type: 'projects', id: '2' } } },
+        },
+      })
+      .reply(
+        200,
+        EnvironmentSerializer.serialize({
+          name: 'Production',
+          apiEndpoint: 'https://prod.forestadmin.com',
+          secretKey: '2c38a1c6bb28e7bea1c943fac1c1c95db5dc1b7bc73bd649a0b113713ee29125',
+          type: 'production',
+          areRolesDisabled: false,
+        }),
+      ),
+
   createEnvironmentForbidden: () =>
     nock('http://localhost:3001').post('/api/environments').reply(403),
 


### PR DESCRIPTION
Exposes `--type production` and makes `--url` optional; payload sends `apiEndpoint`/`type` only when provided. Aligned with the server (apiEndpoint nullable for all types, prod-creation idempotent, ordering enforced server-side). Linear **PRD-524**.

(Intra-repo re-open of fork PR #769.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support `--type` flag and optional `--url` on `environments:create` command
> - Makes `--url`/`-u` optional in `environments:create`, allowing environments to be created without an API endpoint (e.g. production environments).
> - Adds `--type`/`-t` flag accepting `'production'` or `'remote'` values.
> - `EnvironmentManager.createEnvironment` now conditionally includes `apiEndpoint` and `type` in the POST payload based on what flags are provided.
> - Behavioral Change: the POST to `/api/environments` no longer always sends `apiEndpoint`; omitting `--url` will result in a payload without that field.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #773 opened
>
> - Added validation in `CreateCommand.runAuthenticated` method to enforce URL requirements based on environment type and prevent incompatible flag combinations [dc7cdc2]
> - Added test coverage for environment creation validation logic including production environments with URLs, remote environments without URLs, and production environments with role disablement [dc7cdc2]
> - Added comment in `EnvironmentManager` function clarifying server default behavior for environment type [dc7cdc2]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8ead6e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->