### PR TITLE
feat(layout): add `forest layout patch` command

### DIFF
--- a/src/commands/layout/patch.ts
+++ b/src/commands/layout/patch.ts
@@ -1,0 +1,235 @@
+import type { LayoutDomain, PlannedOp } from '../../services/layout/types';
+import type { Config } from '@oclif/core';
+
+import { Args, Flags } from '@oclif/core';
+import { readFile } from 'fs/promises';
+import path from 'path';
+
+import AbstractAuthenticatedCommand from '../../abstract-authenticated-command';
+import { LayoutApiError } from '../../services/layout/errors';
+import LayoutManager from '../../services/layout/layout-manager';
+import { matchesWhitelist } from '../../services/layout/patch-rules';
+import { explainApiError } from '../../services/layout/plan-format';
+import { resolveCommandScope } from '../../services/layout/resolve-command-scope';
+
+/**
+ * Domains this command accepts. Scoped to the layout-only domains on purpose:
+ * `workflows` is deferred because creating a workflow is not a single layout
+ * PATCH — it also needs a BPMN upload to S3 (use `forest layout apply` for that).
+ */
+const PATCH_DOMAINS: Array<Exclude<LayoutDomain, 'workflows'>> = ['layout', 'folders'];
+
+type RawOp = { op: string; path: string; value?: unknown };
+type PatchInput = Partial<Record<LayoutDomain, RawOp[]>>;
+
+const OP_PREFIX: Record<string, string> = { add: '+', remove: '-', replace: '~' };
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', chunk => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+async function readRawInput(filePath: string | undefined): Promise<string> {
+  if (!filePath || filePath === '-') {
+    if (process.stdin.isTTY) {
+      throw new Error(
+        'No input provided. Pass a JSON file or pipe the patch via stdin.\n' +
+          '  Example: forest layout patch ops.json --env Production\n' +
+          '  Example: echo \'{"layout":[...]}\' | forest layout patch --env Production',
+      );
+    }
+
+    return readStdin();
+  }
+
+  return readFile(path.resolve(process.cwd(), filePath), 'utf8');
+}
+
+async function readInput(filePath: string | undefined): Promise<PatchInput> {
+  const raw = await readRawInput(filePath);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('Invalid JSON: could not parse the patch input.');
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(
+      'Invalid patch input: expected a JSON object with domain keys (e.g. {"layout": [...], "folders": [...]}).',
+    );
+  }
+
+  return parsed as PatchInput;
+}
+
+export function toPlannedOps(
+  domain: Exclude<LayoutDomain, 'workflows'>,
+  rawOps: RawOp[],
+): PlannedOp[] {
+  return rawOps.map((raw, i) => {
+    if (!['add', 'replace', 'remove', 'test'].includes(raw.op)) {
+      throw new Error(`[${domain}][${i}]: unknown op "${raw.op}".`);
+    }
+    if (typeof raw.path !== 'string' || !raw.path.startsWith('/')) {
+      throw new Error(`[${domain}][${i}]: path must be a string starting with "/".`);
+    }
+    if (!matchesWhitelist(domain, raw)) {
+      throw new Error(
+        `[${domain}][${i}]: path "${raw.path}" is not allowed by the server whitelist.`,
+      );
+    }
+
+    return {
+      domain,
+      jsonPath: raw.path,
+      label: `${raw.op} ${raw.path}`,
+      op: raw.op as PlannedOp['op'],
+      path: raw.path,
+      value: raw.value,
+    };
+  });
+}
+
+export function buildAllOps(input: PatchInput): PlannedOp[] {
+  if (input.workflows !== undefined) {
+    throw new Error(
+      'The "workflows" domain is not supported by `forest layout patch`: creating a workflow ' +
+        'also needs a BPMN upload, not just a layout PATCH. Use `forest layout apply` for workflows.',
+    );
+  }
+
+  return PATCH_DOMAINS.flatMap(domain => {
+    const rawOps = input[domain];
+    if (!rawOps) return [];
+    if (!Array.isArray(rawOps)) {
+      throw new Error(`"${domain}" must be an array of patch operations.`);
+    }
+
+    return toPlannedOps(domain, rawOps);
+  });
+}
+
+export function formatOps(allOps: PlannedOp[]): string {
+  return PATCH_DOMAINS.flatMap(domain => {
+    const domainOps = allOps.filter(op => op.domain === domain);
+    if (domainOps.length === 0) return [];
+
+    return [
+      `${domain} (${domainOps.length} op${domainOps.length > 1 ? 's' : ''})`,
+      ...domainOps.map(op => `  ${OP_PREFIX[op.op] ?? '·'} ${op.label}`),
+    ];
+  }).join('\n');
+}
+
+/**
+ * `forest layout patch` — send a JSON-Patch array straight to the environment,
+ * exactly like the frontend does when you tweak a collection: a single
+ * `PATCH /api/:domain` per domain, no `pull`/`diff`/`apply` round-trip.
+ *
+ * Scope: the layout-only domains (`layout`, `folders`). `workflows` is out of
+ * scope here — see {@link buildAllOps}.
+ *
+ * Input format (file or stdin):
+ * {
+ *   "layout":  [{ "op": "replace", "path": "/collections/orders/displayName", "value": "Orders" }],
+ *   "folders": [{ "op": "add",     "path": "/folders/<mainId>/children/-",     "value": {...} }]
+ * }
+ */
+export default class LayoutPatchCommand extends AbstractAuthenticatedCommand {
+  private readonly env: { FOREST_SERVER_URL: string } & Record<string, unknown>;
+
+  static override args = {
+    file: Args.string({
+      description: 'JSON patch file to apply. Use "-" or omit to read from stdin.',
+      required: false,
+    }),
+  };
+
+  static override description =
+    'Patch the layout directly (single PATCH per domain, like the front — no pull/apply).';
+
+  static override flags = {
+    'dry-run': Flags.boolean({
+      description: 'Print operations without sending them.',
+    }),
+    env: Flags.string({
+      char: 'e',
+      description: 'Environment name or id.',
+    }),
+    projectId: Flags.integer({
+      char: 'p',
+      description: 'Project id.',
+    }),
+    team: Flags.string({
+      char: 't',
+      description: 'Team name or id.',
+    }),
+  };
+
+  constructor(argv: string[], config: Config, plan?) {
+    super(argv, config, plan);
+    const { assertPresent, env } = this.context;
+    assertPresent({ env });
+    this.env = env;
+  }
+
+  protected async runAuthenticated(): Promise<void> {
+    const { args, flags } = await this.parse(LayoutPatchCommand);
+
+    const allOps = buildAllOps(await readInput(args.file));
+
+    if (allOps.length === 0) {
+      this.logger.success('Nothing to patch: input contains no operations.');
+      return;
+    }
+
+    if (flags['dry-run']) {
+      this.log(formatOps(allOps));
+      this.log('\n(dry-run: nothing sent)');
+      return;
+    }
+
+    const scope = await resolveCommandScope({
+      baseEnv: this.env,
+      flags: { env: flags.env, projectId: flags.projectId, team: flags.team },
+    });
+
+    this.log(formatOps(allOps));
+
+    const manager = new LayoutManager();
+
+    // eslint-disable-next-line no-restricted-syntax -- sequential: one atomic PATCH per domain
+    for (const domain of PATCH_DOMAINS) {
+      const domainOps = allOps.filter(op => op.domain === domain);
+      if (domainOps.length === 0) continue; // eslint-disable-line no-continue
+
+      try {
+        // eslint-disable-next-line no-await-in-loop -- intentional: atomic, ordered per-domain patches
+        await manager.patchDomain(domain, domainOps, scope);
+      } catch (error) {
+        if (error instanceof LayoutApiError && error.status !== 401) {
+          // Scope the error to this domain so path correlation in explainApiError is accurate.
+          this.logger.error(explainApiError(error, domainOps));
+          this.exit(2);
+        }
+
+        throw error;
+      }
+    }
+
+    this.logger.success(
+      `Patched ${allOps.length} op${allOps.length > 1 ? 's' : ''} on ${this.chalk.bold(
+        scope.environmentName,
+      )} / ${this.chalk.bold(scope.teamName)}.`,
+    );
+  }
+}

