### PR TITLE
feat(users): add forest users:edit command

### DIFF
--- a/src/commands/users/edit.ts
+++ b/src/commands/users/edit.ts
@@ -1,0 +1,191 @@
+import type { Config } from '@oclif/core';
+
+import { Flags } from '@oclif/core';
+
+import AbstractAuthenticatedCommand from '../../abstract-authenticated-command';
+import RoleManager from '../../services/role-manager';
+import TeamManager from '../../services/team-manager';
+import UserManager from '../../services/user-manager';
+import withCurrentProject from '../../services/with-current-project';
+
+const PERMISSION_LEVELS = ['admin', 'editor', 'user', 'developer', 'manager'];
+
+type NamedEntity = { id: number | string; name: string };
+type ProjectConfig = { projectId: number | string } & Record<string, unknown>;
+type EditFlags = {
+  email: string;
+  role?: string;
+  team?: string[];
+  'permission-level'?: string;
+  force?: boolean;
+};
+
+export default class UsersEditCommand extends AbstractAuthenticatedCommand {
+  private env: Record<string, string>;
+
+  private inquirer: { prompt(questions: unknown): Promise<{ confirm: boolean }> };
+
+  static override description = "Edit a user's role, team(s) or permission level.";
+
+  static override flags = {
+    email: Flags.string({
+      char: 'e',
+      description: 'Email of the user to edit.',
+      required: true,
+    }),
+    role: Flags.string({
+      char: 'r',
+      description: 'New role name to assign.',
+    }),
+    team: Flags.string({
+      char: 't',
+      description:
+        'Team name to set for this project. Repeatable; this REPLACES the user’s current team set on the project.',
+      multiple: true,
+    }),
+    'permission-level': Flags.string({
+      char: 'l',
+      description: 'New permission level.',
+      options: PERMISSION_LEVELS,
+    }),
+    projectId: Flags.integer({
+      char: 'p',
+      description: 'Forest project ID.',
+    }),
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Skip the confirmation prompt when teams would be removed.',
+    }),
+  };
+
+  constructor(argv: string[], config: Config, plan?) {
+    super(argv, config, plan);
+    const { assertPresent, env, inquirer } = this.context;
+    assertPresent({ env, inquirer });
+    this.env = env;
+    this.inquirer = inquirer;
+  }
+
+  async runAuthenticated() {
+    const { flags } = await this.parse(UsersEditCommand);
+    const teamNames = flags.team ?? [];
+
+    if (!flags.role && !teamNames.length && !flags['permission-level']) {
+      this.logger.error('At least one of --role, --team or --permission-level is required.');
+      this.exit(1);
+      return;
+    }
+
+    const config = await withCurrentProject({ ...this.env, projectId: flags.projectId });
+
+    try {
+      await this.applyEdit(config, flags, teamNames);
+    } catch (error) {
+      this.surfaceApiError(error);
+    }
+  }
+
+  private async applyEdit(config: ProjectConfig, flags: EditFlags, teamNames: string[]) {
+    const userManager = new UserManager(config);
+
+    const user = await userManager.findByEmail(flags.email);
+    if (!user) {
+      this.logger.error(`User "${flags.email}" not found in this project.`);
+      this.exit(1);
+      return;
+    }
+
+    const changes: { roleId?: string; teamIds?: string[]; permissionLevel?: string } = {};
+
+    if (flags.role) {
+      const roleId = await this.resolveRoleId(config, flags.role);
+      if (roleId === null) {
+        this.exit(1);
+        return;
+      }
+      changes.roleId = roleId;
+    }
+
+    if (teamNames.length) {
+      const teamIds = await this.resolveTeamIds(config, teamNames);
+      if (teamIds === null) {
+        this.exit(1);
+        return;
+      }
+
+      // --team replaces the project team set, so flag any teams that would be dropped.
+      const removed = user.teams.filter(name => !teamNames.includes(name));
+      if (removed.length && !flags.force && !(await this.confirmRemoval(flags.email, removed))) {
+        this.logger.info('Aborted: no change made.');
+        return;
+      }
+      changes.teamIds = teamIds;
+    }
+
+    if (flags['permission-level']) {
+      changes.permissionLevel = flags['permission-level'];
+    }
+
+    await userManager.editUser(user.id, user.permissionLevel, user.roleId, changes);
+    this.logger.info(`User "${flags.email}" updated on project ${config.projectId}.`);
+  }
+
+  private async resolveRoleId(config: ProjectConfig, roleName: string): Promise<string | null> {
+    const roles: NamedEntity[] = await new RoleManager(config).listForProject();
+    const role = roles.find(candidate => candidate.name === roleName);
+    if (!role) {
+      const available = roles.map(candidate => candidate.name).join(', ') || '(none)';
+      this.logger.error(`Role "${roleName}" not found. Available: ${available}.`);
+
+      return null;
+    }
+
+    return String(role.id);
+  }
+
+  private async resolveTeamIds(config: ProjectConfig, names: string[]): Promise<string[] | null> {
+    const teams: NamedEntity[] = await new TeamManager(config).listForProject();
+    const byName = new Map(teams.map(team => [team.name, String(team.id)]));
+    const missing = names.filter(name => !byName.has(name));
+    if (missing.length) {
+      const available = teams.map(team => team.name).join(', ') || '(none)';
+      this.logger.error(`Team(s) "${missing.join(', ')}" not found. Available: ${available}.`);
+
+      return null;
+    }
+
+    return names.map(name => byName.get(name) as string);
+  }
+
+  private async confirmRemoval(email: string, removedTeams: string[]): Promise<boolean> {
+    const { confirm } = await this.inquirer.prompt([
+      {
+        message: `This will remove ${email} from team(s): ${removedTeams.join(', ')}. Continue?`,
+        name: 'confirm',
+        type: 'confirm',
+      },
+    ]);
+
+    return confirm;
+  }
+
+  private surfaceApiError(error: unknown): void {
+    // 401/403 keep flowing to the authenticated-command handler.
+    const { response, status } = error as { status?: number; response?: { text?: string } };
+    if (response && status !== 401 && status !== 403 && response.text) {
+      let detail;
+      try {
+        detail = JSON.parse(response.text)?.errors?.[0]?.detail;
+      } catch {
+        // Non-JSON error body: fall through and rethrow the original error.
+      }
+      if (detail) {
+        this.logger.error(detail);
+        this.exit(1);
+        return;
+      }
+    }
+
+    throw error;
+  }
+}

