### PR TITLE
feat(layout): forest layout diff (2/3)

### DIFF
--- a/src/commands/layout/diff.ts
+++ b/src/commands/layout/diff.ts
@@ -1,0 +1,80 @@
+import type { Config } from '@oclif/core';
+
+import { Args, Flags } from '@oclif/core';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+import AbstractAuthenticatedCommand from '../../abstract-authenticated-command';
+import { parseLayoutFile } from '../../services/layout/layout-file';
+import LayoutManager from '../../services/layout/layout-manager';
+import { formatPlan } from '../../services/layout/plan-format';
+import { fetchRemoteDocs } from '../../services/layout/read';
+import { resolveCommandScope } from '../../services/layout/resolve-command-scope';
+import { diffAllDomains, domainsInFile } from '../../services/layout/sync';
+
+/**
+ * `forest layout diff` — compute the JSON-Patch plan between a forest-layout.json
+ * and the live environment, and print it. Writes nothing and sends nothing: this
+ * is the dry-run of `forest layout apply`.
+ */
+export default class LayoutDiffCommand extends AbstractAuthenticatedCommand {
+  private readonly env: { FOREST_SERVER_URL: string } & Record<string, unknown>;
+
+  static override args = {
+    file: Args.string({
+      description: 'Layout file to diff (e.g. forest-layout.json).',
+      name: 'file',
+      required: true,
+    }),
+  };
+
+  static override description =
+    'Show the changes that `forest layout apply` would push (dry-run, reads only).';
+
+  static override flags = {
+    env: Flags.string({
+      char: 'e',
+      description: 'Environment to compare against (name or id). Prompted if omitted.',
+    }),
+    team: Flags.string({
+      char: 't',
+      description: 'Team to compare against (name or id). Prompted if omitted.',
+    }),
+    projectId: Flags.integer({
+      char: 'p',
+      description: 'Id of the project (resolved/prompted when omitted).',
+    }),
+  };
+
+  constructor(argv: string[], config: Config, plan?) {
+    super(argv, config, plan);
+    const { assertPresent, env } = this.context;
+    assertPresent({ env });
+    this.env = env;
+  }
+
+  protected async runAuthenticated(): Promise<void> {
+    const { args, flags } = await this.parse(LayoutDiffCommand);
+
+    const filePath = path.resolve(process.cwd(), args.file);
+    const { docs } = parseLayoutFile(readFileSync(filePath, 'utf8'));
+
+    // The file header is provenance only: the target env/team is chosen here
+    // (flags or interactive prompt), never defaulted to where the file was pulled from.
+    const scope = await resolveCommandScope({
+      baseEnv: this.env,
+      flags: { env: flags.env, projectId: flags.projectId, team: flags.team },
+    });
+
+    const manager = new LayoutManager();
+    const remote = await fetchRemoteDocs(manager, scope, domainsInFile(docs));
+    const { ops, warnings } = diffAllDomains(remote, docs);
+
+    this.log(
+      `Diff of ${this.chalk.bold(args.file)} against ${this.chalk.bold(
+        scope.environmentName,
+      )} / ${this.chalk.bold(scope.teamName)}:\n`,
+    );
+    this.log(formatPlan(ops, warnings));
+  }
+}


### PR DESCRIPTION
## What

`forest layout diff [file]` — compute the JSON-Patch plan between `forest-layout.yml` and the live rendering, and print it. **Dry-run: reads only, sends nothing.** Second of three PRs splitting the layout-as-code feature (after `pull`, before `apply`).

> **Stacked on #779** (`pull`). Base is the pull branch so this PR only shows the diff additions; it will re-target `main` automatically once #779 merges.

## Scope (the diff engine)

- **Identity diff**: match a local item to a remote one by `id` then `name` (so a hand-authored item without its `id` updates the existing element instead of being treated as add + remove), classify `add → replace → remove`, opaque pass-through for complex values, idempotent (unchanged file → empty plan).
- **Whitelist**: every generated op is pre-validated against a local mirror of the server's `make-layout-patch-patterns.ts`.
- **Multi-domain** orchestration (layout / folders / workflow shells).
- Human-readable plan + actionable error mapping (422 → offending `yamlPath`, 403 → premium pack).
- Unit tests: diff engine (incl. the name-only edit and partial-authoring cases) + whitelist matcher.

Workflow `steps` → BPMN preview and the write path (`PATCH`, S3 upload) land with the `apply` PR (3/3).

Implements part of **PRD-555**.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `forest layout diff` CLI command to compare a local layout file against a remote environment
> - Adds [diff.ts](https://github.com/ForestAdmin/toolbelt/pull/780/files#diff-12ee617c6751f385adb5d12a86d1d88814722b407041bdb5510bb698a5fc4391) implementing a new read-only `forest layout diff` command that takes a local `forest-layout.json` file path and optional `env`, `team`, and `projectId` flags.
> - Reads and parses the local file, queries the matching remote environment for layout docs, computes diffs via `diffAllDomains`, and prints a formatted JSON-Patch plan with any warnings.
> - No changes are applied; this command is purely diagnostic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07fc2b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->