### PR TITLE
feat(users): add forest users:invite command

### DIFF
--- a/src/commands/users/invite.ts
+++ b/src/commands/users/invite.ts
@@ -1,0 +1,143 @@
+import type { Config } from '@oclif/core';
+
+import { Flags } from '@oclif/core';
+
+import AbstractAuthenticatedCommand from '../../abstract-authenticated-command';
+import InvitationManager from '../../services/invitation-manager';
+import RoleManager from '../../services/role-manager';
+import TeamManager from '../../services/team-manager';
+import withCurrentProject from '../../services/with-current-project';
+
+const PERMISSION_LEVELS = ['admin', 'editor', 'user', 'developer', 'manager'];
+
+type NamedEntity = { id: number | string; name: string };
+
+export default class UsersInviteCommand extends AbstractAuthenticatedCommand {
+  private env: Record<string, string>;
+
+  private inquirer: { prompt: (questions: unknown[]) => Promise<Record<string, unknown>> };
+
+  static override description = 'Invite users to a project.';
+
+  static override flags = {
+    email: Flags.string({
+      char: 'e',
+      description: 'Email of the user to invite (repeat the flag to invite several users).',
+      required: true,
+      multiple: true,
+    }),
+    team: Flags.string({
+      char: 't',
+      description: 'Team name to add the invited users to (prompted if omitted and several exist).',
+    }),
+    role: Flags.string({
+      char: 'r',
+      description: 'Role name to assign (prompted if omitted and several exist).',
+    }),
+    'permission-level': Flags.string({
+      char: 'l',
+      description: 'Permission level of the invited users.',
+      options: PERMISSION_LEVELS,
+      required: true,
+    }),
+    projectId: Flags.integer({
+      char: 'p',
+      description: 'Forest project ID.',
+    }),
+    format: Flags.string({
+      char: 'f',
+      description: 'Output format.',
+      options: ['table', 'json'],
+      default: 'table',
+    }),
+  };
+
+  constructor(argv: string[], config: Config, plan?) {
+    super(argv, config, plan);
+    const { assertPresent, env, inquirer } = this.context;
+    assertPresent({ env, inquirer });
+    this.env = env;
+    this.inquirer = inquirer;
+  }
+
+  // Resolve a team/role by name (headless when passed as a flag), with the
+  // same UX as project selection: auto-pick when there is only one, prompt
+  // when several and none provided, clear error listing the valid names.
+  private async resolveByName(
+    entities: NamedEntity[],
+    providedName: string | undefined,
+    label: string,
+  ): Promise<NamedEntity> {
+    if (providedName) {
+      const match = entities.find(entity => entity.name === providedName);
+      if (match) return match;
+      const available = entities.map(entity => entity.name).join(', ') || '(none)';
+      this.logger.error(
+        `${label} "${providedName}" not found in this project. Available: ${available}.`,
+      );
+      this.exit(1);
+    }
+
+    if (!entities.length) {
+      this.logger.error(`No ${label} found in this project.`);
+      this.exit(1);
+    }
+    if (entities.length === 1) return entities[0];
+
+    const { choice } = await this.inquirer.prompt([
+      {
+        name: 'choice',
+        message: `Select a ${label}:`,
+        type: 'list',
+        choices: entities.map(entity => ({ name: entity.name, value: entity.id })),
+      },
+    ]);
+    return entities.find(entity => entity.id === choice) as NamedEntity;
+  }
+
+  async runAuthenticated() {
+    const { flags } = await this.parse(UsersInviteCommand);
+    const config = await withCurrentProject({ ...this.env, projectId: flags.projectId });
+
+    try {
+      const teams = await new TeamManager(config).listForProject();
+      const team = await this.resolveByName(teams, flags.team, 'team');
+
+      const roles = await new RoleManager(config).listForProject();
+      const role = await this.resolveByName(roles, flags.role, 'role');
+
+      const invitations = flags.email.map((email: string) => ({
+        email,
+        teamId: team.id,
+        roleId: role.id,
+        permissionLevel: flags['permission-level'],
+      }));
+
+      const result = await new InvitationManager(config).inviteUsers(invitations);
+
+      if (flags.format === 'json') {
+        this.logger.info(JSON.stringify(result, null, 2));
+        return;
+      }
+
+      this.logger.info(
+        `Invited ${invitations.length} user(s) to team "${team.name}" (${
+          flags['permission-level']
+        }) on project ${config.projectId}: ${flags.email.join(', ')}.`,
+      );
+    } catch (error) {
+      const { response, status } = error as {
+        status?: number;
+        response?: { text?: string };
+      };
+      if (response && status !== 403 && response.text) {
+        const errorData = JSON.parse(response.text);
+        if (errorData?.errors?.[0]?.detail) {
+          this.logger.error(errorData.errors[0].detail);
+          this.exit(1);
+        }
+      }
+      throw error;
+    }
+  }
+}

