### PR TITLE
feat(roles): add forest roles:export command

### DIFF
--- a/src/commands/roles/export.ts
+++ b/src/commands/roles/export.ts
@@ -1,0 +1,85 @@
+import type { Config } from '@oclif/core';
+
+import { Flags } from '@oclif/core';
+import { writeFileSync } from 'fs';
+
+import AbstractAuthenticatedCommand from '../../abstract-authenticated-command';
+import EnvironmentManager from '../../services/environment-manager';
+import RoleManager from '../../services/role-manager';
+import { formatWide } from '../../services/roles-csv';
+import withCurrentProject from '../../services/with-current-project';
+
+type NamedEntity = { id: number | string; name: string };
+
+export default class RolesExportCommand extends AbstractAuthenticatedCommand {
+  private env: Record<string, string>;
+
+  static override description = 'Export all roles and their permissions to a wide CSV file.';
+
+  static override flags = {
+    env: Flags.string({
+      char: 'e',
+      description: 'Environment name to export permissions for.',
+      required: true,
+    }),
+    projectId: Flags.integer({
+      char: 'p',
+      description: 'Forest project ID.',
+    }),
+    output: Flags.string({
+      char: 'o',
+      description: 'Output file path (default: stdout).',
+    }),
+  };
+
+  constructor(argv: string[], config: Config, plan?) {
+    super(argv, config, plan);
+    const { assertPresent, env } = this.context;
+    assertPresent({ env });
+    this.env = env;
+  }
+
+  private resolveEnvByName(environments: NamedEntity[], name: string): NamedEntity {
+    const match = environments.find(e => e.name === name);
+    if (match) return match;
+    const available = environments.map(e => e.name).join(', ') || '(none)';
+    this.logger.error(`Environment "${name}" not found in this project. Available: ${available}.`);
+    return this.exit(1);
+  }
+
+  async runAuthenticated() {
+    const { flags } = await this.parse(RolesExportCommand);
+    const config = await withCurrentProject({ ...this.env, projectId: flags.projectId });
+
+    const environments = await new EnvironmentManager(config).listEnvironments();
+    const environment = this.resolveEnvByName(environments, flags.env);
+
+    const roleManager = new RoleManager(config);
+    const roleList = await roleManager.listForProject();
+
+    const fullRoles: Array<{ id: string; name: string; permissions: { environments: unknown[] } }> =
+      [];
+    // eslint-disable-next-line no-restricted-syntax -- sequential: one fetch at a time
+    for (const role of roleList) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const full = await roleManager.getRoleById(role.id);
+        fullRoles.push(full);
+      } catch (error) {
+        this.logger.warn(
+          `Could not fetch permissions for role "${role.name}" (id: ${role.id}): skipped.`,
+        );
+      }
+    }
+
+    const csv = formatWide(fullRoles, environment.id);
+
+    if (flags.output) {
+      writeFileSync(flags.output, csv, 'utf8');
+      process.stderr.write(`Exported ${fullRoles.length} role(s) to ${flags.output}.\n`);
+    } else {
+      process.stdout.write(csv);
+      process.stderr.write(`Exported ${fullRoles.length} role(s).\n`);
+    }
+  }
+}

