### PR TITLE
feat(teams): add forest teams:copy-layout command

### DIFF
--- a/src/commands/teams/copy-layout.ts
+++ b/src/commands/teams/copy-layout.ts
@@ -1,0 +1,101 @@
+import type { Config } from '@oclif/core';
+
+import { Flags } from '@oclif/core';
+
+import AbstractAuthenticatedCommand from '../../abstract-authenticated-command';
+import TeamManager from '../../services/team-manager';
+import withCurrentProject from '../../services/with-current-project';
+
+type NamedEntity = { id: number | string; name: string };
+
+export default class TeamsCopyLayoutCommand extends AbstractAuthenticatedCommand {
+  private env: Record<string, string>;
+
+  private inquirer: { prompt: (questions: unknown[]) => Promise<Record<string, unknown>> };
+
+  static override description = "Copy a team's whole layout onto another team of the same project.";
+
+  static override flags = {
+    from: Flags.string({
+      char: 'f',
+      description: 'Name of the team to copy the layout from.',
+      required: true,
+    }),
+    to: Flags.string({
+      char: 't',
+      description: 'Name of the team to copy the layout to (its layout is overwritten).',
+      required: true,
+    }),
+    projectId: Flags.integer({
+      char: 'p',
+      description: 'Forest project ID.',
+    }),
+    force: Flags.boolean({
+      description: 'Skip the confirmation prompt.',
+    }),
+  };
+
+  constructor(argv: string[], config: Config, plan?) {
+    super(argv, config, plan);
+    const { assertPresent, env, inquirer } = this.context;
+    assertPresent({ env, inquirer });
+    this.env = env;
+    this.inquirer = inquirer;
+  }
+
+  private resolveTeam(teams: NamedEntity[], name: string, label: string): NamedEntity {
+    const match = teams.find(t => t.name === name);
+    if (match) return match;
+    const available = teams.map(t => t.name).join(', ') || '(none)';
+    this.logger.error(
+      `${label} team "${name}" not found in this project. Available: ${available}.`,
+    );
+    return this.exit(1);
+  }
+
+  async runAuthenticated() {
+    const oclifExit = this.exit.bind(this);
+    const { flags } = await this.parse(TeamsCopyLayoutCommand);
+    const config = await withCurrentProject({ ...this.env, projectId: flags.projectId });
+    const teamManager = new TeamManager(config);
+
+    const teams: NamedEntity[] = await teamManager.listForProject();
+    const fromTeam = this.resolveTeam(teams, flags.from, 'Source');
+    const toTeam = this.resolveTeam(teams, flags.to, 'Target');
+
+    if (fromTeam.id === toTeam.id) {
+      this.logger.error('Source and target teams must be different.');
+      this.exit(1);
+      return;
+    }
+
+    if (!flags.force) {
+      const { confirm } = await this.inquirer.prompt([
+        {
+          type: 'confirm',
+          name: 'confirm',
+          message: `This will overwrite the whole layout of team ${this.chalk.red(
+            toTeam.name,
+          )} with the layout of ${this.chalk.red(fromTeam.name)}. Continue?`,
+          default: false,
+        },
+      ]);
+
+      if (!confirm) {
+        this.logger.info('Aborted.');
+        return;
+      }
+    }
+
+    const copied = await teamManager.copyLayout(fromTeam.id, toTeam.id, oclifExit);
+
+    if (copied) {
+      this.logger.info(
+        `Layout of team "${fromTeam.name}" copied to "${toTeam.name}" on project ${config.projectId}.`,
+      );
+    } else {
+      this.logger.error('Oops, something went wrong.');
+      this.exit(1);
+    }
+  }
+}

--- a/src/commands/teams/copy-layout.ts
+++ b/src/commands/teams/copy-layout.ts
@@ -43,6 +43,28 @@ export default class TeamsCopyLayoutCommand extends AbstractAuthenticatedCommand
     this.inquirer = inquirer;
   }
 
