### PR TITLE
feat(teams): add forest teams:delete command

### DIFF
--- a/src/commands/teams/delete.ts
+++ b/src/commands/teams/delete.ts
@@ -1,0 +1,76 @@
+import type { Config } from '@oclif/core';
+
+import { Flags } from '@oclif/core';
+
+import AbstractAuthenticatedCommand from '../../abstract-authenticated-command';
+import TeamManager from '../../services/team-manager';
+import withCurrentProject from '../../services/with-current-project';
+
+type NamedEntity = { id: number | string; name: string };
+
+export default class TeamsDeleteCommand extends AbstractAuthenticatedCommand {
+  private env: Record<string, string>;
+
+  private inquirer: { prompt: (questions: unknown[]) => Promise<Record<string, unknown>> };
+
+  static override description = 'Delete a team from a project.';
+
+  static override flags = {
+    name: Flags.string({
+      char: 'n',
+      description: 'Name of the team to delete.',
+      required: true,
+    }),
+    projectId: Flags.integer({
+      char: 'p',
+      description: 'Forest project ID.',
+    }),
+    force: Flags.boolean({
+      description: 'Skip the confirmation prompt.',
+    }),
+  };
+
+  constructor(argv: string[], config: Config, plan?) {
+    super(argv, config, plan);
+    const { assertPresent, env, inquirer } = this.context;
+    assertPresent({ env, inquirer });
+    this.env = env;
+    this.inquirer = inquirer;
+  }
+
+  async runAuthenticated() {
+    const { flags } = await this.parse(TeamsDeleteCommand);
+    const config = await withCurrentProject({ ...this.env, projectId: flags.projectId });
+    const teamManager = new TeamManager(config);
+
+    const teams: NamedEntity[] = await teamManager.listForProject();
+    const team = teams.find(t => t.name === flags.name);
+    if (!team) {
+      const available = teams.map(t => t.name).join(', ') || '(none)';
+      this.logger.error(`Team "${flags.name}" not found in this project. Available: ${available}.`);
+      this.exit(1);
+      return;
+    }
+
+    if (!flags.force) {
+      const { confirm } = await this.inquirer.prompt([
+        {
+          type: 'confirm',
+          name: 'confirm',
+          message: `This will permanently delete team ${this.chalk.red(team.name)} on project ${
+            config.projectId
+          }. Continue?`,
+          default: false,
+        },
+      ]);
+
+      if (!confirm) {
+        this.logger.info('Aborted.');
+        return;
+      }
+    }
+
+    await teamManager.deleteTeam(team.id);
+    this.logger.info(`Team "${team.name}" deleted from project ${config.projectId}.`);
+  }
+}

--- a/src/services/team-manager.js
+++ b/src/services/team-manager.js
@@ -25,6 +25,21 @@ function TeamManager(config) {
       name: team.attributes.name,
     }));
   };