--- a/test/commands/layout/patch.unit.test.ts
+++ b/test/commands/layout/patch.unit.test.ts
@@ -1,0 +1,103 @@
+import { buildAllOps, formatOps, toPlannedOps } from '../../../src/commands/layout/patch';
+
+describe('toPlannedOps', () => {
+  it('accepts a valid add op', () => {
+    expect.assertions(4);
+    const ops = toPlannedOps('layout', [
+      {
+        op: 'add',
+        path: '/collections/orders/layout/segments/-',
+        value: { id: 'seg1', name: 'VIP' },
+      },
+    ]);
+    expect(ops).toHaveLength(1);
+    expect(ops[0].op).toBe('add');
+    expect(ops[0].domain).toBe('layout');
+    expect(ops[0].jsonPath).toBe('/collections/orders/layout/segments/-');
+  });
+
+  it('accepts a valid replace op', () => {
+    expect.assertions(2);
+    const ops = toPlannedOps('layout', [
+      { op: 'replace', path: '/collections/orders/displayName', value: 'Orders v2' },
+    ]);
+    expect(ops[0].op).toBe('replace');
+    expect(ops[0].label).toBe('replace /collections/orders/displayName');
+  });
+
+  it('rejects an unknown op type', () => {
+    expect.assertions(1);
+    expect(() =>
+      toPlannedOps('layout', [{ op: 'upsert', path: '/collections/orders/displayName' }]),
+    ).toThrow(/unknown op "upsert"/);
+  });
+
+  it('rejects a path that does not start with "/"', () => {
+    expect.assertions(1);
+    expect(() =>
+      toPlannedOps('layout', [{ op: 'replace', path: 'collections/orders/displayName' }]),
+    ).toThrow(/path must be a string starting with/);
+  });
+
+  it('rejects a path outside the server whitelist', () => {
+    expect.assertions(1);
+    expect(() =>
+      toPlannedOps('layout', [
+        { op: 'replace', path: '/collections/orders/__internal__', value: 'x' },
+      ]),
+    ).toThrow(/not allowed by the server whitelist/);
+  });
+});
+
+describe('buildAllOps', () => {
+  it('collects ops from layout and folders in domain order', () => {
+    expect.assertions(3);
+    const ops = buildAllOps({
+      folders: [{ op: 'add', path: '/folders/12/children/-', value: { id: 'f1', name: 'Sales' } }],
+      layout: [{ op: 'replace', path: '/collections/orders/displayName', value: 'Orders v2' }],
+    });
+    expect(ops).toHaveLength(2);
+    expect(ops[0].domain).toBe('layout');
+    expect(ops[1].domain).toBe('folders');
+  });
+
+  it('returns an empty array when input has no ops', () => {
+    expect.assertions(1);
+    expect(buildAllOps({})).toHaveLength(0);
+  });
+
+  it('throws when a domain value is not an array', () => {
+    expect.assertions(1);
+    expect(() =>
+      buildAllOps({ layout: 'bad' as unknown as Array<{ op: string; path: string }> }),
+    ).toThrow(/"layout" must be an array/);
+  });
+
+  it('rejects the workflows domain (deferred to apply)', () => {
+    expect.assertions(1);
+    expect(() =>
+      buildAllOps({ workflows: [{ op: 'replace', path: '/workflows/42/isVisible', value: true }] }),
+    ).toThrow(/"workflows" domain is not supported/);
+  });
+});
+
+describe('formatOps', () => {
+  it('groups ops by domain with a singular count', () => {
+    expect.assertions(1);
+    const ops = buildAllOps({
+      layout: [{ op: 'replace', path: '/collections/orders/displayName', value: 'Orders v2' }],
+    });
+    expect(formatOps(ops)).toContain('layout (1 op)');
+  });
+
+  it('uses plural for multiple ops', () => {
+    expect.assertions(1);
+    const ops = buildAllOps({
+      layout: [
+        { op: 'replace', path: '/collections/orders/displayName', value: 'A' },
+        { op: 'replace', path: '/collections/orders/icon', value: 'truck' },
+      ],
+    });
+    expect(formatOps(ops)).toContain('layout (2 ops)');
+  });
+});


