### PR TITLE
feat(projects): add projects:create:demo — zero-DB onboarding on the dummy datasource

### DIFF
--- a/src/abstract-project-create-command.ts
+++ b/src/abstract-project-create-command.ts
@@ -243,6 +243,11 @@ export default abstract class AbstractProjectCreateCommand extends AbstractAuthe
 
   private async notifySuccess(): Promise<void> {
     this.logger.info(`Hooray, ${this.chalk.green('installation success')}!`);
+    this.logNextSteps();
     await this.eventSender.notifySuccess();
   }
+
+  // Overridable no-op: subcommands print follow-up guidance here (the demo points to create:sql).
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-empty-function -- intentional no-op hook
+  protected logNextSteps(): void {}
 }

--- a/src/abstract-project-create-command.ts
+++ b/src/abstract-project-create-command.ts
@@ -33,6 +33,11 @@ export default abstract class AbstractProjectCreateCommand extends AbstractAuthe
 
   protected abstract readonly agent: string | null;
 
+  // Whether the project is backed by a database. When false (e.g. the demo
+  // project on a dummy datasource), all DB steps (dialect requirement, connection
+  // test, introspection) are skipped.
+  protected readonly requiresDatabase: boolean = true;
+
   static override args = {
     applicationName: Args.string({
       name: 'applicationName',
@@ -93,7 +98,7 @@ export default abstract class AbstractProjectCreateCommand extends AbstractAuthe
 
       this.eventSender.meta.projectId = id;
 
-      await this.testDatabaseConnection(dbConfig);
+      if (this.requiresDatabase) await this.testDatabaseConnection(dbConfig);
 
       await this.generateProject({
         dbConfig,
@@ -117,7 +122,7 @@ export default abstract class AbstractProjectCreateCommand extends AbstractAuthe
   }
 
   protected async generateProject(config: Config): Promise<void> {
-    const schema = await this.analyzeDatabase(config.dbConfig);
+    const schema = this.requiresDatabase ? await this.analyzeDatabase(config.dbConfig) : undefined;
     this.spinner.start({ text: 'Creating your project files' });
     const dumpPromise = this.dump(config, schema);
     await this.spinner.attachToPromise(dumpPromise);
@@ -156,7 +161,7 @@ export default abstract class AbstractProjectCreateCommand extends AbstractAuthe
     this.eventSender.command = 'projects:create';
     this.eventSender.applicationName = config.applicationName;
 
-    if (!config.databaseDialect && !config.databaseConnectionURL) {
+    if (this.requiresDatabase && !config.databaseDialect && !config.databaseConnectionURL) {
       this.logger.error('Missing database dialect option value');
       this.exit(1);
     }

--- a/src/commands/projects/create/demo.ts
+++ b/src/commands/projects/create/demo.ts
@@ -1,0 +1,47 @@
+import type { Config } from '../../../interfaces/project-create-interface';
+import type AgentNodeJs from '../../../services/dumpers/agent-nodejs';
+import type { CommandOptions } from '../../../utils/option-parser';
+import type { Config as OclifConfig } from '@oclif/core';
+
+import AbstractProjectCreateCommand from '../../../abstract-project-create-command';
+import * as projectCreateOptions from '../../../services/projects/create/options';
+import Agents from '../../../utils/agents';
+import { optionsToFlags } from '../../../utils/option-parser';
+
+export default class DemoCommand extends AbstractProjectCreateCommand {
+  protected static options: CommandOptions = {
+    applicationHost: projectCreateOptions.applicationHost,
+    applicationPort: projectCreateOptions.applicationPort,
+    language: projectCreateOptions.language,
+  };
+
+  /** @see https://oclif.io/docs/args */
+  static override readonly args = AbstractProjectCreateCommand.args;
+
+  /** @see https://oclif.io/docs/flags */
+  static override readonly flags = optionsToFlags(this.options);
+
+  static override readonly description =
+    'Create a new Forest Admin project with demo data — no database required.';
+
+  private readonly dumper: AgentNodeJs;
+
+  protected readonly agent = Agents.NodeJS;
+
+  // Demo runs on an in-memory dummy datasource: no DB connection, no introspection.
+  protected override readonly requiresDatabase = false;
+
+  constructor(argv: string[], config: OclifConfig, plan?) {
+    super(argv, config, plan);
+
+    const { assertPresent, agentNodejsDumper } = this.context;
+
+    assertPresent({ agentNodejsDumper });
+
+    this.dumper = agentNodejsDumper;
+  }
+
+  protected override async dump(config: Config) {
+    return this.dumper.dump({ ...config, isDemo: true });
+  }
+}

--- a/src/commands/projects/create/demo.ts
+++ b/src/commands/projects/create/demo.ts
@@ -44,4 +44,11 @@ export default class DemoCommand extends AbstractProjectCreateCommand {
   protected override async dump(config: Config) {
     return this.dumper.dump({ ...config, isDemo: true });
   }
+
+  protected override logNextSteps(): void {
+    this.logger.info('This demo runs on in-memory sample data — no database required.');
+    this.logger.info(
+      `Next step — connect your real database: ${this.chalk.bold('forest projects:create:sql')}.`,
+    );
+  }
 }

--- a/src/interfaces/project-create-interface.ts
+++ b/src/interfaces/project-create-interface.ts
@@ -44,4 +44,5 @@ export interface Config {
   forestAuthSecret: string;
   forestEnvSecret: string;
   language?: Language;
+  isDemo?: boolean;
 }

--- a/src/services/dumpers/agent-nodejs.ts
+++ b/src/services/dumpers/agent-nodejs.ts
@@ -69,19 +69,21 @@ export default class AgentNodeJs extends AbstractDumper {
     this.toValidPackageName = toValidPackageName;
   }
 
-  writePackageJson(language: Language, dbDialect: string, appName: string) {
+  writePackageJson(language: Language, dbDialect: string, appName: string, isDemo = false) {
     const dependencies: { [name: string]: string } = {
       dotenv: '^16.0.1',
       '@forestadmin/agent': '^1.0.0',
     };
 
-    if (dbDialect === 'mongodb') {
+    if (isDemo) {
+      dependencies['@forestadmin/datasource-dummy'] = '^1.0.0';
+    } else if (dbDialect === 'mongodb') {
       dependencies['@forestadmin/datasource-mongo'] = '^1.0.0';
     } else {
       dependencies['@forestadmin/datasource-sql'] = '^1.0.0';
     }
 
-    if (dbDialect) {
+    if (!isDemo && dbDialect) {
       if (dbDialect.includes('postgres')) {
         dependencies.pg = '^8.8.0';
       } else if (dbDialect === 'mysql') {
@@ -157,10 +159,11 @@ export default class AgentNodeJs extends AbstractDumper {
     );
   }
 
-  writeIndex(language: Language, dbDialect: string, dbSchema: string) {
+  writeIndex(language: Language, dbDialect: string, dbSchema: string, isDemo = false) {
     const isMongo = dbDialect === 'mongodb';
 
     const context = {
+      isDemo,
       isMongo,
       isMySQL: dbDialect === 'mysql',
       isMSSQL: dbDialect === 'mssql',
@@ -181,11 +184,12 @@ export default class AgentNodeJs extends AbstractDumper {
     appPort: number,
     forestEnvSecret: string,
     forestAuthSecret: string,
+    isDemo = false,
   ) {
-    const dbUrl = this.buildDatabaseUrl(dbConfig);
     const context = {
+      isDemo,
       isMongo: dbConfig.dbDialect === 'mongodb',
-      dbUrl,
+      dbUrl: '',
       dbSchema: dbConfig.dbSchema,
       dbSslMode: dbConfig.dbSslMode ?? 'disabled',
       appPort,
@@ -196,9 +200,15 @@ export default class AgentNodeJs extends AbstractDumper {
       dockerDbUrl: '',
     };
 
-    if (!this.isLinuxOs) {
-      context.hasDockerDbUrl = true;
-      context.dockerDbUrl = dbUrl.replace('localhost', 'host.docker.internal');
+    // Demo runs on an in-memory dummy datasource: no DATABASE_URL.
+    if (!isDemo) {
+      const dbUrl = this.buildDatabaseUrl(dbConfig);
+      context.dbUrl = dbUrl;
+
+      if (!this.isLinuxOs) {
+        context.hasDockerDbUrl = true;
+        context.dockerDbUrl = dbUrl.replace('localhost', 'host.docker.internal');
+      }
     }
 
     this.copyHandleBarsTemplate('common/env.hbs', '.env', context);
@@ -251,10 +261,13 @@ export default class AgentNodeJs extends AbstractDumper {
   }
 
   protected async createFiles(dumpConfig: Config) {
+    const { isDemo } = dumpConfig;
+
     this.writePackageJson(
       dumpConfig.language,
       dumpConfig.dbConfig.dbDialect,
       dumpConfig.appConfig.appName,
+      isDemo,
     );
     if (dumpConfig.language === languages.Typescript) {
       this.writeTsConfigJson();
@@ -263,17 +276,20 @@ export default class AgentNodeJs extends AbstractDumper {
       dumpConfig.language,
       dumpConfig.dbConfig.dbDialect,
       dumpConfig.dbConfig.dbSchema,
+      isDemo,
     );
     this.writeDotEnv(
       dumpConfig.dbConfig,
       dumpConfig.appConfig.appPort || this.DEFAULT_PORT,
       dumpConfig.forestEnvSecret,
       dumpConfig.forestAuthSecret,
+      isDemo,
     );
     this.writeTypings();
     this.writeGitignore(dumpConfig.language);
     this.writeDockerignore(dumpConfig.language);
     this.writeDockerfile(dumpConfig.language);
-    this.writeDockerCompose(dumpConfig);
+    // The demo project has no database, so no docker-compose DB service is needed.
+    if (!isDemo) this.writeDockerCompose(dumpConfig);
   }
 }

--- a/src/services/dumpers/templates/agent-nodejs/common/env.hbs
+++ b/src/services/dumpers/templates/agent-nodejs/common/env.hbs
@@ -8,6 +8,7 @@ NODE_TLS_REJECT_UNAUTHORIZED=0
 
 {{/if}}
 APPLICATION_PORT={{ appPort }}
+{{#unless isDemo}}
 
 DATABASE_URL={{ dbUrl }}
 {{#unless isMongo}}
@@ -19,5 +20,6 @@ DATABASE_SCHEMA={{ dbSchema }}
 {{#if hasDockerDbUrl}}
 DOCKER_DATABASE_URL={{ dockerDbUrl }}
 {{/if}}
+{{/unless}}
 
 NODE_ENV=development

--- a/src/services/dumpers/templates/agent-nodejs/javascript/index.hbs
+++ b/src/services/dumpers/templates/agent-nodejs/javascript/index.hbs
@@ -1,9 +1,13 @@
 require('dotenv').config();
 const { createAgent } = require('@forestadmin/agent');
+{{#if isDemo}}
+const { createDummyDataSource } = require('@forestadmin/datasource-dummy');
+{{else}}
 {{#if isMongo}}
 const { createMongoDataSource } = require('@forestadmin/datasource-mongo');
 {{else}}
 const { createSqlDataSource } = require('@forestadmin/datasource-sql');
+{{/if}}
 {{/if}}
 
 // Create the Forest Admin agent.
@@ -28,6 +32,11 @@ const agent = createAgent({
 
 // Connect your datasources
 // All options are documented at https://docs.forestadmin.com/developer-guide-agents-nodejs/data-sources/connection
+{{#if isDemo}}
+// Demo data source (in-memory sample data) — no database required.
+// Replace it with your real database: https://docs.forestadmin.com/developer-guide-agents-nodejs/data-sources/connection
+agent.addDataSource(createDummyDataSource());
+{{else}}
 {{#if isMongo}}
 agent.addDataSource(
   createMongoDataSource({
@@ -47,6 +56,7 @@ agent.addDataSource(
     sslMode: process.env.DATABASE_SSL_MODE,
   }),
 );
+{{/if}}
 {{/if}}
 
 // Add customizations here.

--- a/src/services/dumpers/templates/agent-nodejs/typescript/index.hbs
+++ b/src/services/dumpers/templates/agent-nodejs/typescript/index.hbs
@@ -1,14 +1,20 @@
+{{#unless isDemo}}
 {{#unless isMongo}}
 import type { SslMode } from '@forestadmin/datasource-sql';
+{{/unless}}
 {{/unless}}
 import type { Schema } from './typings';
 
 import 'dotenv/config';
 import { createAgent } from '@forestadmin/agent';
+{{#if isDemo}}
+import { createDummyDataSource } from '@forestadmin/datasource-dummy';
+{{else}}
 {{#if isMongo}}
 import { createMongoDataSource } from '@forestadmin/datasource-mongo';
 {{else}}
 import { createSqlDataSource } from '@forestadmin/datasource-sql';
+{{/if}}
 {{/if}}
 
 // This object allows to configure your Forest Admin panel
@@ -30,6 +36,11 @@ const agent = createAgent<Schema>({
 
 // Connect your datasources
 // All options are documented at https://docs.forestadmin.com/developer-guide-agents-nodejs/data-sources/connection
+{{#if isDemo}}
+// Demo data source (in-memory sample data) — no database required.
+// Replace it with your real database: https://docs.forestadmin.com/developer-guide-agents-nodejs/data-sources/connection
+agent.addDataSource(createDummyDataSource());
+{{else}}
 {{#if isMongo}}
 agent.addDataSource(
   createMongoDataSource({
@@ -49,6 +60,7 @@ agent.addDataSource(
     sslMode: process.env.DATABASE_SSL_MODE as SslMode,
   }),
 );
+{{/if}}
 {{/if}}
 
 // Add customizations here.

--- a/test/commands/projects/create/demo.test.js
+++ b/test/commands/projects/create/demo.test.js
@@ -1,0 +1,48 @@
+const testCli = require('../../test-cli-helper/test-cli');
+const DemoCommand = require('../../../../src/commands/projects/create/demo').default;
+const { testEnvWithSecret } = require('../../../fixtures/env');
+const { createProject, updateNewEnvironmentEndpoint } = require('../../../fixtures/api');
+const { default: Agents } = require('../../../../src/utils/agents');
+const { default: languages } = require('../../../../src/utils/languages');
+
+describe('projects:create:demo', () => {
+  describe('execution', () => {
+    it('should create a demo project on the dummy datasource, skipping all database steps', () =>
+      testCli({
+        commandClass: DemoCommand,
+        commandArgs: ['name', '--applicationHost', 'http://localhost', '--applicationPort', '3310'],
+        env: testEnvWithSecret,
+        token: 'any',
+        prompts: [
+          {
+            in: [
+              {
+                name: 'language',
+                message: 'In which language would you like to generate your sources?',
+                type: 'list',
+                choices: [
+                  { name: languages.Javascript.name, value: languages.Javascript },
+                  { name: languages.Typescript.name, value: languages.Typescript },
+                ],
+                default: languages.Javascript,
+              },
+            ],
+            out: { language: languages.Javascript },
+          },
+        ],
+        api: [
+          () => createProject({ databaseType: null, agent: Agents.NodeJS }),
+          () => updateNewEnvironmentEndpoint(),
+        ],
+        std: [
+          { spinner: '√ Creating your project on Forest Admin' },
+          // No "Testing connection" spinner: requiresDatabase = false → DB steps skipped.
+          { spinner: '√ Creating your project files' },
+          { out: 'create index.js' },
+          { out: '> Hooray, installation success!' },
+          { out: 'forest projects:create:sql' },
+        ],
+        exitCode: 0,
+      }));
+  });
+});

--- a/test/services/dumpers/agent-nodejs/agent-nodejs.unit.test.ts
+++ b/test/services/dumpers/agent-nodejs/agent-nodejs.unit.test.ts
@@ -104,6 +104,54 @@ describe('services > dumpers > AgentNodeJs', () => {
     };
   };
 
+  describe.each([languages.Javascript, languages.Typescript])(
+    'when dumping a demo project in $name (isDemo)',
+    language => {
+      const demoConfig = (base: Config): Config => ({ ...base, isDemo: true });
+
+      it('uses the dummy datasource dependency, not sql', async () => {
+        expect.assertions(2);
+        const { dumper, context, defaultConfig } = createDumper(language);
+
+        await dumper.dump(demoConfig(defaultConfig));
+
+        const pkgCall = context.fs.writeFileSync.mock.calls.find(([p]: [string]) =>
+          p.endsWith('package.json'),
+        );
+        expect(pkgCall[1]).toContain('@forestadmin/datasource-dummy');
+        expect(pkgCall[1]).not.toContain('@forestadmin/datasource-sql');
+      });
+
+      it('passes isDemo to the index and .env templates', async () => {
+        expect.assertions(2);
+        const { dumper, context, defaultConfig } = createDumper(language);
+
+        await dumper.dump(demoConfig(defaultConfig));
+
+        expect(context.fs.writeFileSync).toHaveBeenCalledWith(
+          `/test/a${language.name}Application/index.${language.fileExtension}`,
+          expect.objectContaining({ isDemo: true }),
+        );
+        expect(context.fs.writeFileSync).toHaveBeenCalledWith(
+          `/test/a${language.name}Application/.env`,
+          expect.objectContaining({ isDemo: true }),
+        );
+      });
+
+      it('does not write a docker-compose file (no database)', async () => {
+        expect.assertions(1);
+        const { dumper, context, defaultConfig } = createDumper(language);
+
+        await dumper.dump(demoConfig(defaultConfig));
+
+        expect(context.fs.writeFileSync).not.toHaveBeenCalledWith(
+          `/test/a${language.name}Application/docker-compose.yml`,
+          expect.anything(),
+        );
+      });
+    },
+  );
+
   describe.each([languages.Javascript, languages.Typescript])('when dumping in $name', language => {
     describe('when writing common files', () => {
       it('should write a .gitignore file', async () => {
@@ -171,6 +219,7 @@ describe('services > dumpers > AgentNodeJs', () => {
           expect(context.fs.writeFileSync).toHaveBeenCalledWith(
             `/test/a${language.name}Application/.env`,
             {
+              isDemo: false,
               dbUrl: 'localhost',
               dbSslMode: 'disabled',
               dbSchema: 'public',


### PR DESCRIPTION
Adds `forest projects:create:demo` — scaffolds an agent on `@forestadmin/datasource-dummy` (no DB/connection/introspection/Docker). A `requiresDatabase` flag guards the DB steps; demo branch in the agent-nodejs dumper/templates. **No server change.** Dumper tests green (160/160); validated e2e. Linear **PRD-531**.

(Intra-repo re-open of fork PR #771.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `projects:create:demo` command for zero-DB onboarding using a dummy datasource
> - Adds a new `projects:create:demo` CLI command that creates a Forest Admin project without a real database, using `@forestadmin/datasource-dummy` instead.
> - Introduces a `requiresDatabase` flag on `AbstractProjectCreateCommand` to skip DB option validation, connection testing, and schema analysis when false.
> - Generated files (package.json, index, .env) are templated conditionally via `isDemo` in [agent-nodejs.ts](https://github.com/ForestAdmin/toolbelt/pull/775/files#diff-11e0a97bdd052ff5ed049df41111ed67e67b9c7659260915df0c62acbee00dd3) and the Handlebars templates; docker-compose is omitted entirely for demo projects.
> - On success, the demo command prints next-step guidance pointing users to `forest projects:create:sql`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6159ecf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->