--- a/src/services/user-manager.ts
+++ b/src/services/user-manager.ts
@@ -6,6 +6,7 @@ export type ProjectUser = {
   email: string;
   name: string;
   permissionLevel: string;
+  roleId: string | null;
   role: string | null;
   teams: string[];
 };
@@ -77,34 +78,90 @@ export default class UserManager {
   }
 
   async listForProject(): Promise<ProjectUser[]> {
-    // Unlike the per-user enrichment below, a failure here surfaces to the command.
+    const users = await this.requestUsers();
+
+    return mapWithConcurrency(users, ENRICH_CONCURRENCY, user => this.toProjectUser(user));
+  }
+
+  /** Raw project-users list (one call, no enrichment). Failures surface to the caller. */
+  private async requestUsers(): Promise<ApiResource[]> {
     const response = await agent
       .get(`${this.env.FOREST_SERVER_URL}/api/projects/${this.config.projectId}/users`)
       .set(this.headers())
       .send();
 
-    const users = (response.body?.data ?? []) as ApiResource[];
-
-    return mapWithConcurrency(users, ENRICH_CONCURRENCY, user => this.toProjectUser(user));
+    return (response.body?.data ?? []) as ApiResource[];
   }
 
-  private async toProjectUser(user: ApiResource): Promise<ProjectUser> {
+  private async toProjectUser(user: ApiResource, strict = false): Promise<ProjectUser> {
     const attributes = user.attributes ?? {};
     const userId = user.id ? String(user.id) : '';
 
-    const [teams, role] = await Promise.all([this.fetchTeams(userId), this.fetchRole(userId)]);
+    const [teams, role] = await Promise.all([
+      this.fetchTeams(userId, strict),
+      this.fetchRole(userId, strict),
+    ]);
 
     return {
       id: userId,
       email: String(attributes.email ?? ''),
       name: [attributes.first_name, attributes.last_name].filter(Boolean).join(' '),
       permissionLevel: String(attributes.permission_level ?? ''),
-      role,
+      roleId: role.id,
+      role: role.name,
       teams,
     };
   }
 
-  private async fetchTeams(userId: string): Promise<string[]> {
+  /**
+   * Resolve a project user by email for the edit path. Returns undefined when no
+   * user matches; transport/API failures throw. The role/teams are read in `strict`
+   * mode (never degraded): the edit reassigns the role and replaces the teams from
+   * these values, so a failed read must abort the edit, not silently wipe them.
+   */
+  async findByEmail(email: string): Promise<ProjectUser | undefined> {
+    const users = await this.requestUsers();
+    const match = users.find(user => String(user.attributes?.email ?? '') === email);
+    if (!match) return undefined;
+
+    return this.toProjectUser(match, true);
+  }
+
+  async editUser(
+    userId: string,
+    currentPermissionLevel: string,
+    currentRoleId: string | null,
+    changes: { roleId?: string; teamIds?: string[]; permissionLevel?: string },
+  ): Promise<void> {
+    const effectiveRoleId = changes.roleId ?? currentRoleId;
+    // Ids are sent as integers: the server's update validator requires
+    // `id: number` for data/role/teams/projects on this route.
+    const relationships: Record<string, unknown> = {
+      projects: { data: [{ type: 'projects', id: Number(this.config.projectId) }] },
+      ...(effectiveRoleId && { role: { data: { type: 'roles', id: Number(effectiveRoleId) } } }),
+    };
+    if (changes.teamIds) {
+      relationships.teams = {
+        data: changes.teamIds.map(id => ({ type: 'teams', id: Number(id) })),
+      };
+    }
+
+    await agent
+      .put(`${this.env.FOREST_SERVER_URL}/api/users/${userId}`)
+      .set(this.headers())
+      .send({
+        data: {
+          type: 'users',
+          id: Number(userId),
+          attributes: { permission_level: changes.permissionLevel ?? currentPermissionLevel },
+          relationships,
+        },
+      });
+  }
+
+  // `strict` is used by the edit path: a failed read must surface (abort the edit)
+  // rather than degrade, since the edit writes these values back.
+  private async fetchTeams(userId: string, strict = false): Promise<string[]> {
     if (!userId) return [];
 
     try {
@@ -117,14 +174,18 @@ export default class UserManager {
         .map(team => String(team.attributes?.name ?? ''))
         .filter(Boolean);
     } catch (error) {
+      if (strict) throw error;
       this.logger.warn(`Could not fetch teams for user ${userId} (showing none): ${error}`);
 
       return [];
     }
   }
 
-  private async fetchRole(userId: string): Promise<string | null> {
-    if (!userId) return null;
+  private async fetchRole(
+    userId: string,
+    strict = false,
+  ): Promise<{ id: string | null; name: string | null }> {
+    if (!userId) return { id: null, name: null };
 
     try {
       const response = await agent
@@ -138,11 +199,12 @@ export default class UserManager {
       );
       const name = role?.attributes?.name;
 
-      return typeof name === 'string' ? name : null;
+      return { id: role?.id ?? null, name: typeof name === 'string' ? name : null };
     } catch (error) {
+      if (strict) throw error;
       this.logger.warn(`Could not fetch role for user ${userId} (showing none): ${error}`);
 
-      return null;
+      return { id: null, name: null };
     }
   }
 }

--- a/test/commands/users/edit.test.js
+++ b/test/commands/users/edit.test.js
@@ -1,0 +1,271 @@
+const nock = require('nock');
+const testCli = require('../test-cli-helper/test-cli');
+const UsersEditCommand = require('../../../src/commands/users/edit').default;
+
+const { testEnvWithoutSecret } = require('../../fixtures/env');
+
+const OPERATIONS = { id: '7', type: 'teams', attributes: { name: 'Operations' } };
+const TECH = { id: '9', type: 'teams', attributes: { name: 'Tech' } };
+
+// alice (id 1): role Admin (id 3), permission editor, team(s) as provided (default: Operations).
+function getUserForEdit(teams = [OPERATIONS]) {
+  return nock('http://localhost:3001')
+    .get('/api/projects/2/users')
+    .reply(200, {
+      data: [
+        {
+          type: 'users',
+          id: '1',
+          attributes: {
+            email: 'alice@company.com',
+            first_name: 'Alice',
+            last_name: 'Smith',
+            permission_level: 'editor',
+          },
+        },
+      ],
+    })
+    .get('/api/users/1/teams')
+    .reply(200, { data: teams })
+    .get('/api/users')
+    .query({ projectId: '2', id: '1', include: 'role' })
+    .reply(200, {
+      data: { id: '1', type: 'users' },
+      included: [{ id: '3', type: 'roles', attributes: { name: 'Admin' } }],
+    });
+}
+
+const roles = scope =>
+  scope
+    .get('/api/projects/2/roles')
+    .reply(200, { data: [{ type: 'roles', id: '3', attributes: { name: 'Admin' } }] });
+
+const teamsList = scope =>
+  scope.get('/api/projects/2/teams').reply(200, { data: [OPERATIONS, TECH] });
+
+describe('users:edit', () => {
+  describe('with --permission-level', () => {
+    it('updates the level and preserves the current role (id sent as integer)', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersEditCommand,
+        commandArgs: ['-p', '2', '-e', 'alice@company.com', '-l', 'admin'],
+        api: [
+          () =>
+            getUserForEdit()
+              .put(
+                '/api/users/1',
+                body =>
+                  body.data.id === 1 &&
+                  body.data.attributes.permission_level === 'admin' &&
+                  body.data.relationships.role.data.id === 3 &&
+                  body.data.relationships.teams === undefined,
+              )
+              .reply(200, {}),
+        ],
+        std: [{ out: 'User "alice@company.com" updated on project 2.' }],
+        assertNoStdError: false,
+      }));
+  });
+
+  describe('with --role', () => {
+    it('resolves the role and preserves the current permission level', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersEditCommand,
+        commandArgs: ['-p', '2', '-e', 'alice@company.com', '-r', 'Admin'],
+        api: [
+          () =>
+            roles(getUserForEdit())
+              .put(
+                '/api/users/1',
+                body =>
+                  body.data.attributes.permission_level === 'editor' &&
+                  body.data.relationships.role.data.id === 3,
+              )
+              .reply(200, {}),
+        ],
+        std: [{ out: 'User "alice@company.com" updated on project 2.' }],
+        assertNoStdError: false,
+      }));
+  });
+
+  describe('with --team (no team removed)', () => {
+    it('sends the team set and preserves role + level', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersEditCommand,
+        commandArgs: ['-p', '2', '-e', 'alice@company.com', '-t', 'Operations'],
+        api: [
+          () =>
+            teamsList(getUserForEdit())
+              .put(
+                '/api/users/1',
+                body =>
+                  body.data.relationships.teams.data.length === 1 &&
+                  body.data.relationships.teams.data[0].id === 7 &&
+                  body.data.relationships.role.data.id === 3,
+              )
+              .reply(200, {}),
+        ],
+        std: [{ out: 'User "alice@company.com" updated on project 2.' }],
+        assertNoStdError: false,
+      }));
+  });
+
+  describe('with multiple --team', () => {
+    it('sends the full team set', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersEditCommand,
+        commandArgs: ['-p', '2', '-e', 'alice@company.com', '-t', 'Operations', '-t', 'Tech'],
+        api: [
+          () =>
+            teamsList(getUserForEdit())
+              .put('/api/users/1', body => body.data.relationships.teams.data.length === 2)
+              .reply(200, {}),
+        ],
+        std: [{ out: 'User "alice@company.com" updated on project 2.' }],
+        assertNoStdError: false,
+      }));
+  });
+
+  describe('when --team would remove other teams', () => {
+    it('asks for confirmation and proceeds when accepted', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersEditCommand,
+        commandArgs: ['-p', '2', '-e', 'alice@company.com', '-t', 'Operations'],
+        api: [
+          () =>
+            teamsList(getUserForEdit([OPERATIONS, TECH]))
+              .put('/api/users/1', body => body.data.relationships.teams.data.length === 1)
+              .reply(200, {}),
+        ],
+        prompts: [
+          {
+            in: [
+              {
+                message: 'This will remove alice@company.com from team(s): Tech. Continue?',
+                name: 'confirm',
+                type: 'confirm',
+              },
+            ],
+            out: { confirm: true },
+          },
+        ],
+        std: [{ out: 'User "alice@company.com" updated on project 2.' }],
+        assertNoStdError: false,
+      }));
+
+    it('aborts without any PUT when declined', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersEditCommand,
+        commandArgs: ['-p', '2', '-e', 'alice@company.com', '-t', 'Operations'],
+        // No .put interceptor: the command must not write when the user declines.
+        api: [() => teamsList(getUserForEdit([OPERATIONS, TECH]))],
+        prompts: [
+          {
+            in: [
+              {
+                message: 'This will remove alice@company.com from team(s): Tech. Continue?',
+                name: 'confirm',
+                type: 'confirm',
+              },
+            ],
+            out: { confirm: false },
+          },
+        ],
+        std: [{ out: 'Aborted: no change made.' }],
+        assertNoStdError: false,
+      }));
+
+    it('skips the confirmation with --force', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersEditCommand,
+        commandArgs: ['-p', '2', '-e', 'alice@company.com', '-t', 'Operations', '-f'],
+        api: [
+          () =>
+            teamsList(getUserForEdit([OPERATIONS, TECH]))
+              .put('/api/users/1', body => body.data.relationships.teams.data.length === 1)
+              .reply(200, {}),
+        ],
+        std: [{ out: 'User "alice@company.com" updated on project 2.' }],
+        assertNoStdError: false,
+      }));
+  });
+
+  describe('with no flags', () => {
+    it('errors and exits 1', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersEditCommand,
+        commandArgs: ['-p', '2', '-e', 'alice@company.com'],
+        api: [],
+        std: [{ err: 'At least one of --role, --team or --permission-level is required.' }],
+        exitCode: 1,
+      }));
+  });
+
+  describe('with an unknown user email', () => {
+    it('errors and exits 1', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersEditCommand,
+        commandArgs: ['-p', '2', '-e', 'unknown@company.com', '-l', 'admin'],
+        // No match → findByEmail returns after the list, without enriching teams/role.
+        api: [
+          () =>
+            nock('http://localhost:3001')
+              .get('/api/projects/2/users')
+              .reply(200, {
+                data: [{ type: 'users', id: '1', attributes: { email: 'alice@company.com' } }],
+              }),
+        ],
+        std: [{ err: '× User "unknown@company.com" not found in this project.' }],
+        exitCode: 1,
+      }));
+  });
+
+  describe('with an unknown role name', () => {
+    it('errors and lists available roles', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersEditCommand,
+        commandArgs: ['-p', '2', '-e', 'alice@company.com', '-r', 'Nope'],
+        api: [() => roles(getUserForEdit())],
+        std: [{ err: '× Role "Nope" not found. Available: Admin.' }],
+        exitCode: 1,
+      }));
+  });
+
+  describe('when the server rejects the edit', () => {
+    it('prints the API error detail and exits 1', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: UsersEditCommand,
+        commandArgs: ['-p', '2', '-e', 'alice@company.com', '-r', 'Admin'],
+        api: [
+          () =>
+            roles(getUserForEdit())
+              .put('/api/users/1')
+              .reply(422, { errors: [{ detail: 'Role does not belong to this project.' }] }),
+        ],
+        std: [{ err: 'Role does not belong to this project.' }],
+        exitCode: 1,
+      }));
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `forest users:edit --email <email> [--role <name>] [--team <name>...] [--permission-level <level>] [-p <projectId>] [--force]`
- At least one of `--role`, `--team`, `--permission-level` is required
- Resolves role/team by name via the existing `RoleManager` / `TeamManager`
- Adds `UserManager.findByEmail()` and `editUser()`