--- a/src/commands/roles/export.ts
+++ b/src/commands/roles/export.ts
@@ -51,35 +51,89 @@ export default class RolesExportCommand extends AbstractAuthenticatedCommand {
     const { flags } = await this.parse(RolesExportCommand);
     const config = await withCurrentProject({ ...this.env, projectId: flags.projectId });
 
+    try {
+      await this.exportRoles(config, flags.env, flags.output);
+    } catch (error) {
+      this.surfaceApiError(error);
+    }
+  }
+
+  private async exportRoles(
+    config: { projectId: number | string } & Record<string, unknown>,
+    envName: string,
+    output?: string,
+  ): Promise<void> {
     const environments = await new EnvironmentManager(config).listEnvironments();
-    const environment = this.resolveEnvByName(environments, flags.env);
+    const environment = this.resolveEnvByName(environments, envName);
 
     const roleManager = new RoleManager(config);
     const roleList = await roleManager.listForProject();
 
     const fullRoles: Array<{ id: string; name: string; permissions: { environments: unknown[] } }> =
       [];
+    let failures = 0;
     // eslint-disable-next-line no-restricted-syntax -- sequential: one fetch at a time
     for (const role of roleList) {
       try {
         // eslint-disable-next-line no-await-in-loop
-        const full = await roleManager.getRoleById(role.id);
-        fullRoles.push(full);
+        fullRoles.push(await roleManager.getRoleById(role.id));
       } catch (error) {
+        const { status } = error as { status?: number };
+        // Auth / server / network failures are fatal; only a per-role 4xx is skippable.
+        if (status === undefined || status === 401 || status === 403 || status >= 500) throw error;
+        failures += 1;
         this.logger.warn(
-          `Could not fetch permissions for role "${role.name}" (id: ${role.id}): skipped.`,
+          `Could not fetch permissions for role "${role.name}" (id: ${role.id}): skipped (HTTP ${status}).`,
         );
       }
     }
 
-    const csv = formatWide(fullRoles, environment.id);
-
-    if (flags.output) {
-      writeFileSync(flags.output, csv, 'utf8');
-      process.stderr.write(`Exported ${fullRoles.length} role(s) to ${flags.output}.\n`);
-    } else {
-      process.stdout.write(csv);
-      process.stderr.write(`Exported ${fullRoles.length} role(s).\n`);
+    if (roleList.length > 0 && fullRoles.length === 0) {
+      this.logger.error(`Could not fetch permissions for any of the ${roleList.length} role(s).`);
+      this.exit(1);
+      return;
     }
+    if (failures > 0) {
+      this.logger.warn(`${failures} of ${roleList.length} role(s) could not be exported.`);
+    }
+
+    this.writeOutput(formatWide(fullRoles, environment.id), output, fullRoles.length);
+  }
+
+  private writeOutput(csv: string, output: string | undefined, count: number): void {
+    if (!output) {
+      process.stdout.write(csv);
+      process.stderr.write(`Exported ${count} role(s).\n`);
+      return;
+    }
+
+    try {
+      writeFileSync(output, csv, 'utf8');
+    } catch (error) {
+      this.logger.error(`Could not write export to "${output}": ${(error as Error).message}.`);
+      this.exit(1);
+      return;
+    }
+    process.stderr.write(`Exported ${count} role(s) to ${output}.\n`);
+  }
+
+  private surfaceApiError(error: unknown): void {
+    // 401/403 keep flowing to the authenticated-command handler.
+    const { response, status } = error as { status?: number; response?: { text?: string } };
+    if (response && status !== 401 && status !== 403 && response.text) {
+      let detail;
+      try {
+        detail = JSON.parse(response.text)?.errors?.[0]?.detail;
+      } catch {
+        // Non-JSON error body: fall through and rethrow the original error.
+      }
+      if (detail) {
+        this.logger.error(detail);
+        this.exit(1);
+        return;
+      }
+    }
+
+    throw error;
   }
 }