+
+  /**
+   * Delete a team by its id.
+   * @param {string|number} teamId
+   * @returns {Promise<void>}
+   */
+  this.deleteTeam = async teamId => {
+    const authToken = authenticator.getAuthToken();
+
+    await agent
+      .delete(`${env.FOREST_SERVER_URL}/api/teams/${teamId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .set('forest-project-id', config.projectId)
+      .send();
+  };
 }
 
 module.exports = TeamManager;

--- a/test/commands/teams/delete.test.js
+++ b/test/commands/teams/delete.test.js
@@ -1,0 +1,73 @@
+const testCli = require('../test-cli-helper/test-cli');
+const TeamsDeleteCommand = require('../../../src/commands/teams/delete').default;
+const { getTeamsValid, deleteTeamValid } = require('../../fixtures/api');
+const { testEnvWithoutSecret } = require('../../fixtures/env');
+
+const confirmPrompt = confirm => ({
+  in: [
+    {
+      type: 'confirm',
+      name: 'confirm',
+      message: 'This will permanently delete team Support on project 2. Continue?',
+      default: false,
+    },
+  ],
+  out: { confirm },
+});
+
+describe('teams:delete', () => {
+  describe('with --force', () => {
+    it('should delete the team without prompting and print a confirmation', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsDeleteCommand,
+        commandArgs: ['-p', '2', '-n', 'Support', '--force'],
+        api: [() => getTeamsValid(), () => deleteTeamValid()],
+        std: [{ out: 'Team "Support" deleted from project 2.' }],
+      }));
+  });
+
+  describe('when the user confirms the prompt', () => {
+    it('should delete the team', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsDeleteCommand,
+        commandArgs: ['-p', '2', '-n', 'Support'],
+        api: [() => getTeamsValid(), () => deleteTeamValid()],
+        prompts: [confirmPrompt(true)],
+        std: [{ out: 'Team "Support" deleted from project 2.' }],
+      }));
+  });
+
+  describe('when the user declines the prompt', () => {
+    it('should abort without deleting', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsDeleteCommand,
+        commandArgs: ['-p', '2', '-n', 'Support'],
+        api: [() => getTeamsValid()],
+        prompts: [confirmPrompt(false)],
+        std: [{ out: 'Aborted.' }],
+      }));
+  });
+
+  describe('when the team does not exist', () => {
+    it('should error, list available teams and exit with code 1', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsDeleteCommand,
+        commandArgs: ['-p', '2', '-n', 'Unknown', '--force'],
+        api: [() => getTeamsValid()],
+        std: [
+          {
+            err: '× Team "Unknown" not found in this project. Available: Operations, Support.',
+          },
+        ],
+        exitCode: 1,
+      }));
+  });
+});

--- a/test/fixtures/api.js
+++ b/test/fixtures/api.js
@@ -545,6 +545,12 @@ module.exports = {
         ],
       }),
 
+  deleteTeamValid: (teamId = '8', projectId = 2) =>
+    nock('http://localhost:3001')
+      .delete(`/api/teams/${teamId}`)
+      .matchHeader('forest-project-id', String(projectId))
+      .reply(204),
+
   getRolesValid: () =>
     nock('http://localhost:3001')
       .get('/api/projects/2/roles')


### PR DESCRIPTION
## What

Adds `forest teams:delete -n <name> [-p <projectId>] [--force]` (PRD-586 / PRD-589).

```
forest teams:delete --name "Support"
forest teams:delete --name "Support" -p 132019 --force
```

## How

- **`TeamManager.deleteTeam`** — `DELETE /api/teams/:id`. Verified against `private-api` (`teams-route.ts` → 204 No Content).
- Resolves the team **by name** via `listForProject`; on a miss it errors with the list of available team names and exits 1 — same UX as `users:edit`.
- **Destructive-action guard**: a confirm prompt before deletion (mirrors `environments:delete`), skippable with `--force` for headless/CI use.
- `projectId` resolved via `withCurrentProject` (`-p` optional).

## Acceptance criteria (PRD-589)

- [x] `--projectId` (`-p`) optional — resolved via `withCurrentProject`
- [x] Resolves the team by name → deletes
- [x] Confirmation prompt before deletion; `--force` to skip
- [x] Clear error when the team is not found

## Tests

- Command-level tests: `--force` happy path, prompt **confirm**, prompt **decline** (`Aborted.`), and **not-found** (exit 1). `deleteTeamValid` fixture added. 4/4 green.
- **Tested manually** against BaaSDemo (132019):
  - Not found → `× Team "Zzz Does Not Exist" not found in this project. Available: …`, exit 1.
  - `--force` delete of a real test team → `Team "CLI Test Team" deleted from project 132019.`, confirmed gone via the API.

## Definition of Done

- [x] Conventional Commits title
- [x] Tested manually
- [x] Code quality (reuses listForProject + the environments:delete confirm pattern)
- [x] Security: deletion is gated behind name resolution + a confirm prompt unless `--force` is explicit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `teams:delete` CLI command to delete a team from a project
> - Adds a new `teams:delete` oclif command in [`src/commands/teams/delete.ts`](https://github.com/ForestAdmin/toolbelt/pull/789/files#diff-b8f1f856ac7eba739ed9a50aaa7a36a462fadafd03974635ef4078657f5ac0e5) with `--name` (required), `--projectId` (optional), and `--force` (optional) flags.
> - Without `--force`, prompts the user for confirmation before deleting; logs `Aborted.` if declined.
> - Exits with code 1 and lists available teams if the specified team name is not found.
> - Adds `deleteTeam(teamId)` to [`src/services/team-manager.js`](https://github.com/ForestAdmin/toolbelt/pull/789/files#diff-7083afebe926c101165a5a4bd58e5f3528e9eca5990974175bd3f4dbb6da1019), sending a DELETE request to `/api/teams/{teamId}` with the `forest-project-id` header.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ebf8f08.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->