--- a/src/commands/users/invite.ts
+++ b/src/commands/users/invite.ts
@@ -67,6 +67,7 @@ export default class UsersInviteCommand extends AbstractAuthenticatedCommand {
     entities: NamedEntity[],
     providedName: string | undefined,
     label: string,
+    emptyHint?: string,
   ): Promise<NamedEntity> {
     if (providedName) {
       const match = entities.find(entity => entity.name === providedName);
@@ -75,12 +76,12 @@ export default class UsersInviteCommand extends AbstractAuthenticatedCommand {
       this.logger.error(
         `${label} "${providedName}" not found in this project. Available: ${available}.`,
       );
-      this.exit(1);
+      return this.exit(1);
     }
 
     if (!entities.length) {
-      this.logger.error(`No ${label} found in this project.`);
-      this.exit(1);
+      this.logger.error(`No ${label} found in this project.${emptyHint ? ` ${emptyHint}` : ''}`);
+      return this.exit(1);
     }
     if (entities.length === 1) return entities[0];
 
@@ -104,7 +105,12 @@ export default class UsersInviteCommand extends AbstractAuthenticatedCommand {
       const team = await this.resolveByName(teams, flags.team, 'team');
 
       const roles = await new RoleManager(config).listForProject();
-      const role = await this.resolveByName(roles, flags.role, 'role');
+      const role = await this.resolveByName(
+        roles,
+        flags.role,
+        'role',
+        "Deploy a production environment first (it creates the project's first role), or create one via the API.",
+      );
 
       const invitations = flags.email.map((email: string) => ({
         email,
@@ -131,9 +137,14 @@ export default class UsersInviteCommand extends AbstractAuthenticatedCommand {
         response?: { text?: string };
       };
       if (response && status !== 403 && response.text) {
-        const errorData = JSON.parse(response.text);
-        if (errorData?.errors?.[0]?.detail) {
-          this.logger.error(errorData.errors[0].detail);
+        let detail;
+        try {
+          detail = JSON.parse(response.text)?.errors?.[0]?.detail;
+        } catch {
+          // Non-JSON error body: fall through and rethrow the original error.
+        }
+        if (detail) {
+          this.logger.error(detail);
           this.exit(1);
         }
       }

--- a/src/services/invitation-manager.js
+++ b/src/services/invitation-manager.js
@@ -1,0 +1,43 @@
+const agent = require('superagent');
+const Context = require('@forestadmin/context');
+
+/**
+ * @param {{ projectId: number | string }} config
+ */
+function InvitationManager(config) {
+  const { assertPresent, authenticator, env } = Context.inject();
+  assertPresent({ authenticator, env });
+
+  /**
+   * @param {Array<{
+   *  email: string;
+   *  teamId: number | string;
+   *  roleId: number | string;
+   *  permissionLevel: string;
+   * }>} invitations
+   */
+  this.inviteUsers = async invitations => {
+    const authToken = authenticator.getAuthToken();
+
+    const data = invitations.map(invitation => ({
+      type: 'invitations',
+      attributes: {
+        email: invitation.email,
+        'permission-level': invitation.permissionLevel,
+      },
+      relationships: {
+        team: { data: { type: 'teams', id: String(invitation.teamId) } },
+        role: { data: { type: 'roles', id: String(invitation.roleId) } },
+      },
+    }));
+
+    return agent
+      .post(`${env.FOREST_SERVER_URL}/api/invitations`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .set('forest-project-id', config.projectId)
+      .send({ data })
+      .then(response => response.body);
+  };
+}
+
+module.exports = InvitationManager;

--- a/src/services/role-manager.js
+++ b/src/services/role-manager.js
@@ -1,0 +1,30 @@
+const agent = require('superagent');
+const Context = require('@forestadmin/context');
+
+/**
+ * Read access to a project's roles.
+ * Future `forest roles:*` commands (PRD-528/529) should extend this manager
+ * with write operations rather than re-implementing the HTTP calls.
+ * @param {{ projectId: number | string }} config
+ */
+function RoleManager(config) {
+  const { assertPresent, authenticator, env } = Context.inject();
+  assertPresent({ authenticator, env });
+
+  this.listForProject = async () => {
+    const authToken = authenticator.getAuthToken();
+
+    const response = await agent
+      .get(`${env.FOREST_SERVER_URL}/api/projects/${config.projectId}/roles`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .set('forest-project-id', config.projectId)
+      .send();
+
+    return (response.body.data || []).map(role => ({
+      id: role.id,
+      name: role.attributes.name,
+    }));
+  };
+}
+
+module.exports = RoleManager;

--- a/src/services/team-manager.js
+++ b/src/services/team-manager.js
@@ -1,0 +1,30 @@
+const agent = require('superagent');
+const Context = require('@forestadmin/context');
+
+/**
+ * Read access to a project's teams.
+ * Future `forest teams:*` commands (PRD-528/529) should extend this manager
+ * with write operations rather than re-implementing the HTTP calls.
+ * @param {{ projectId: number | string }} config
+ */
+function TeamManager(config) {
+  const { assertPresent, authenticator, env } = Context.inject();
+  assertPresent({ authenticator, env });
+
+  this.listForProject = async () => {
+    const authToken = authenticator.getAuthToken();
+
+    const response = await agent
+      .get(`${env.FOREST_SERVER_URL}/api/projects/${config.projectId}/teams`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .set('forest-project-id', config.projectId)
+      .send();
+
+    return (response.body.data || []).map(team => ({
+      id: team.id,
+      name: team.attributes.name,
+    }));
+  };
+}
+
+module.exports = TeamManager;

--- a/test/commands/users/invite.test.js
+++ b/test/commands/users/invite.test.js
@@ -4,7 +4,9 @@ const UsersInviteCommand = require('../../../src/commands/users/invite').default
 const {
   getTeamsValid,
   getRolesValid,
+  getRolesEmpty,
   inviteUsersValid,
+  inviteUsersMultipleValid,
   inviteUsersDetailedError,
 } = require('../../fixtures/api');
 const { testEnvWithoutSecret } = require('../../fixtures/env');
@@ -47,6 +49,77 @@ describe('users:invite', () => {
         api: [() => getTeamsValid()],
         std: [{ err: '× team "Nope" not found in this project. Available: Operations, Support.' }],
         exitCode: 1,
+      }));
+  });
+
+  describe('with several emails', () => {
+    it('should send one invitation per email in a single request', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersInviteCommand,
+        commandArgs: [
+          '-p',
+          '2',
+          '-e',
+          'new@user.com',
+          '-e',
+          'second@user.com',
+          '-t',
+          'Operations',
+          '-r',
+          'Admin',
+          '-l',
+          'editor',
+        ],
+        api: [() => getTeamsValid(), () => getRolesValid(), () => inviteUsersMultipleValid()],
+        std: [
+          {
+            out: 'Invited 2 user(s) to team "Operations" (editor) on project 2: new@user.com, second@user.com.',
+          },
+        ],
+      }));
+  });
+
+  describe('when the project has no role yet', () => {
+    it('should error with an actionable hint and exit 1', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersInviteCommand,
+        commandArgs: ['-p', '2', '-e', 'new@user.com', '-t', 'Operations', '-l', 'editor'],
+        api: [() => getTeamsValid(), () => getRolesEmpty()],
+        std: [
+          {
+            err: "No role found in this project. Deploy a production environment first (it creates the project's first role), or create one via the API.",
+          },
+        ],
+        exitCode: 1,
+      }));
+  });
+
+  describe('with --format json', () => {
+    it('should print the raw invitation result', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersInviteCommand,
+        commandArgs: [
+          '-p',
+          '2',
+          '-e',
+          'new@user.com',
+          '-t',
+          'Operations',
+          '-r',
+          'Admin',
+          '-l',
+          'editor',
+          '-f',
+          'json',
+        ],
+        api: [() => getTeamsValid(), () => getRolesValid(), () => inviteUsersValid()],
+        std: [{ out: '"data": [' }, { out: '"email": "new@user.com"' }],
       }));
   });
 

--- a/test/commands/users/invite.test.js
+++ b/test/commands/users/invite.test.js
@@ -1,0 +1,76 @@
+const testCli = require('../test-cli-helper/test-cli');
+const UsersInviteCommand = require('../../../src/commands/users/invite').default;
+
+const {
+  getTeamsValid,
+  getRolesValid,
+  inviteUsersValid,
+  inviteUsersDetailedError,
+} = require('../../fixtures/api');
+const { testEnvWithoutSecret } = require('../../fixtures/env');
+
+describe('users:invite', () => {
+  describe('with team and role names', () => {
+    it('should resolve names to ids, invite the user and confirm', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersInviteCommand,
+        commandArgs: [
+          '-p',
+          '2',
+          '-e',
+          'new@user.com',
+          '-t',
+          'Operations',
+          '-r',
+          'Admin',
+          '-l',
+          'editor',
+        ],
+        api: [() => getTeamsValid(), () => getRolesValid(), () => inviteUsersValid()],
+        std: [
+          {
+            out: 'Invited 1 user(s) to team "Operations" (editor) on project 2: new@user.com.',
+          },
+        ],
+      }));
+  });
+
+  describe('with an unknown team name', () => {
+    it('should error and list the available teams', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersInviteCommand,
+        commandArgs: ['-p', '2', '-e', 'new@user.com', '-t', 'Nope', '-r', 'Admin', '-l', 'editor'],
+        api: [() => getTeamsValid()],
+        std: [{ err: '× team "Nope" not found in this project. Available: Operations, Support.' }],
+        exitCode: 1,
+      }));
+  });
+
+  describe('when the server rejects the invitation', () => {
+    it('should display the server error and exit 1', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersInviteCommand,
+        commandArgs: [
+          '-p',
+          '2',
+          '-e',
+          'new@user.com',
+          '-t',
+          'Operations',
+          '-r',
+          'Admin',
+          '-l',
+          'editor',
+        ],
+        api: [() => getTeamsValid(), () => getRolesValid(), () => inviteUsersDetailedError()],
+        std: [{ err: '× Role project does not match team project.' }],
+        exitCode: 1,
+      }));
+  });
+});