--- a/src/services/role-manager.js
+++ b/src/services/role-manager.js
@@ -41,6 +41,9 @@ function RoleManager(config) {
       .send();
 
     const { data } = response.body;
+    if (!data || !data.attributes) {
+      throw new Error(`Unexpected response for role ${roleId}: missing data.attributes.`);
+    }
     return {
       id: data.id,
       name: data.attributes.name,

--- a/src/services/role-manager.js
+++ b/src/services/role-manager.js
@@ -3,8 +3,8 @@ const Context = require('@forestadmin/context');
 
 /**
  * Read access to a project's roles.
- * Future `forest roles:*` commands (PRD-528/529) should extend this manager
- * with write operations rather than re-implementing the HTTP calls.
+ * PRD-535: extended with `getRoleById` for `forest roles:export`.
+ * Write operations (create / patch / copy permissions) land with `forest roles:apply` (PRD-528).
  * @param {{ projectId: number | string }} config
  */
 function RoleManager(config) {
@@ -24,6 +24,28 @@ function RoleManager(config) {
       id: role.id,
       name: role.attributes.name,
     }));
+  };
+
+  /**
+   * Fetch a single role with its full permissions object.
+   * @param {string|number} roleId
+   * @returns {Promise<{ id: string, name: string, permissions: object }>}
+   */
+  this.getRoleById = async roleId => {
+    const authToken = authenticator.getAuthToken();
+
+    const response = await agent
+      .get(`${env.FOREST_SERVER_URL}/api/roles/${roleId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .set('forest-project-id', config.projectId)
+      .send();
+
+    const { data } = response.body;
+    return {
+      id: data.id,
+      name: data.attributes.name,
+      permissions: data.attributes.permissions || {},
+    };
   };
 }
 

--- a/src/services/roles-csv.js
+++ b/src/services/roles-csv.js
@@ -1,0 +1,142 @@
+/**
+ * Wide role-centric CSV formatting for `forest roles:export`.
+ * PRD-535. The parse / diff side (consumed by `forest roles:apply`) lands in PRD-528.
+ */
+
+const CRUD_SUFFIXES = ['browse', 'read', 'add', 'edit', 'delete', 'export'];
+const SMART_ACTION_SUFFIXES = [
+  'trigger',
+  'approvalRequired',
+  'userApproval',
+  'selfApproval',
+  'hasConditions',
+];
+
+const CRUD_FIELD_MAP = {
+  browse: 'browseEnabled',
+  read: 'readEnabled',
+  add: 'addEnabled',
+  edit: 'editEnabled',
+  delete: 'deleteEnabled',
+  export: 'exportEnabled',
+};
+
+const SA_FIELD_MAP = {
+  trigger: 'triggerEnabled',
+  approvalRequired: 'approvalRequired',
+  userApproval: 'userApprovalEnabled',
+  selfApproval: 'selfApprovalEnabled',
+};
+
+// ---------------------------------------------------------------------------
+// Internal CSV helpers (no external library)
+// ---------------------------------------------------------------------------
+
+function escapeCsv(value) {
+  const str = String(value == null ? '' : value);
+  if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+// ---------------------------------------------------------------------------
+// Build the ordered column list from a set of roles (for formatWide)
+// ---------------------------------------------------------------------------
+
+function collectSmartActionsForCollection(roles, envId, colName) {
+  const actionSet = new Set();
+  roles.forEach(role => {
+    const envPerms = (role.permissions.environments || []).find(
+      e => String(e.id) === String(envId),
+    );
+    if (!envPerms) return;
+    const col = (envPerms.collections || []).find(c => c.collectionName === colName);
+    if (!col) return;
+    (col.smartActions || []).forEach(sa => actionSet.add(sa.smartActionName));
+  });
+  return Array.from(actionSet).sort();
+}
+
+function collectColumns(collections, roles, envId) {
+  return collections.reduce((cols, colName) => {
+    const crudCols = CRUD_SUFFIXES.map(s => `${colName}:${s}`);
+    const actions = collectSmartActionsForCollection(roles, envId, colName);
+    const saCols = actions.reduce(
+      (acc, action) => [...acc, ...SMART_ACTION_SUFFIXES.map(s => `${colName}:${action}:${s}`)],
+      [],
+    );
+    return [...cols, ...crudCols, ...saCols];
+  }, []);
+}
+
+function buildColumns(roles, envId) {
+  const collectionSet = new Set();
+  roles.forEach(role => {
+    const envPerms = (role.permissions.environments || []).find(
+      e => String(e.id) === String(envId),
+    );
+    if (!envPerms) return;
+    (envPerms.collections || []).forEach(col => collectionSet.add(col.collectionName));
+  });
+  const collections = Array.from(collectionSet).sort();
+  return collectColumns(collections, roles, envId);
+}
+
+// ---------------------------------------------------------------------------
+// formatWide helpers
+// ---------------------------------------------------------------------------
+
+function getCrudValue(col, suffix) {
+  if (!col) return false;
+  return Boolean(col[CRUD_FIELD_MAP[suffix]]);
+}
+
+function getSmartActionValue(col, actionName, suffix) {
+  if (!col) return false;
+  const sa = (col.smartActions || []).find(a => a.smartActionName === actionName);
+  if (!sa) return false;
+  if (suffix === 'hasConditions') return sa.conditionCreator != null || sa.conditionCaller != null;
+  return Boolean(sa[SA_FIELD_MAP[suffix]]);
+}
+
+function buildCellForColumn(colHeader, colByName) {
+  const parts = colHeader.split(':');
+  if (parts.length === 2) {
+    const [colName, suffix] = parts;
+    return String(getCrudValue(colByName[colName], suffix));
+  }
+  if (parts.length === 3) {
+    const [colName, actionName, suffix] = parts;
+    return String(getSmartActionValue(colByName[colName], actionName, suffix));
+  }
+  return 'false';
+}
+
+function buildRoleRow(role, columns, envId) {
+  const envPerms = (role.permissions.environments || []).find(e => String(e.id) === String(envId));
+  const enabled = envPerms ? Boolean(envPerms.enabled) : false;
+  const colByName = {};
+  if (envPerms) {
+    (envPerms.collections || []).forEach(col => {
+      colByName[col.collectionName] = col;
+    });
+  }
+  const cells = [role.name, String(enabled), ...columns.map(h => buildCellForColumn(h, colByName))];
+  return cells.map(escapeCsv).join(',');
+}
+
+/**
+ * Format an array of full role objects into a wide CSV string.
+ * @param {Array<{ id: string, name: string, permissions: { environments: Array } }>} roles
+ * @param {string|number} envId
+ * @returns {string}
+ */
+function formatWide(roles, envId) {
+  const columns = buildColumns(roles, envId);
+  const header = ['role', 'enabled', ...columns].map(escapeCsv).join(',');
+  const rows = [header, ...roles.map(role => buildRoleRow(role, columns, envId))];
+  return `${rows.join('\n')}\n`;
+}
+
+module.exports = { formatWide };

--- a/src/services/roles-csv.js
+++ b/src/services/roles-csv.js
@@ -48,7 +48,7 @@ function collectSmartActionsForCollection(roles, envId, colName) {
   const actionSet = new Set();
   roles.forEach(role => {
     const envPerms = (role.permissions.environments || []).find(
-      e => String(e.id) === String(envId),
+      e => String(e.environmentId ?? e.id) === String(envId),
     );
     if (!envPerms) return;
     const col = (envPerms.collections || []).find(c => c.collectionName === colName);
@@ -74,7 +74,7 @@ function buildColumns(roles, envId) {
   const collectionSet = new Set();
   roles.forEach(role => {
     const envPerms = (role.permissions.environments || []).find(
-      e => String(e.id) === String(envId),
+      e => String(e.environmentId ?? e.id) === String(envId),
     );
     if (!envPerms) return;
     (envPerms.collections || []).forEach(col => collectionSet.add(col.collectionName));
@@ -96,7 +96,13 @@ function getSmartActionValue(col, actionName, suffix) {
   if (!col) return false;
   const sa = (col.smartActions || []).find(a => a.smartActionName === actionName);
   if (!sa) return false;
-  if (suffix === 'hasConditions') return sa.conditionCreator != null || sa.conditionCaller != null;
+  if (suffix === 'hasConditions') {
+    return (
+      sa.triggerCondition != null ||
+      sa.approvalRequiredCondition != null ||
+      sa.userApprovalCondition != null
+    );
+  }
   return Boolean(sa[SA_FIELD_MAP[suffix]]);
 }
 
@@ -114,7 +120,9 @@ function buildCellForColumn(colHeader, colByName) {
 }
 
 function buildRoleRow(role, columns, envId) {
-  const envPerms = (role.permissions.environments || []).find(e => String(e.id) === String(envId));
+  const envPerms = (role.permissions.environments || []).find(
+    e => String(e.environmentId ?? e.id) === String(envId),
+  );
   const enabled = envPerms ? Boolean(envPerms.enabled) : false;
   const colByName = {};
   if (envPerms) {

--- a/test/commands/roles/export.test.js
+++ b/test/commands/roles/export.test.js
@@ -1,6 +1,11 @@
 const testCli = require('../test-cli-helper/test-cli');
 const RolesExportCommand = require('../../../src/commands/roles/export').default;
-const { getEnvironmentListValid, getRolesValid, getRoleByIdValid } = require('../../fixtures/api');
+const {
+  getEnvironmentListValid,
+  getRolesValid,
+  getRoleByIdValid,
+  getRoleByIdNotFound,
+} = require('../../fixtures/api');
 const { testEnvWithoutSecret } = require('../../fixtures/env');
 
 describe('roles:export', () => {
@@ -21,6 +26,7 @@ describe('roles:export', () => {
           {
             out: 'role,enabled,orders:browse,orders:read,orders:add,orders:edit,orders:delete,orders:export,orders:Mark as shipped:trigger,orders:Mark as shipped:approvalRequired,orders:Mark as shipped:userApproval,orders:Mark as shipped:selfApproval,orders:Mark as shipped:hasConditions',
           },
+          { out: 'Admin,true,true,true,false,false,false,true' },
         ],
         assertNoStdError: false,
       }));
@@ -39,6 +45,46 @@ describe('roles:export', () => {
             err: '× Environment "nonexistent" not found in this project. Available: name1, name2, test.',
           },
         ],
+        exitCode: 1,
+      }));
+  });
+
+  describe('when one role cannot be fetched', () => {
+    it('should skip it (HTTP 4xx) and still export the others', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: RolesExportCommand,
+        commandArgs: ['-p', '2', '-e', 'name1'],
+        api: [
+          () => getEnvironmentListValid(),
+          () => getRolesValid(),
+          () => getRoleByIdValid('3', 2),
+          () => getRoleByIdNotFound('4', 2),
+        ],
+        std: [
+          { out: 'Admin,true,true,true,false,false,false,true' },
+          { out: 'skipped (HTTP 404)' },
+          { out: '1 of 2 role(s) could not be exported' },
+        ],
+        assertNoStdError: false,
+      }));
+  });
+
+  describe('when no role can be fetched', () => {
+    it('should error and exit 1 instead of reporting an empty success', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: RolesExportCommand,
+        commandArgs: ['-p', '2', '-e', 'name1'],
+        api: [
+          () => getEnvironmentListValid(),
+          () => getRolesValid(),
+          () => getRoleByIdNotFound('3', 2),
+          () => getRoleByIdNotFound('4', 2),
+        ],
+        std: [{ err: 'Could not fetch permissions for any of the 2 role(s).' }],
         exitCode: 1,
       }));
   });

--- a/test/commands/roles/export.test.js
+++ b/test/commands/roles/export.test.js
@@ -1,0 +1,45 @@
+const testCli = require('../test-cli-helper/test-cli');
+const RolesExportCommand = require('../../../src/commands/roles/export').default;
+const { getEnvironmentListValid, getRolesValid, getRoleByIdValid } = require('../../fixtures/api');
+const { testEnvWithoutSecret } = require('../../fixtures/env');
+
+describe('roles:export', () => {
+  describe('with a valid environment name', () => {
+    it('should print a wide CSV to stdout', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: RolesExportCommand,
+        commandArgs: ['-p', '2', '-e', 'name1'],
+        api: [
+          () => getEnvironmentListValid(),
+          () => getRolesValid(),
+          () => getRoleByIdValid('3', 2),
+          () => getRoleByIdValid('4', 2),
+        ],
+        std: [
+          {
+            out: 'role,enabled,orders:browse,orders:read,orders:add,orders:edit,orders:delete,orders:export,orders:Mark as shipped:trigger,orders:Mark as shipped:approvalRequired,orders:Mark as shipped:userApproval,orders:Mark as shipped:selfApproval,orders:Mark as shipped:hasConditions',
+          },
+        ],
+        assertNoStdError: false,
+      }));
+  });
+
+  describe('with an unknown environment name', () => {
+    it('should error and list available environments', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: RolesExportCommand,
+        commandArgs: ['-p', '2', '-e', 'nonexistent'],
+        api: [() => getEnvironmentListValid()],
+        std: [
+          {
+            err: '× Environment "nonexistent" not found in this project. Available: name1, name2, test.',
+          },
+        ],
+        exitCode: 1,
+      }));
+  });
+});

--- a/test/fixtures/api.js
+++ b/test/fixtures/api.js
@@ -693,6 +693,48 @@ module.exports = {
       .query({ projectId: '2', id: '1', include: 'role' })
       .reply(200, { data: { id: '1', type: 'users' }, included: [] }),
 
+  getRoleByIdValid: (roleId = '3', projectId = 2) =>
+    nock('http://localhost:3001')
+      .get(`/api/roles/${roleId}`)
+      .matchHeader('forest-project-id', String(projectId))
+      .reply(200, {
+        data: {
+          type: 'roles',
+          id: roleId,
+          attributes: {
+            name: 'Admin',
+            permissions: {
+              environments: [
+                {
+                  id: 3,
+                  enabled: true,
+                  collections: [
+                    {
+                      collectionName: 'orders',
+                      browseEnabled: true,
+                      readEnabled: true,
+                      addEnabled: false,
+                      editEnabled: false,
+                      deleteEnabled: false,
+                      exportEnabled: true,
+                      smartActions: [
+                        {
+                          smartActionName: 'Mark as shipped',
+                          triggerEnabled: true,
+                          approvalRequired: false,
+                          userApprovalEnabled: false,
+                          selfApprovalEnabled: false,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      }),
+
   getRolesEmpty: () =>
     nock('http://localhost:3001').get('/api/projects/2/roles').reply(200, {
       data: [],

--- a/test/fixtures/api.js
+++ b/test/fixtures/api.js
@@ -706,7 +706,7 @@ module.exports = {
             permissions: {
               environments: [
                 {
-                  id: 3,
+                  environmentId: 3,
                   enabled: true,
                   collections: [
                     {
@@ -734,6 +734,12 @@ module.exports = {
           },
         },
       }),
+
+  getRoleByIdNotFound: (roleId = '4', projectId = 2) =>
+    nock('http://localhost:3001')
+      .get(`/api/roles/${roleId}`)
+      .matchHeader('forest-project-id', String(projectId))
+      .reply(404, { errors: [{ detail: 'Role not found.' }] }),
 
   getRolesEmpty: () =>
     nock('http://localhost:3001').get('/api/projects/2/roles').reply(200, {

--- a/test/services/roles-csv.unit.test.js
+++ b/test/services/roles-csv.unit.test.js
@@ -1,0 +1,166 @@
+const { formatWide } = require('../../src/services/roles-csv');
+
+// Real backend shape: environments[].environmentId, collections[].<crud>Enabled,
+// smartActions[].{triggerEnabled, approvalRequired, userApprovalEnabled,
+// selfApprovalEnabled, triggerCondition?, approvalRequiredCondition?, userApprovalCondition?}.
+const role = (name, environments) => ({ id: '1', name, permissions: { environments } });
+
+const rows = csv => csv.trim().split('\n');
+
+describe('roles-csv formatWide', () => {
+  it('maps CRUD flags to true/false cells and the env-level enabled column', () => {
+    expect.assertions(2);
+    const csv = formatWide(
+      [
+        role('Admin', [
+          {
+            environmentId: 3,
+            enabled: true,
+            collections: [
+              {
+                collectionName: 'orders',
+                browseEnabled: true,
+                readEnabled: true,
+                addEnabled: false,
+                editEnabled: false,
+                deleteEnabled: false,
+                exportEnabled: true,
+                smartActions: [],
+              },
+            ],
+          },
+        ]),
+      ],
+      3,
+    );
+    const [header, row] = rows(csv);
+    expect(header).toBe(
+      'role,enabled,orders:browse,orders:read,orders:add,orders:edit,orders:delete,orders:export',
+    );
+    expect(row).toBe('Admin,true,true,true,false,false,false,true');
+  });
+
+  it('maps smart-action flags and derives hasConditions from the *Condition fields', () => {
+    expect.assertions(2);
+    const collections = [
+      {
+        collectionName: 'orders',
+        browseEnabled: false,
+        readEnabled: false,
+        addEnabled: false,
+        editEnabled: false,
+        deleteEnabled: false,
+        exportEnabled: false,
+        smartActions: [
+          {
+            smartActionName: 'ship',
+            triggerEnabled: true,
+            approvalRequired: false,
+            userApprovalEnabled: true,
+            selfApprovalEnabled: false,
+            triggerCondition: { field: 'status' },
+          },
+        ],
+      },
+    ];
+    const csv = formatWide([role('R', [{ environmentId: 3, enabled: true, collections }])], 3);
+    const [header, row] = rows(csv);
+    // ...:trigger, :approvalRequired, :userApproval, :selfApproval, :hasConditions
+    expect(
+      header.endsWith(
+        'orders:ship:trigger,orders:ship:approvalRequired,orders:ship:userApproval,orders:ship:selfApproval,orders:ship:hasConditions',
+      ),
+    ).toBe(true);
+    expect(row.endsWith('true,false,true,false,true')).toBe(true);
+  });
+
+  it('hasConditions is false when no *Condition field is set', () => {
+    expect.assertions(1);
+    const collections = [
+      {
+        collectionName: 'orders',
+        smartActions: [
+          {
+            smartActionName: 'ship',
+            triggerEnabled: true,
+            approvalRequired: false,
+            userApprovalEnabled: false,
+            selfApprovalEnabled: false,
+          },
+        ],
+      },
+    ];
+    const csv = formatWide([role('R', [{ environmentId: 3, enabled: true, collections }])], 3);
+    // last column is orders:ship:hasConditions → false (no *Condition field set)
+    expect(rows(csv)[1].endsWith('false')).toBe(true);
+  });
+
+  it('emits enabled=false and all-false cells when the role has no perms for the env', () => {
+    expect.assertions(1);
+    const csv = formatWide(
+      [
+        role('Other', [
+          {
+            environmentId: 99, // different env
+            enabled: true,
+            collections: [{ collectionName: 'orders', browseEnabled: true, smartActions: [] }],
+          },
+        ]),
+      ],
+      3,
+    );
+    // env 3 not present → no columns from this role, enabled=false
+    expect(rows(csv)[1]).toBe('Other,false');
+  });
+
+  it('unions columns across roles and fills false for collections a role lacks', () => {
+    expect.assertions(3);
+    const csv = formatWide(
+      [
+        role('A', [
+          {
+            environmentId: 3,
+            enabled: true,
+            collections: [{ collectionName: 'orders', browseEnabled: true, smartActions: [] }],
+          },
+        ]),
+        role('B', [
+          {
+            environmentId: 3,
+            enabled: true,
+            collections: [{ collectionName: 'users', browseEnabled: true, smartActions: [] }],
+          },
+        ]),
+      ],
+      3,
+    );
+    const [header, rowA, rowB] = rows(csv);
+    // sorted union: orders then users
+    expect(header).toBe(
+      'role,enabled,orders:browse,orders:read,orders:add,orders:edit,orders:delete,orders:export,users:browse,users:read,users:add,users:edit,users:delete,users:export',
+    );
+    expect(rowA).toBe(
+      'A,true,true,false,false,false,false,false,false,false,false,false,false,false',
+    );
+    expect(rowB).toBe(
+      'B,true,false,false,false,false,false,false,true,false,false,false,false,false',
+    );
+  });
+
+  it('quotes values containing a comma or quote (RFC 4180)', () => {
+    expect.assertions(1);
+    const csv = formatWide(
+      [
+        role('Ops, "Lead"', [
+          {
+            environmentId: 3,
+            enabled: true,
+            collections: [{ collectionName: 'orders', smartActions: [] }],
+          },
+        ]),
+      ],
+      3,
+    );
+    expect(rows(csv)[1].startsWith('"Ops, ""Lead"""')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `forest roles:export --env <env> [-p <projectId>] [-o <file>]` — a read-only, **role-centric** audit export.
- Output is a **wide CSV**: one row per role, one column per permission (`collection:permission` for CRUD, `collection:action:grant` for Smart Actions, plus role-level `role` + `enabled`). At Qonto scale (~88 roles) this is 88 rows vs ~250k for a long form, and blank/`false` = not granted, `true` = granted — no omission ambiguity.
- Smart Actions carrying conditions are flagged via a read-only `…:hasConditions` column.
- Writes to a file with `-o`, otherwise prints the CSV to stdout (progress line goes to stderr).

## Implementation

No bulk "roles+permissions for an env" endpoint exists, so the export assembles data via **N+1 calls**: `GET /api/projects/:projectId/roles` then `GET /api/roles/:roleId` per role, filtered on the target environment. A per-role 4xx is **reported and skipped** so one bad role can't abort the export; auth/server/network errors are fatal (they propagate instead of silently yielding an empty CSV), and if no role can be fetched the command exits 1.

- `src/commands/roles/export.ts` — the command
- `src/services/role-manager.js` — adds `getRoleById` (full permissions object)
- `src/services/roles-csv.js` — `formatWide` (wide CSV formatting)

## Scope

This is PRD-535 (audit / read side) only. The write side — `roles:apply` / `create` / `copy` (PRD-528) — stacks on top of this branch in a follow-up PR and reuses `roles-csv.js` (parse/diff) and `role-manager.js` (write methods).

## Test plan

- [x] `roles:export --env <env>` → deterministic wide CSV, one row per role
- [x] unknown env name → exits 1, lists available environments
- [x] 2 unit tests pass · build · lint clean

Closes PRD-535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `roles:export` CLI command to export role permissions as a wide CSV
> - Adds a new `forest roles:export` command ([export.ts](https://github.com/ForestAdmin/toolbelt/pull/786/files#diff-c76ab065921fe09461e03afbb46011074bb2a7eca928d748b6c0b9ff4ba55dd7)) that fetches all roles and their permissions for a given environment and writes a wide CSV to stdout or a file via `--output`.
> - Adds `RoleManager.getRoleById` ([role-manager.js](https://github.com/ForestAdmin/toolbelt/pull/786/files#diff-9a0caf92ffc6f1d4735786395cc30a13986ca93e439a2e374f466da135171ad0)) to fetch a single role's full permissions by ID from `/api/roles/:id`.
> - Adds `formatWide` in [roles-csv.js](https://github.com/ForestAdmin/toolbelt/pull/786/files#diff-36705b98120028488fb528d23700064264a96b969e1e7dc91c6d50374e6933ef) to build RFC-4180 CSV with per-collection CRUD and smart-action columns, including a derived `hasConditions` flag.
> - Per-role 4xx errors (non-auth) are skipped with a warning; the command exits with code 1 if no roles could be fetched or if writing the output file fails.
> - Risk: the PR summary flags a stray `+` token in `escapeCsv` inside [roles-csv.js](https://github.com/ForestAdmin/toolbelt/pull/786/files#diff-36705b98120028488fb528d23700064264a96b969e1e7dc91c6d50374e6933ef) that may cause a SyntaxError on module load — this should be verified before merging.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized baa045f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
