### PR TITLE
chore(security): prune 8 redundant Dependabot resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,21 +137,11 @@
   },
   "resolutions": {
     "semantic-release-slack-bot/**/micromatch": "^4.0.8",
-    "@azure/core-auth": "1.8.0",
-    "@azure/core-client": "1.7.3",
-    "@azure/core-rest-pipeline": "1.18.0",
     "@azure/core-tracing": "1.0.1",
-    "@azure/core-util": "1.11.0",
-    "@azure/identity": "4.2.1",
-    "@azure/keyvault-keys": "4.4.0",
-    "@azure/logger": "1.0.4",
     "jws": ">=4.0.1",
     "js-yaml": "3.14.2",
     "fast-xml-parser": ">=5.7.0",
     "uuid": "^11.1.1",
     "inquirer/**/tmp": "^0.2.6"
-  },
-  "overrides": {
-    "@paralleldrive/cuid2": "2.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1155,7 +1155,7 @@
   dependencies:
     tslib "^2.6.2"
 
-"@azure/core-auth@1.8.0", "@azure/core-auth@^1.3.0", "@azure/core-auth@^1.4.0", "@azure/core-auth@^1.5.0", "@azure/core-auth@^1.7.2", "@azure/core-auth@^1.8.0":
+"@azure/core-auth@^1.3.0", "@azure/core-auth@^1.4.0", "@azure/core-auth@^1.5.0", "@azure/core-auth@^1.7.2", "@azure/core-auth@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.8.0.tgz#281b4a6d3309c3e7b15bcd967f01d4c79ae4a1d6"
   integrity sha512-YvFMowkXzLbXNM11yZtVLhUCmuG0ex7JKOH366ipjmHBhL3vpDcPAeWF+jf0X+jVXwFqo3UhsWUq4kH0ZPdu/g==
@@ -1164,7 +1164,7 @@
     "@azure/core-util" "^1.1.0"
     tslib "^2.6.2"
 
-"@azure/core-client@1.7.3", "@azure/core-client@^1.4.0":
+"@azure/core-client@^1.4.0":
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/@azure/core-client/-/core-client-1.7.3.tgz#f8cb2a1f91e8bc4921fa2e745cfdfda3e6e491a3"
   integrity sha512-kleJ1iUTxcO32Y06dH9Pfi9K4U+Tlb111WXEnbt7R/ne+NLRwppZiTGJuTD5VVoxTMK5NTbEtm5t2vcdNCFe2g==
@@ -1215,7 +1215,7 @@
   dependencies:
     tslib "^2.6.2"
 
-"@azure/core-rest-pipeline@1.18.0", "@azure/core-rest-pipeline@^1.1.0", "@azure/core-rest-pipeline@^1.9.1":
+"@azure/core-rest-pipeline@^1.1.0", "@azure/core-rest-pipeline@^1.9.1":
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/@azure/core-rest-pipeline/-/core-rest-pipeline-1.18.0.tgz#165f1cd9bb1060be3b6895742db3d1f1106271d3"
   integrity sha512-QSoGUp4Eq/gohEFNJaUOwTN7BCc2nHTjjbm75JT0aD7W65PWM1H/tItz0GsABn22uaKyGxiMhWQLt2r+FGU89Q==
@@ -1236,7 +1236,7 @@
   dependencies:
     tslib "^2.2.0"
 
-"@azure/core-util@1.11.0", "@azure/core-util@^1.0.0", "@azure/core-util@^1.1.0", "@azure/core-util@^1.1.1", "@azure/core-util@^1.11.0", "@azure/core-util@^1.2.0", "@azure/core-util@^1.3.0":
+"@azure/core-util@^1.0.0", "@azure/core-util@^1.1.0", "@azure/core-util@^1.1.1", "@azure/core-util@^1.11.0", "@azure/core-util@^1.2.0", "@azure/core-util@^1.3.0":
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.11.0.tgz#f530fc67e738aea872fbdd1cc8416e70219fada7"
   integrity sha512-DxOSLua+NdpWoSqULhjDyAZTXFdP/LKkqtYuxxz1SCN289zk3OG8UOpnCQAz/tygyACBtWp/BoO72ptK7msY8g==
@@ -1244,7 +1244,7 @@
     "@azure/abort-controller" "^2.0.0"
     tslib "^2.6.2"
 
-"@azure/identity@4.2.1", "@azure/identity@^4.2.1":
+"@azure/identity@^4.2.1":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@azure/identity/-/identity-4.2.1.tgz#22b366201e989b7b41c0e1690e103bd579c31e4c"
   integrity sha512-U8hsyC9YPcEIzoaObJlRDvp7KiF0MGS7xcWbyJSVvXRkC/HXo1f0oYeBYmEvVgRfacw7GHf6D6yAoh9JHz6A5Q==
@@ -1264,7 +1264,7 @@
     stoppable "^1.1.0"
     tslib "^2.2.0"
 
-"@azure/keyvault-keys@4.4.0", "@azure/keyvault-keys@^4.4.0":
+"@azure/keyvault-keys@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@azure/keyvault-keys/-/keyvault-keys-4.4.0.tgz#1f4d5f5d8708f6b122eaf08069fe2a1ddc64782d"
   integrity sha512-W9sPZebXYa3aar7BGIA+fAsq/sy1nf2TZAETbkv7DRawzVLrWv8QoVVceqNHjy3cigT4HNxXjaPYCI49ez5CUA==
@@ -1277,7 +1277,7 @@
     "@azure/logger" "^1.0.0"
     tslib "^2.2.0"
 
-"@azure/logger@1.0.4", "@azure/logger@^1.0.0":
+"@azure/logger@^1.0.0":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@azure/logger/-/logger-1.0.4.tgz#28bc6d0e5b3c38ef29296b32d35da4e483593fa1"
   integrity sha512-ustrPY8MryhloQj7OWGe+HrYx+aoiOxzbXTtgblbV3xwCqpzUK36phH3XNHQKj3EPonyFUuDTfR3qFhTEAuZEg==


### PR DESCRIPTION
> 👋 First-level support: see [Handling automated security PRs](https://forest.slite.com/app/docs/rmjdwFgmV2RzUp) for how to triage and merge this PR.

## Summary
0 fixed, 0 ignored, 5 deferred, 0 resolutions added, 8 resolutions removed. | label: :lock: security applied

This run found no actionable Dependabot alerts — all 5 open alerts are within the 7-day deferral window and will be handled by the next scheduled run. The PR ships solely for resolution hygiene: 8 entries in `package.json` were verified redundant against the natural dependency tree and removed (and the corresponding orphaned range keys were dropped from `yarn.lock`). The resolved version of every affected package is unchanged.

## Fixed

_None._

## Ignored

_None._

## Deferred

Alerts opened less than 7 days ago — deferred to the next run:

| Alert | Package | Severity | Created |
| --- | --- | --- | --- |
| [#225](https://github.com/ForestAdmin/toolbelt/security/dependabot/225) | form-data | high | 2026-06-18 |
| [#224](https://github.com/ForestAdmin/toolbelt/security/dependabot/224) | tar | medium | 2026-06-18 |
| [#223](https://github.com/ForestAdmin/toolbelt/security/dependabot/223) | js-yaml | medium | 2026-06-18 |
| [#222](https://github.com/ForestAdmin/toolbelt/security/dependabot/222) | @babel/core | low | 2026-06-18 |
| [#221](https://github.com/ForestAdmin/toolbelt/security/dependabot/221) | joi | medium | 2026-06-12 |

## Resolutions added

_None._

## Resolutions removed

For each entry below, the redundancy was verified by removing the entry, re-running `yarn install`, and confirming `yarn why <pkg>` reported a version `>= ` the original pin. The resolved tree is unchanged from what was in `yarn.lock` before this PR.

| File | Field | Package | Pinned | Natural | Reason |
| --- | --- | --- | --- | --- | --- |
| `package.json` | `resolutions` | `@azure/core-auth` | `1.8.0` | `1.8.0` | Redundant — `tedious` parent ranges already converge on `1.8.0` |
| `package.json` | `resolutions` | `@azure/core-client` | `1.7.3` | `1.7.3` | Redundant — `@azure/identity` already pulls `1.7.3` |
| `package.json` | `resolutions` | `@azure/core-rest-pipeline` | `1.18.0` | `1.18.0` | Redundant — `@azure/identity` already pulls `1.18.0` |
| `package.json` | `resolutions` | `@azure/core-util` | `1.11.0` | `1.11.0` | Redundant — `@azure/*` parents already converge on `1.11.0` |
| `package.json` | `resolutions` | `@azure/identity` | `4.2.1` | `4.2.1` | Redundant — `tedious` already pulls `4.2.1` |
| `package.json` | `resolutions` | `@azure/keyvault-keys` | `4.4.0` | `4.4.0` | Redundant — `tedious` already pulls `4.4.0` |
| `package.json` | `resolutions` | `@azure/logger` | `1.0.4` | `1.0.4` | Redundant — `@azure/*` parents already converge on `1.0.4` |
| `package.json` | `overrides` | `@paralleldrive/cuid2` | `2.2.2` | `2.2.2` | Redundant — Yarn does not honor `overrides`, and the same version is already pinned as a direct dependency |

Kept (verified still necessary — removal would lower a nested path below the pin):

- `@azure/core-tracing` `1.0.1` — without the pin, `@azure/keyvault-keys` and `@azure/core-http` pull `1.0.0-preview.13`.
- `jws` `>=4.0.1` — without the pin, `@azure/msal-node` pulls `jws@3.2.3`.
- `fast-xml-parser` `>=5.7.0` — without the pin, the lockfile entry drops to `5.3.6`.
- `js-yaml` `3.14.2`, `uuid` `^11.1.1`, `semantic-release-slack-bot/**/micromatch` `^4.0.8`, `inquirer/**/tmp` `^0.2.6` — each changes nested versions in the tree when removed (left for a focused review).

## Risks

No behavior change. Eight unused entries were removed from `package.json` and the corresponding duplicate range keys from `yarn.lock`; every resolved version in the dependency graph is identical to the pre-PR tree (verified with `yarn why <pkg>` for each affected package). `yarn install --frozen-lockfile` succeeds on the new lockfile.

## Manual testing

Covered by CI.

## Validation

✅ CI green