--- a/test/fixtures/api.js
+++ b/test/fixtures/api.js
@@ -487,6 +487,49 @@ module.exports = {
       .post('/api/environments')
       .reply(422, { errors: [{ detail: 'dummy test error' }] }),
 
+  getTeamsValid: () =>
+    nock('http://localhost:3001')
+      .get('/api/projects/2/teams')
+      .reply(200, {
+        data: [
+          { type: 'teams', id: '7', attributes: { name: 'Operations' } },
+          { type: 'teams', id: '8', attributes: { name: 'Support' } },
+        ],
+      }),
+
+  getRolesValid: () =>
+    nock('http://localhost:3001')
+      .get('/api/projects/2/roles')
+      .reply(200, {
+        data: [
+          { type: 'roles', id: '3', attributes: { name: 'Admin' } },
+          { type: 'roles', id: '4', attributes: { name: 'Viewer' } },
+        ],
+      }),
+
+  inviteUsersValid: () =>
+    nock('http://localhost:3001')
+      .post('/api/invitations', {
+        data: [
+          {
+            type: 'invitations',
+            attributes: { email: 'new@user.com', 'permission-level': 'editor' },
+            relationships: {
+              team: { data: { type: 'teams', id: '7' } },
+              role: { data: { type: 'roles', id: '3' } },
+            },
+          },
+        ],
+      })
+      .reply(200, {
+        data: [{ type: 'invitations', id: '1', attributes: { email: 'new@user.com' } }],
+      }),
+
+  inviteUsersDetailedError: () =>
+    nock('http://localhost:3001')
+      .post('/api/invitations')
+      .reply(422, { errors: [{ detail: 'Role project does not match team project.' }] }),
+
   getEnvironmentNotFound: (id = '3947') =>
     nock('http://localhost:3001')
       .matchHeader('forest-environment-id', id)

--- a/test/fixtures/api.js
+++ b/test/fixtures/api.js
@@ -507,6 +507,11 @@ module.exports = {
         ],
       }),
 