### PR DESCRIPTION
## What
Adds `forest layout patch` — apply a JSON-Patch directly to a layout (one PATCH per domain, mirroring the front-end), instead of the `pull → edit → apply` round-trip.

## Why
For programmatic / agent-driven layout edits where the exact ops are already known, a direct patch is simpler and atomic per domain. Complements the existing `layout pull` / `layout apply`.

## How
- reads ops from a file arg or stdin (`-`)
- validates op type + path against the server whitelist (`patch-rules`)
- `--dry-run` prints the planned ops without sending anything
- scope via `-e/--env`, `-p/--projectId`, `-t/--team` (`resolveCommandScope`)
- `workflows` domain intentionally deferred to `layout apply` (creating a workflow needs a BPMN S3 upload, not a single layout PATCH)

## Tests
- 11 unit tests (`toPlannedOps` / `buildAllOps` / `formatOps`): op validation, whitelist rejection, per-domain ordering, workflows-deferred — all green.
- `eslint` + `tsc --noEmit` clean.

## Notes
- Command is auto-discovered by oclif (`src/commands/layout/patch.ts` → `forest layout patch`); `oclif.manifest.json` and the README command list are regenerated at pack time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `forest layout patch` CLI command for applying JSON patches to layout domains
> - Adds a new authenticated `layout patch` command in [patch.ts](https://github.com/ForestAdmin/toolbelt/pull/795/files#diff-2957a72e606bfe75fd4b36f7a745fffa83bff16698a0912f488937fce57f11aa) that reads a JSON patch file (or stdin) and applies it per-domain via `LayoutManager.patchDomain`.
> - Validates input shape, op types, and path prefixes against a server-side whitelist before executing; supports `--dry-run` to preview planned operations without applying them.
> - Supports `layout` and `folders` domains (rejects `workflows`); executes domain patches sequentially and reports scoped errors with exit code 2 on non-401 API failures.
> - Unit tests cover `toPlannedOps`, `buildAllOps`, and `formatOps` edge cases including unknown ops, bad paths, whitelist rejection, and domain ordering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0396a03.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->