+  // Surface a server error's `errors[0].detail` cleanly (exit 1), letting
+  // 401/403 flow to the base command's auth handler. Mirrors teams:create/delete.
+  private surfaceApiError(error: unknown): never {
+    const { response, status } = error as {
+      status?: number;
+      response?: { text?: string };
+    };
+    if (response && status !== 401 && status !== 403 && response.text) {
+      let detail;
+      try {
+        detail = JSON.parse(response.text)?.errors?.[0]?.detail;
+      } catch {
+        // Non-JSON error body: fall through and rethrow the original error.
+      }
+      if (detail) {
+        this.logger.error(detail);
+        return this.exit(1);
+      }
+    }
+    throw error;
+  }
+
   private resolveTeam(teams: NamedEntity[], name: string, label: string): NamedEntity {
     const match = teams.find(t => t.name === name);
     if (match) return match;
@@ -87,7 +109,12 @@ export default class TeamsCopyLayoutCommand extends AbstractAuthenticatedCommand
       }
     }
 
-    const copied = await teamManager.copyLayout(fromTeam.id, toTeam.id, oclifExit);
+    let copied;
+    try {
+      copied = await teamManager.copyLayout(fromTeam.id, toTeam.id, oclifExit);
+    } catch (error) {
+      this.surfaceApiError(error);
+    }
 
     if (copied) {
       this.logger.info(

--- a/src/services/team-manager.js
+++ b/src/services/team-manager.js
@@ -1,6 +1,8 @@
 const agent = require('superagent');
 const Context = require('@forestadmin/context');
 
+const JobStateChecker = require('./job-state-checker');
+
 /**
  * Read access to a project's teams.
  * Future `forest teams:*` commands (PRD-528/529) should extend this manager
@@ -71,6 +73,40 @@ function TeamManager(config) {
       .set('Authorization', `Bearer ${authToken}`)
       .set('forest-project-id', config.projectId)
       .send();
+  };
+
+  /**
+   * Copy the whole layout of one team onto another, within the same project.
+   * Asynchronous server-side: posts a deployment request, then polls the job
+   * until completion.
+   * @param {string|number} fromTeamId
+   * @param {string|number} toTeamId
+   * @param {(code: number) => void} oclifExit
+   * @returns {Promise<boolean>} true when the job completes, false on failure
+   */
+  this.copyLayout = async (fromTeamId, toTeamId, oclifExit) => {
+    const authToken = authenticator.getAuthToken();
+    const jobStateChecker = new JobStateChecker('Copying layout', oclifExit);
+
+    const response = await agent
+      .post(`${env.FOREST_SERVER_URL}/api/deployment-requests`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .set('forest-project-id', config.projectId)
+      .send({
+        data: {
+          type: 'deployment-requests',
+          attributes: {
+            type: 'team',
+            from: Number(fromTeamId),
+            to: Number(toTeamId),
+          },
+        },
+      });
+
+    const jobId = response.body?.meta?.job_id;
+    if (!jobId) return false;
+
+    return jobStateChecker.check(jobId);
   };
 }
 

--- a/test/commands/teams/copy-layout.test.js
+++ b/test/commands/teams/copy-layout.test.js
@@ -1,0 +1,89 @@
+const testCli = require('../test-cli-helper/test-cli');
+const TeamsCopyLayoutCommand = require('../../../src/commands/teams/copy-layout').default;
+const { getTeamsValid, postCopyTeamLayout, getJob, getJobFailed } = require('../../fixtures/api');
+const { testEnvWithoutSecret } = require('../../fixtures/env');
+
+describe('teams:copy-layout', () => {
+  describe('on a completed job', () => {
+    it('should copy the layout and print a confirmation', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsCopyLayoutCommand,
+        commandArgs: ['-p', '2', '-f', 'Operations', '-t', 'Support', '--force'],
+        api: [() => getTeamsValid(), () => postCopyTeamLayout(), () => getJob()],
+        assertNoStdError: false,
+        std: [{ out: 'Layout of team "Operations" copied to "Support" on project 2.' }],
+      }));
+  });
+
+  describe('on a failed job', () => {
+    it('should exit with status 1', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsCopyLayoutCommand,
+        commandArgs: ['-p', '2', '-f', 'Operations', '-t', 'Support', '--force'],
+        api: [() => getTeamsValid(), () => postCopyTeamLayout(), () => getJobFailed()],
+        assertNoStdError: false,
+        std: [{ err: '× Oops, something went wrong.' }],
+        exitCode: 1,
+      }));
+  });
+
+  describe('when the user declines the prompt', () => {
+    it('should abort without copying', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsCopyLayoutCommand,
+        commandArgs: ['-p', '2', '-f', 'Operations', '-t', 'Support'],
+        api: [() => getTeamsValid()],
+        prompts: [
+          {
+            in: [
+              {
+                type: 'confirm',
+                name: 'confirm',
+                message:
+                  'This will overwrite the whole layout of team Support with the layout of Operations. Continue?',
+                default: false,
+              },
+            ],
+            out: { confirm: false },
+          },
+        ],
+        std: [{ out: 'Aborted.' }],
+      }));
+  });
+
+  describe('when the source team does not exist', () => {
+    it('should error and exit with code 1', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsCopyLayoutCommand,
+        commandArgs: ['-p', '2', '-f', 'Unknown', '-t', 'Support', '--force'],
+        api: [() => getTeamsValid()],
+        std: [
+          {
+            err: '× Source team "Unknown" not found in this project. Available: Operations, Support.',
+          },
+        ],
+        exitCode: 1,
+      }));
+  });
+
+  describe('when source and target are the same team', () => {
+    it('should error and exit with code 1', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsCopyLayoutCommand,
+        commandArgs: ['-p', '2', '-f', 'Operations', '-t', 'Operations', '--force'],
+        api: [() => getTeamsValid()],
+        std: [{ err: '× Source and target teams must be different.' }],
+        exitCode: 1,
+      }));
+  });
+});

