### PR TITLE
feat(teams): add forest teams:delete command

### DIFF
--- a/src/commands/teams/delete.ts
+++ b/src/commands/teams/delete.ts
@@ -1,0 +1,76 @@
+import type { Config } from '@oclif/core';
+
+import { Flags } from '@oclif/core';
+
+import AbstractAuthenticatedCommand from '../../abstract-authenticated-command';
+import TeamManager from '../../services/team-manager';
+import withCurrentProject from '../../services/with-current-project';
+
+type NamedEntity = { id: number | string; name: string };
+
+export default class TeamsDeleteCommand extends AbstractAuthenticatedCommand {
+  private env: Record<string, string>;
+
+  private inquirer: { prompt: (questions: unknown[]) => Promise<Record<string, unknown>> };
+
+  static override description = 'Delete a team from a project.';
+
+  static override flags = {
+    name: Flags.string({
+      char: 'n',
+      description: 'Name of the team to delete.',
+      required: true,
+    }),
+    projectId: Flags.integer({
+      char: 'p',
+      description: 'Forest project ID.',
+    }),
+    force: Flags.boolean({
+      description: 'Skip the confirmation prompt.',
+    }),
+  };
+
+  constructor(argv: string[], config: Config, plan?) {
+    super(argv, config, plan);
+    const { assertPresent, env, inquirer } = this.context;
+    assertPresent({ env, inquirer });
+    this.env = env;
+    this.inquirer = inquirer;
+  }
+
+  async runAuthenticated() {
+    const { flags } = await this.parse(TeamsDeleteCommand);
+    const config = await withCurrentProject({ ...this.env, projectId: flags.projectId });
+    const teamManager = new TeamManager(config);
+
+    const teams: NamedEntity[] = await teamManager.listForProject();
+    const team = teams.find(t => t.name === flags.name);
+    if (!team) {
+      const available = teams.map(t => t.name).join(', ') || '(none)';
+      this.logger.error(`Team "${flags.name}" not found in this project. Available: ${available}.`);
+      this.exit(1);
+      return;
+    }
+
+    if (!flags.force) {
+      const { confirm } = await this.inquirer.prompt([
+        {
+          type: 'confirm',
+          name: 'confirm',
+          message: `This will permanently delete team ${this.chalk.red(team.name)} on project ${
+            config.projectId
+          }. Continue?`,
+          default: false,
+        },
+      ]);
+
+      if (!confirm) {
+        this.logger.info('Aborted.');
+        return;
+      }
+    }
+
+    await teamManager.deleteTeam(team.id);
+    this.logger.info(`Team "${team.name}" deleted from project ${config.projectId}.`);
+  }
+}

--- a/src/commands/teams/delete.ts
+++ b/src/commands/teams/delete.ts
@@ -70,7 +70,28 @@ export default class TeamsDeleteCommand extends AbstractAuthenticatedCommand {
       }
     }
 
-    await teamManager.deleteTeam(team.id);
-    this.logger.info(`Team "${team.name}" deleted from project ${config.projectId}.`);
+    try {
+      await teamManager.deleteTeam(team.id);
+      this.logger.info(`Team "${team.name}" deleted from project ${config.projectId}.`);
+    } catch (error) {
+      const { response, status } = error as {
+        status?: number;
+        response?: { text?: string };
+      };
+      if (response && status !== 401 && status !== 403 && response.text) {
+        let detail;
+        try {
+          detail = JSON.parse(response.text)?.errors?.[0]?.detail;
+        } catch {
+          // Non-JSON error body: fall through and rethrow the original error.
+        }
+        if (detail) {
+          this.logger.error(detail);
+          this.exit(1);
+          return;
+        }
+      }
+      throw error;
+    }
   }
 }

--- a/src/services/team-manager.js
+++ b/src/services/team-manager.js
@@ -57,6 +57,21 @@ function TeamManager(config) {
       name: data.attributes.name,
     };
   };