+  getRolesEmpty: () =>
+    nock('http://localhost:3001').get('/api/projects/2/roles').reply(200, {
+      data: [],
+    }),
+
   inviteUsersValid: () =>
     nock('http://localhost:3001')
       .post('/api/invitations', {
@@ -523,6 +528,35 @@ module.exports = {
       })
       .reply(200, {
         data: [{ type: 'invitations', id: '1', attributes: { email: 'new@user.com' } }],
+      }),
+
+  inviteUsersMultipleValid: () =>
+    nock('http://localhost:3001')
+      .post('/api/invitations', {
+        data: [
+          {
+            type: 'invitations',
+            attributes: { email: 'new@user.com', 'permission-level': 'editor' },
+            relationships: {
+              team: { data: { type: 'teams', id: '7' } },
+              role: { data: { type: 'roles', id: '3' } },
+            },
+          },
+          {
+            type: 'invitations',
+            attributes: { email: 'second@user.com', 'permission-level': 'editor' },
+            relationships: {
+              team: { data: { type: 'teams', id: '7' } },
+              role: { data: { type: 'roles', id: '3' } },
+            },
+          },
+        ],
+      })
+      .reply(200, {
+        data: [
+          { type: 'invitations', id: '1', attributes: { email: 'new@user.com' } },
+          { type: 'invitations', id: '2', attributes: { email: 'second@user.com' } },
+        ],
       }),
 
   inviteUsersDetailedError: () =>


### PR DESCRIPTION
Adds `forest users:invite` (`POST /api/invitations`). Team & role are resolved **by name** (auto-pick / prompt / clear error) via new read-only `team-manager`/`role-manager` so PRD-528/529 can extend them. Validated e2e. Linear **PRD-525**.

(Intra-repo re-open of fork PR #770.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `users:invite` CLI command to batch-invite users to a project
> - Adds a new `users:invite` command in [invite.ts](https://github.com/ForestAdmin/toolbelt/pull/774/files#diff-34d2442af9c1bf123dfd48ab0fd1d80a489770d114f82a536d7556ea9ddf6586) that accepts one or more `--email` flags along with `--team`, `--role`, and `--permission-level` options.
> - Resolves team and role by name: auto-selects when only one exists, prompts interactively when multiple exist, and exits with an error listing valid names when a provided name is not found.
> - Adds three supporting services: [InvitationManager](https://github.com/ForestAdmin/toolbelt/pull/774/files#diff-3f1db832a0d5b6850f1f157c140706742b2d5e1153f802934469d10bf47b5d19) (POST `/api/invitations`), [TeamManager](https://github.com/ForestAdmin/toolbelt/pull/774/files#diff-7083afebe926c101165a5a4bd58e5f3528e9eca5990974175bd3f4dbb6da1019) (GET project teams), and [RoleManager](https://github.com/ForestAdmin/toolbelt/pull/774/files#diff-9a0caf92ffc6f1d4735786395cc30a13986ca93e439a2e374f466da135171ad0) (GET project roles).
> - Supports `--format json` for machine-readable output and surfaces server-provided error details (e.g. 422 responses) with exit code 1.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f412cec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->