--- a/test/commands/teams/copy-layout.test.js
+++ b/test/commands/teams/copy-layout.test.js
@@ -1,6 +1,13 @@
 const testCli = require('../test-cli-helper/test-cli');
 const TeamsCopyLayoutCommand = require('../../../src/commands/teams/copy-layout').default;
-const { getTeamsValid, postCopyTeamLayout, getJob, getJobFailed } = require('../../fixtures/api');
+const {
+  getTeamsValid,
+  postCopyTeamLayout,
+  postCopyTeamLayoutNoJob,
+  postCopyTeamLayoutError,
+  getJob,
+  getJobFailed,
+} = require('../../fixtures/api');
 const { testEnvWithoutSecret } = require('../../fixtures/env');
 
 describe('teams:copy-layout', () => {
@@ -57,6 +64,33 @@ describe('teams:copy-layout', () => {
       }));
   });
 
+  describe('when the user confirms the prompt', () => {
+    it('should copy the layout', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsCopyLayoutCommand,
+        commandArgs: ['-p', '2', '-f', 'Operations', '-t', 'Support'],
+        api: [() => getTeamsValid(), () => postCopyTeamLayout(), () => getJob()],
+        prompts: [
+          {
+            in: [
+              {
+                type: 'confirm',
+                name: 'confirm',
+                message:
+                  'This will overwrite the whole layout of team Support with the layout of Operations. Continue?',
+                default: false,
+              },
+            ],
+            out: { confirm: true },
+          },
+        ],
+        assertNoStdError: false,
+        std: [{ out: 'Layout of team "Operations" copied to "Support" on project 2.' }],
+      }));
+  });
+
   describe('when the source team does not exist', () => {
     it('should error and exit with code 1', () =>
       testCli({
@@ -83,6 +117,51 @@ describe('teams:copy-layout', () => {
         commandArgs: ['-p', '2', '-f', 'Operations', '-t', 'Operations', '--force'],
         api: [() => getTeamsValid()],
         std: [{ err: '× Source and target teams must be different.' }],
+        exitCode: 1,
+      }));
+  });
+
+  describe('when the target team does not exist', () => {
+    it('should error and exit with code 1', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsCopyLayoutCommand,
+        commandArgs: ['-p', '2', '-f', 'Operations', '-t', 'Unknown', '--force'],
+        api: [() => getTeamsValid()],
+        std: [
+          {
+            err: '× Target team "Unknown" not found in this project. Available: Operations, Support.',
+          },
+        ],
+        exitCode: 1,
+      }));
+  });
+
+  describe('when the deployment request returns no job', () => {
+    it('should report a failure and exit with code 1', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsCopyLayoutCommand,
+        commandArgs: ['-p', '2', '-f', 'Operations', '-t', 'Support', '--force'],
+        api: [() => getTeamsValid(), () => postCopyTeamLayoutNoJob()],
+        assertNoStdError: false,
+        std: [{ err: '× Oops, something went wrong.' }],
+        exitCode: 1,
+      }));
+  });
+
+  describe('when the server rejects the deployment request', () => {
+    it('should surface the server error detail and exit with code 1', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: TeamsCopyLayoutCommand,
+        commandArgs: ['-p', '2', '-f', 'Operations', '-t', 'Support', '--force'],
+        api: [() => getTeamsValid(), () => postCopyTeamLayoutError()],
+        assertNoStdError: false,
+        std: [{ err: '× Source team no longer exists.' }],
         exitCode: 1,
       }));
   });