+
+  /**
+   * Delete a team by its id.
+   * @param {string|number} teamId
+   * @returns {Promise<void>}
+   */
+  this.deleteTeam = async teamId => {
+    const authToken = authenticator.getAuthToken();
+
+    await agent
+      .delete(`${env.FOREST_SERVER_URL}/api/teams/${teamId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .set('forest-project-id', config.projectId)
+      .send();
+  };
 }
 
 module.exports = TeamManager;

--- a/test/commands/teams/delete.test.js
+++ b/test/commands/teams/delete.test.js
@@ -1,0 +1,73 @@
+const testCli = require('../test-cli-helper/test-cli');
+const TeamsDeleteCommand = require('../../../src/commands/teams/delete').default;
+const { getTeamsValid, deleteTeamValid } = require('../../fixtures/api');
+const { testEnvWithoutSecret } = require('../../fixtures/env');
+
+const confirmPrompt = confirm => ({
+  in: [
+    {
+      type: 'confirm',
+      name: 'confirm',
+      message: 'This will permanently delete team Support on project 2. Continue?',
+      default: false,
+    },
+  ],
+  out: { confirm },
+});
+
+describe('teams:delete', () => {
+  describe('with --force', () => {
+    it('should delete the team without prompting and print a confirmation', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsDeleteCommand,
+        commandArgs: ['-p', '2', '-n', 'Support', '--force'],
+        api: [() => getTeamsValid(), () => deleteTeamValid()],
+        std: [{ out: 'Team "Support" deleted from project 2.' }],
+      }));
+  });
+
+  describe('when the user confirms the prompt', () => {
+    it('should delete the team', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsDeleteCommand,
+        commandArgs: ['-p', '2', '-n', 'Support'],
+        api: [() => getTeamsValid(), () => deleteTeamValid()],
+        prompts: [confirmPrompt(true)],
+        std: [{ out: 'Team "Support" deleted from project 2.' }],
+      }));
+  });
+
+  describe('when the user declines the prompt', () => {
+    it('should abort without deleting', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsDeleteCommand,
+        commandArgs: ['-p', '2', '-n', 'Support'],
+        api: [() => getTeamsValid()],
+        prompts: [confirmPrompt(false)],
+        std: [{ out: 'Aborted.' }],
+      }));
+  });
+
+  describe('when the team does not exist', () => {
+    it('should error, list available teams and exit with code 1', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsDeleteCommand,
+        commandArgs: ['-p', '2', '-n', 'Unknown', '--force'],
+        api: [() => getTeamsValid()],
+        std: [
+          {
+            err: '× Team "Unknown" not found in this project. Available: Operations, Support.',
+          },
+        ],
+        exitCode: 1,
+      }));
+  });
+});

--- a/test/commands/teams/delete.test.js
+++ b/test/commands/teams/delete.test.js
@@ -1,6 +1,11 @@
 const testCli = require('../test-cli-helper/test-cli');
 const TeamsDeleteCommand = require('../../../src/commands/teams/delete').default;
-const { getTeamsValid, deleteTeamValid } = require('../../fixtures/api');
+const {
+  getTeamsValid,
+  getTeamsEmpty,
+  deleteTeamValid,
+  deleteTeamError,
+} = require('../../fixtures/api');
 const { testEnvWithoutSecret } = require('../../fixtures/env');
 
 const confirmPrompt = confirm => ({
@@ -23,8 +28,11 @@ describe('teams:delete', () => {
         token: 'any',
         commandClass: TeamsDeleteCommand,
         commandArgs: ['-p', '2', '-n', 'Support', '--force'],
-        api: [() => getTeamsValid(), () => deleteTeamValid()],
+        // '8' is Support's id in getTeamsValid: this asserts the name→id resolution.
+        api: [() => getTeamsValid(), () => deleteTeamValid('8')],
         std: [{ out: 'Team "Support" deleted from project 2.' }],
+        // punycode DEP0040 leaks to stderr on the first command test of a run.
+        assertNoStdError: false,
       }));
   });
 
@@ -35,7 +43,7 @@ describe('teams:delete', () => {
         token: 'any',
         commandClass: TeamsDeleteCommand,
         commandArgs: ['-p', '2', '-n', 'Support'],
-        api: [() => getTeamsValid(), () => deleteTeamValid()],
+        api: [() => getTeamsValid(), () => deleteTeamValid('8')],
         prompts: [confirmPrompt(true)],
         std: [{ out: 'Team "Support" deleted from project 2.' }],
       }));
@@ -67,6 +75,36 @@ describe('teams:delete', () => {
             err: '× Team "Unknown" not found in this project. Available: Operations, Support.',
           },
         ],
+        exitCode: 1,
+      }));
+  });
+
+  describe('when no team exists in the project', () => {
+    it('should report an empty available list and exit with code 1', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsDeleteCommand,
+        commandArgs: ['-p', '2', '-n', 'Support', '--force'],
+        api: [() => getTeamsEmpty()],
+        std: [
+          {
+            err: '× Team "Support" not found in this project. Available: (none).',
+          },
+        ],
+        exitCode: 1,
+      }));
+  });
+
+  describe('when the server rejects the deletion', () => {
+    it('should surface the server error detail and exit with code 1', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsDeleteCommand,
+        commandArgs: ['-p', '2', '-n', 'Support', '--force'],
+        api: [() => getTeamsValid(), () => deleteTeamError('8')],
+        std: [{ err: '× Team not found.' }],
         exitCode: 1,
       }));
   });

--- a/test/fixtures/api.js
+++ b/test/fixtures/api.js
@@ -585,6 +585,15 @@ module.exports = {
       .matchHeader('forest-project-id', String(projectId))
       .reply(204),
 
+  deleteTeamError: (teamId = '8', projectId = 2) =>
+    nock('http://localhost:3001')
+      .delete(`/api/teams/${teamId}`)
+      .matchHeader('forest-project-id', String(projectId))
+      .reply(404, { errors: [{ detail: 'Team not found.' }] }),
+
+  getTeamsEmpty: () =>
+    nock('http://localhost:3001').get('/api/projects/2/teams').reply(200, { data: [] }),
+
   getRolesValid: () =>
     nock('http://localhost:3001')
       .get('/api/projects/2/roles')

--- a/test/fixtures/api.js
+++ b/test/fixtures/api.js
@@ -579,6 +579,12 @@ module.exports = {
       .matchHeader('forest-project-id', String(projectId))
       .reply(422, { errors: [{ detail: 'Name has already been taken.' }] }),
 
+  deleteTeamValid: (teamId = '8', projectId = 2) =>
+    nock('http://localhost:3001')
+      .delete(`/api/teams/${teamId}`)
+      .matchHeader('forest-project-id', String(projectId))
+      .reply(204),
+
   getRolesValid: () =>
     nock('http://localhost:3001')
       .get('/api/projects/2/roles')


### PR DESCRIPTION
## What

Adds `forest teams:delete -n <name> [-p <projectId>] [--force]` (PRD-586 / PRD-589).

```
forest teams:delete --name "Support"
forest teams:delete --name "Support" -p 132019 --force
```

## How

- **`TeamManager.deleteTeam`** — `DELETE /api/teams/:id`. Verified against `private-api` (`teams-route.ts` → 204 No Content).
- Resolves the team **by name** via `listForProject`; on a miss it errors with the list of available team names (`(none)` when the project has none) and exits 1 — same UX as `users:edit`.
- **Destructive-action guard**: a confirm prompt before deletion (mirrors `environments:delete`), skippable with `--force` for headless/CI use.
- **Server-error handling**: the `deleteTeam` call is wrapped in the same `surfaceApiError` pattern as `teams:create` — a server error (e.g. a 404 *delete-after-resolve* race) prints the JSON:API `errors[0].detail` cleanly and exits 1, while 401/403 flow to the base command's auth handler (login / exit 2). No raw stack traces.
- `projectId` resolved via `withCurrentProject` (`-p` optional).

## Acceptance criteria (PRD-589)

- [x] `--projectId` (`-p`) optional — resolved via `withCurrentProject`
- [x] Resolves the team by name → deletes
- [x] Confirmation prompt before deletion; `--force` to skip
- [x] Clear error when the team is not found

## Tests

- Command-level tests (`test/commands/teams/delete.test.js`): `--force` happy path, prompt **confirm**, prompt **decline** (`Aborted.`), **not-found** (exit 1), **empty team list** (`Available: (none).`, exit 1), and **server rejection** (detail surfaced, exit 1). The resolved team id is asserted explicitly (`deleteTeamValid('8')` = Support's id), proving the name→id resolution targets the right team. `deleteTeamValid` / `deleteTeamError` / `getTeamsEmpty` fixtures added. **9/9 green** (teams suite).
- **Tested manually** against the development environment (project 2):
  - confirm **Yes** → `Team "tmp-del" deleted from project 2.`
  - confirm **No** → `Aborted.` (team preserved)
  - `--force` → deleted with no prompt
  - not-found → `× Team "Zzz Inexistant" not found in this project. Available: …`, exit 1

## Definition of Done

- [x] Conventional Commits title
- [x] Tested manually (local + live)
- [x] Code quality (reuses listForProject + the environments:delete confirm pattern + the create.ts error-surfacing pattern)
- [x] Security: deletion is gated behind name resolution + a confirm prompt unless `--force` is explicit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `teams:delete` CLI command to delete a team by name
> - Adds a new `teams:delete` oclif command in [`src/commands/teams/delete.ts`](https://github.com/ForestAdmin/toolbelt/pull/792/files#diff-b8f1f856ac7eba739ed9a50aaa7a36a462fadafd03974635ef4078657f5ac0e5) with `--name`, `--projectId`, and `--force` flags.
> - Looks up the team by name via `TeamManager`, logs available team names and exits with code 1 if not found.
> - Prompts for confirmation unless `--force` is provided; on confirmation calls the new `TeamManager.deleteTeam` method which issues a `DELETE /api/teams/:teamId` request.
> - Surfaces the first JSON:API error detail from the server response on failure and exits with code 1.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4eaa886.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