### Behaviour
- **Role preserved on partial edits.** The server reassigns the role unconditionally on update, so the current role is read in *strict* mode on the edit path: a failed read **aborts** the edit rather than silently unassigning the role.
- **`--team` is repeatable and sets the project team set.** The server replaces (not merges) team affiliations for the project, so `--team` defines the full set. When the resulting set would **remove** teams the user is currently in, the command asks for confirmation (skip with `--force`).
- **Errors surfaced cleanly.** API errors on the update print the server's `errors[0].detail` and exit 1 (401/403 flow to the authenticated-command handler); an unknown email reports "user not found".
- ids are sent as integers (the server's update validator requires `id: number`).

## Backend constraint
`PUT /api/users/:id` requires `permission_level` and `relationships.projects`, and reassigns `role` unconditionally — current values are echoed when not explicitly changed, and the role is read reliably before the write.

## Test plan
- [x] `--role <name>` changes the role; preserves the current permission level
- [x] `--permission-level <level>` preserves the current role + teams
- [x] `--team A --team B` sets the team set; a single `--team` on a multi-team user prompts before removing the others (`--force` to skip)
- [x] unknown role / unknown user / no-flag → clear error, exit 1
- [x] server rejection (422) → prints the detail, exit 1
- [x] validated live against a dev project

_Rebuilt on `main` (the branch was stacked on #783 / users:list)._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `users:list` and `users:edit` CLI commands for project user management
> - Adds `users:list` to fetch and display project users as a table or JSON, and `users:edit` to update a user's role, team, or permission level by email.
> - Introduces [`UserManager`](https://github.com/ForestAdmin/toolbelt/pull/785/files#diff-990a085a3b739a90f8a5b0e0a4ab3d8770331e01bcda84df7462cf8959c192ec) to handle API interactions: listing users with their roles and teams, finding by email, and updating via `PUT /api/users/:id`.
> - Adds [`UsersRenderer`](https://github.com/ForestAdmin/toolbelt/pull/785/files#diff-66108abce403d91de2f5615f8f64f2eae82e1f1663535bf607f5c4317024f5a7) for table/JSON output, registered in the DI plan in [`renderers-plan.js`](https://github.com/ForestAdmin/toolbelt/pull/785/files#diff-082c7a2d34b599bfd4b03451d52bd94234fe339d630aff18d5998bb1257f4bed).
> - `users:edit` validates that at least one of `--role`, `--team`, or `--permission-level` is provided, and resolves names to IDs before calling the API.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82c338e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