--- a/test/fixtures/api.js
+++ b/test/fixtures/api.js
@@ -605,6 +605,28 @@ module.exports = {
       .matchHeader('forest-project-id', String(projectId))
       .reply(200, { meta: { job_id: 78 } }),
 
+  postCopyTeamLayoutNoJob: (projectId = 2) =>
+    nock('http://localhost:3001')
+      .post('/api/deployment-requests', {
+        data: {
+          type: 'deployment-requests',
+          attributes: { type: 'team', from: 7, to: 8 },
+        },
+      })
+      .matchHeader('forest-project-id', String(projectId))
+      .reply(200, {}),
+
+  postCopyTeamLayoutError: (projectId = 2) =>
+    nock('http://localhost:3001')
+      .post('/api/deployment-requests', {
+        data: {
+          type: 'deployment-requests',
+          attributes: { type: 'team', from: 7, to: 8 },
+        },
+      })
+      .matchHeader('forest-project-id', String(projectId))
+      .reply(404, { errors: [{ detail: 'Source team no longer exists.' }] }),
+
   getRolesValid: () =>
     nock('http://localhost:3001')
       .get('/api/projects/2/roles')

--- a/test/fixtures/api.js
+++ b/test/fixtures/api.js
@@ -594,6 +594,17 @@ module.exports = {
   getTeamsEmpty: () =>
     nock('http://localhost:3001').get('/api/projects/2/teams').reply(200, { data: [] }),
 
+  postCopyTeamLayout: (projectId = 2) =>
+    nock('http://localhost:3001')
+      .post('/api/deployment-requests', {
+        data: {
+          type: 'deployment-requests',
+          attributes: { type: 'team', from: 7, to: 8 },
+        },
+      })
+      .matchHeader('forest-project-id', String(projectId))
+      .reply(200, { meta: { job_id: 78 } }),
+
   getRolesValid: () =>
     nock('http://localhost:3001')
       .get('/api/projects/2/roles')


### PR DESCRIPTION
## What

Adds `forest teams:copy-layout -f <team> -t <team> [-p <projectId>] [--force]` (PRD-586 / PRD-584) — replicate a team's whole layout onto another team of the same project, headlessly.

```
forest teams:copy-layout --from "Operations" --to "Support"
forest teams:copy-layout -f "Operations" -t "Support" -p 132019 --force
```

## How

- **`TeamManager.copyLayout`** — `POST /api/deployment-requests` with `attributes.type: "team"` and integer `from`/`to` team ids, then polls the job via `JobStateChecker` until completion (`meta.job_id`). This revives the async pattern of the **removed** `environments:copy-layout` command (#606), retargeted at teams.
- Resolves both teams by name via `listForProject`; clear *Source/Target team not found* errors listing available names; guards against `from == to`.
- **Destructive-action guard**: confirm prompt (the target's layout is overwritten), skippable with `--force`.
- **Server-error handling**: the synchronous deployment-request POST is wrapped in the same `surfaceApiError` pattern as `teams:create`/`teams:delete` — a server error (e.g. a team deleted between resolution and the POST) prints the JSON:API `errors[0].detail` and exits 1, while 401/403 flow to the base auth handler. A 2xx response missing `meta.job_id`, or a job that ends `failed`, exits 1 with a generic message.
- `projectId` resolved via `withCurrentProject` (`-p` optional).

## ⚠️ Spec divergence: no `--env`

PRD-584 lists a `--env <env>` flag, but I verified there is **no server contract for it**:
- `deployment-requests` validator accepts only `{ type, from, to }`.
- `copy-layout-service.copyTeamLayout(userId, fromTeamId, toTeamId)` takes **no environment**.
- The deserializer for `type: "team"` resolves teams by id only.

The "same project" rule is enforced **server-side** (`Cannot copy layout between teams from different projects`) and implicitly by resolving both teams within one project. The ticket's acceptance criteria don't mention `--env` either, so this is implemented **without** it. Confirmed with the ticket author before shipping.

## Acceptance criteria (PRD-584)

- [x] `--projectId` (`-p`) optional — resolved via `withCurrentProject`
- [x] Resolves both teams by name → their ids
- [x] Launches the copy job + waits for completion
- [x] Clear error when a team is not found (source/target) — same-project enforced server-side
- [x] (n/a) `--env` — no server equivalent, see above

## Tests

- Command-level tests: completed job (success), failed job (exit 1), prompt **decline** (`Aborted.`), prompt **accept** (success via prompt, no `--force`), source-not-found, **target-not-found**, same-team guard, **2xx without `job_id`** (generic failure), and **server rejection** (detail surfaced) — all exit 1 where expected. `postCopyTeamLayout` / `postCopyTeamLayoutNoJob` / `postCopyTeamLayoutError` fixtures added; reuses `getJob` / `getJobFailed`. **9/9 green**.
- **Tested manually** against the development environment (project 2): created a throwaway target team, `copy-layout -f Operations -t tmp-copy-target` → confirm prompt → progress bar to 100% → `Layout of team "Operations" copied to "tmp-copy-target" on project 2.`; verified the same-team and source-not-found guards; cleaned up via `teams:delete`.

## Definition of Done

- [x] Conventional Commits title
- [x] Tested manually
- [x] Code quality (mirrors the removed env copy-layout async pattern + the teams family)
- [x] Security: destructive copy gated behind name resolution + confirm prompt unless `--force`; same-project enforced server-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `teams:copy-layout` CLI command to copy a team's layout to another team
> - Adds a new `teams:copy-layout` command in [`src/commands/teams/copy-layout.ts`](https://github.com/ForestAdmin/toolbelt/pull/793/files#diff-c9bc2c8d002900ada9689237add3becd1292cd4e95e62b049c6462893bc80e05) with `--from`, `--to`, `--projectId`, and `--force` flags; resolves teams by name and exits with code 1 if a team is not found or source and target are the same.
> - Adds `TeamManager.copyLayout` in [`src/services/team-manager.js`](https://github.com/ForestAdmin/toolbelt/pull/793/files#diff-7083afebe926c101165a5a4bd58e5f3528e9eca5990974175bd3f4dbb6da1019) which POSTs to `/api/deployment-requests` and polls job completion via `JobStateChecker`, returning a boolean indicating success.
> - Without `--force`, the command prompts for confirmation before initiating the copy job.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b702663.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

