### PR TITLE
feat(teams): add forest teams:create command

### DIFF
--- a/src/commands/teams/create.ts
+++ b/src/commands/teams/create.ts
@@ -1,0 +1,61 @@
+import type { Config } from '@oclif/core';
+
+import { Flags } from '@oclif/core';
+
+import AbstractAuthenticatedCommand from '../../abstract-authenticated-command';
+import TeamManager from '../../services/team-manager';
+import withCurrentProject from '../../services/with-current-project';
+
+export default class TeamsCreateCommand extends AbstractAuthenticatedCommand {
+  private env: Record<string, string>;
+
+  static override description = 'Create a new team in a project.';
+
+  static override flags = {
+    name: Flags.string({
+      char: 'n',
+      description: 'Name of the team to create.',
+      required: true,
+    }),
+    projectId: Flags.integer({
+      char: 'p',
+      description: 'Forest project ID.',
+    }),
+  };
+
+  constructor(argv: string[], config: Config, plan?) {
+    super(argv, config, plan);
+    const { assertPresent, env } = this.context;
+    assertPresent({ env });
+    this.env = env;
+  }
+
+  async runAuthenticated() {
+    const { flags } = await this.parse(TeamsCreateCommand);
+    const config = await withCurrentProject({ ...this.env, projectId: flags.projectId });
+
+    try {
+      const team = await new TeamManager(config).createTeam(flags.name, config.projectId);
+      this.logger.info(`Team "${team.name}" created (id: ${team.id}).`);
+    } catch (error) {
+      const { response, status } = error as {
+        status?: number;
+        response?: { text?: string };
+      };
+      if (response && status !== 403 && response.text) {
+        let detail;
+        try {
+          detail = JSON.parse(response.text)?.errors?.[0]?.detail;
+        } catch {
+          // Non-JSON error body: fall through and rethrow the original error.
+        }
+        if (detail) {
+          this.logger.error(detail);
+          this.exit(1);
+          return;
+        }
+      }
+      throw error;
+    }
+  }
+}

--- a/src/services/team-manager.js
+++ b/src/services/team-manager.js
@@ -25,6 +25,36 @@ function TeamManager(config) {
       name: team.attributes.name,
     }));
   };
+
+  /**
+   * Create a new team in the project.
+   * @param {string} name
+   * @param {string|number} projectId
+   * @returns {Promise<{ id: string, name: string }>}
+   */
+  this.createTeam = async (name, projectId) => {
+    const authToken = authenticator.getAuthToken();
+
+    const response = await agent
+      .post(`${env.FOREST_SERVER_URL}/api/teams`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .set('forest-project-id', config.projectId)
+      .send({
+        data: {
+          type: 'teams',
+          attributes: { name },
+          relationships: {
+            project: { data: { id: String(projectId), type: 'projects' } },
+          },
+        },
+      });
+
+    const { data } = response.body;
+    return {
+      id: data.id,
+      name: data.attributes.name,
+    };
+  };
 }
 
 module.exports = TeamManager;

--- a/test/commands/teams/create.test.js
+++ b/test/commands/teams/create.test.js
@@ -1,0 +1,31 @@
+const testCli = require('../test-cli-helper/test-cli');
+const TeamsCreateCommand = require('../../../src/commands/teams/create').default;
+const { createTeamValid, createTeamConflict } = require('../../fixtures/api');
+const { testEnvWithoutSecret } = require('../../fixtures/env');
+
+describe('teams:create', () => {
+  describe('with a valid team name', () => {
+    it('should create the team and print a confirmation', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsCreateCommand,
+        commandArgs: ['-p', '2', '-n', 'Support'],
+        api: [() => createTeamValid()],
+        std: [{ out: 'Team "Support" created (id: 12).' }],
+      }));
+  });
+
+  describe('when the name is already taken', () => {
+    it('should show the server error and exit with code 1', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsCreateCommand,
+        commandArgs: ['-p', '2', '-n', 'Support'],
+        api: [() => createTeamConflict()],
+        std: [{ err: '× Name has already been taken.' }],
+        exitCode: 1,
+      }));
+  });
+});

--- a/test/fixtures/api.js
+++ b/test/fixtures/api.js
@@ -545,6 +545,32 @@ module.exports = {
         ],
       }),
 
+  createTeamValid: (projectId = 2) =>
+    nock('http://localhost:3001')
+      .post('/api/teams', {
+        data: {
+          type: 'teams',
+          attributes: { name: 'Support' },
+          relationships: {
+            project: { data: { id: String(projectId), type: 'projects' } },
+          },
+        },
+      })
+      .matchHeader('forest-project-id', String(projectId))
+      .reply(201, {
+        data: {
+          type: 'teams',
+          id: '12',
+          attributes: { name: 'Support' },
+        },
+      }),
+
+  createTeamConflict: (projectId = 2) =>
+    nock('http://localhost:3001')
+      .post('/api/teams')
+      .matchHeader('forest-project-id', String(projectId))
+      .reply(422, { errors: [{ detail: 'Name has already been taken.' }] }),
+
   getRolesValid: () =>
     nock('http://localhost:3001')
       .get('/api/projects/2/roles')


### PR DESCRIPTION
## What

Adds `forest teams:create -n <name> [-p <projectId>]` — the first command of the `forest teams:*` family (PRD-586).

```
forest teams:create --name "Support"
forest teams:create --name "Operations" -p 132019
```

It's the foundation of the team commands: it prints the new team's **id**, which `users:invite` / `users:edit` consume to place users on a team.

fixes PRD-529

## How

- **`TeamManager.createTeam`** — `POST /api/teams` (JSON:API), a direct mirror of the existing `RoleManager.createRole`. I verified the contract against `private-api` rather than guessing: `teams-route.ts` + the team deserializer expect `type: teams`, `attributes.name`, and a `project` relationship of type `projects`.
- **Command** mirrors `roles:create`: `projectId` resolved via `withCurrentProject` (`-p` optional, AC ✅), the server error `detail` is relayed cleanly with `exit 1`, and 403s are deliberately left to the base command's handler.
- On success: `Team "<name>" created (id: <id>).` — the id is the AC deliverable.

## Acceptance criteria (PRD-529)

- [x] `--projectId` (`-p`) optional — resolved from `.forestrc` when absent
- [x] Creates the team and prints its id
- [x] Clear error when a team with that name already exists

## Tests

- Command-level tests mirroring `roles/create.test.js`: happy path + name-already-taken (exit 1). `createTeamValid` / `createTeamConflict` fixtures added.
- **Tested manually** against the BaaSDemo project (132019):
  - `teams:create --name "CLI Test Team" -p 132019` → `Team "CLI Test Team" created (id: 122419).`, confirmed present via the API.
  - Re-running the same name → `× A team with this name already exists...`, exit 1.

## Definition of Done

- [x] Conventional Commits title
- [x] Tested manually
- [x] Code quality (mirrors the reviewed roles:create pattern)
- [x] Security: no new surface — same auth/headers as sibling commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `teams:create` CLI command to create a team via the Forest API
> - Adds a new `teams:create` authenticated command in [`src/commands/teams/create.ts`](https://github.com/ForestAdmin/toolbelt/pull/788/files#diff-c3792b32f6ea34b6794f31f744292339274418a0029d365a57b75a139e59c25b) with required `--name` and optional `--projectId` flags.
> - Uses `TeamManager.createTeam` (added to [`src/services/team-manager.js`](https://github.com/ForestAdmin/toolbelt/pull/788/files#diff-7083afebe926c101165a5a4bd58e5f3528e9eca5990974175bd3f4dbb6da1019)) which POSTs a JSON:API payload to `/api/teams` and returns the created team's `id` and `name`.
> - On success, logs a confirmation message; on a server-returned JSON:API error (e.g. 422 name conflict), prints the error detail and exits with code 1.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a672cc9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->