### PR TITLE
feat(layout): add `forest layout patch` command

### DIFF
--- a/src/commands/layout/patch.ts
+++ b/src/commands/layout/patch.ts
@@ -25,15 +25,37 @@ type PatchInput = Partial<Record<LayoutDomain, RawOp[]>>;
 
 const OP_PREFIX: Record<string, string> = { add: '+', remove: '-', replace: '~' };
 
+const STDIN_FIRST_BYTE_TIMEOUT_MS = 10_000;
+
 function readStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
     let data = '';
+    // In a spawned process with an open-but-silent stdin, `isTTY` is undefined
+    // and `end` never fires (oclif's own parser defends against the same hang):
+    // give the FIRST byte a deadline, then let a slow-but-real pipe stream for
+    // as long as it needs.
+    const timeout = setTimeout(() => {
+      reject(
+        new Error(
+          `No data received on stdin after ${STDIN_FIRST_BYTE_TIMEOUT_MS / 1000}s. ` +
+            'Pass a JSON file argument, or pipe the patch via stdin.',
+        ),
+      );
+    }, STDIN_FIRST_BYTE_TIMEOUT_MS);
+
     process.stdin.setEncoding('utf8');
     process.stdin.on('data', chunk => {
+      clearTimeout(timeout);
       data += chunk;
     });
-    process.stdin.on('end', () => resolve(data));
-    process.stdin.on('error', reject);
+    process.stdin.on('end', () => {
+      clearTimeout(timeout);
+      resolve(data);
+    });
+    process.stdin.on('error', error => {
+      clearTimeout(timeout);
+      reject(error);
+    });
   });
 }
 
@@ -42,8 +64,8 @@ async function readRawInput(filePath: string | undefined): Promise<string> {
     if (process.stdin.isTTY) {
       throw new Error(
         'No input provided. Pass a JSON file or pipe the patch via stdin.\n' +
-          '  Example: forest layout patch ops.json --env Production\n' +
-          '  Example: echo \'{"layout":[...]}\' | forest layout patch --force -p 42 -e Production -t Operations',
+          '  Example: forest layout:patch ops.json --env Production\n' +
+          '  Example: echo \'{"layout":[...]}\' | forest layout:patch --force -p 42 -e Production -t Operations',
       );
     }
 
@@ -139,10 +161,11 @@ export function buildAllOps(input: PatchInput): PlannedOp[] {
 }
 
 /**
- * Piped input consumes stdin, so no inquirer prompt (project, environment,
- * team, confirmation) can run afterwards: it would read from an already-closed
- * pipe and hang or crash. Stdin mode therefore requires the full scope and
- * `--force` up front — fail fast, listing exactly what is missing.
+ * When stdin is not an interactive terminal — the patch is piped, or the
+ * command runs in CI / spawned by an agent, even with a file argument — no
+ * inquirer prompt (project, environment, team, confirmation) can run: it would
+ * read from a pipe and hang or crash. Non-TTY runs therefore require the full
+ * scope and `--force` up front — fail fast, listing exactly what is missing.
  *
  * `FOREST_ENV_SECRET` only stands in for `-p/--projectId`: scope resolution
  * derives the project from the secret (`withCurrentProject`) but NEVER the
@@ -160,7 +183,7 @@ export function assertNonInteractiveFlags(
 
   if (missing.length > 0) {
     throw new Error(
-      'Reading the patch from stdin consumes the interactive input, so prompts ' +
+      'stdin is not an interactive terminal, so prompts ' +
         `(project, environment, team, confirmation) cannot run. Missing: ${missing.join(', ')}. ` +
         'Set FOREST_ENV_SECRET to omit -p/--projectId, or use --dry-run to preview without a scope.',
     );
@@ -193,8 +216,9 @@ export function formatOps(allOps: PlannedOp[]): string {
  *   "folders": [{ "op": "add",     "path": "/folders/<mainId>/children/-",     "value": {...} }]
  * }
  *
- * Stdin mode is non-interactive by construction (the pipe IS the input): it
- * requires the full scope flags and `--force` — see {@link assertNonInteractiveFlags}.
+ * Any non-TTY run (piped input, CI, spawned by an agent) is non-interactive by
+ * construction: it requires the full scope flags and `--force` — see
+ * {@link assertNonInteractiveFlags}.
  */
 export default class LayoutPatchCommand extends AbstractAuthenticatedCommand {
   private readonly env: { FOREST_SERVER_URL: string } & Record<string, unknown>;
@@ -248,8 +272,10 @@ export default class LayoutPatchCommand extends AbstractAuthenticatedCommand {
   protected async runAuthenticated(): Promise<void> {
     const { args, flags } = await this.parse(LayoutPatchCommand);
 
-    const fromStdin = !args.file || args.file === '-';
-    if (fromStdin && !flags['dry-run']) {
+    // No TTY on stdin ⇒ no prompt can run (scope or confirmation) — whether the
+    // patch is piped or read from a file argument in CI. `--dry-run` is exempt:
+    // it neither prompts nor sends.
+    if (!process.stdin.isTTY && !flags['dry-run']) {
       assertNonInteractiveFlags(flags, Boolean(this.env.FOREST_ENV_SECRET));
     }
 

--- a/src/commands/layout/patch.ts
+++ b/src/commands/layout/patch.ts
@@ -143,16 +143,18 @@ export function buildAllOps(input: PatchInput): PlannedOp[] {
  * team, confirmation) can run afterwards: it would read from an already-closed
  * pipe and hang or crash. Stdin mode therefore requires the full scope and
  * `--force` up front — fail fast, listing exactly what is missing.
+ *
+ * `FOREST_ENV_SECRET` only stands in for `-p/--projectId`: scope resolution
+ * derives the project from the secret (`withCurrentProject`) but NEVER the
+ * environment — without `-e/--env` it would still prompt.
  */
 export function assertNonInteractiveFlags(
   flags: { env?: string; force?: boolean; projectId?: number; team?: string },
   hasEnvSecret: boolean,
 ): void {
   const missing: string[] = [];
-  if (!hasEnvSecret) {
-    if (!flags.env) missing.push('-e/--env');
-    if (flags.projectId === undefined) missing.push('-p/--projectId');
-  }
+  if (!flags.env) missing.push('-e/--env');
+  if (!hasEnvSecret && flags.projectId === undefined) missing.push('-p/--projectId');
   if (!flags.team) missing.push('-t/--team');
   if (!flags.force) missing.push('--force');
 
@@ -160,7 +162,7 @@ export function assertNonInteractiveFlags(
     throw new Error(
       'Reading the patch from stdin consumes the interactive input, so prompts ' +
         `(project, environment, team, confirmation) cannot run. Missing: ${missing.join(', ')}. ` +
-        'Set FOREST_ENV_SECRET to omit -e/-p, or use --dry-run to preview without a scope.',
+        'Set FOREST_ENV_SECRET to omit -p/--projectId, or use --dry-run to preview without a scope.',
     );
   }
 }

--- a/src/commands/layout/patch.ts
+++ b/src/commands/layout/patch.ts
@@ -86,6 +86,12 @@ export function toPlannedOps(
     if (typeof raw.path !== 'string' || !raw.path.startsWith('/')) {
       throw new Error(`[${domain}][${i}]: path must be a string starting with "/".`);
     }
+    if (
+      (raw.op === 'add' || raw.op === 'replace' || raw.op === 'test') &&
+      raw.value === undefined
+    ) {
+      throw new Error(`[${domain}][${i}]: op "${raw.op}" requires a "value" field.`);
+    }
     if (!matchesWhitelist(domain, raw)) {
       throw new Error(
         `[${domain}][${i}]: path "${raw.path}" is not allowed by the server whitelist.`,

--- a/src/commands/layout/patch.ts
+++ b/src/commands/layout/patch.ts
@@ -1,0 +1,235 @@
+import type { LayoutDomain, PlannedOp } from '../../services/layout/types';
+import type { Config } from '@oclif/core';
+
+import { Args, Flags } from '@oclif/core';
+import { readFile } from 'fs/promises';
+import path from 'path';
+
+import AbstractAuthenticatedCommand from '../../abstract-authenticated-command';
+import { LayoutApiError } from '../../services/layout/errors';
+import LayoutManager from '../../services/layout/layout-manager';
+import { matchesWhitelist } from '../../services/layout/patch-rules';
+import { explainApiError } from '../../services/layout/plan-format';
+import { resolveCommandScope } from '../../services/layout/resolve-command-scope';
+
+/**
+ * Domains this command accepts. Scoped to the layout-only domains on purpose:
+ * `workflows` is deferred because creating a workflow is not a single layout
+ * PATCH — it also needs a BPMN upload to S3 (use `forest layout apply` for that).
+ */
+const PATCH_DOMAINS: Array<Exclude<LayoutDomain, 'workflows'>> = ['layout', 'folders'];
+
+type RawOp = { op: string; path: string; value?: unknown };
+type PatchInput = Partial<Record<LayoutDomain, RawOp[]>>;
+
+const OP_PREFIX: Record<string, string> = { add: '+', remove: '-', replace: '~' };
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', chunk => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+async function readRawInput(filePath: string | undefined): Promise<string> {
+  if (!filePath || filePath === '-') {
+    if (process.stdin.isTTY) {
+      throw new Error(
+        'No input provided. Pass a JSON file or pipe the patch via stdin.\n' +
+          '  Example: forest layout patch ops.json --env Production\n' +
+          '  Example: echo \'{"layout":[...]}\' | forest layout patch --env Production',
+      );
+    }
+
+    return readStdin();
+  }
+
+  return readFile(path.resolve(process.cwd(), filePath), 'utf8');
+}
+
+async function readInput(filePath: string | undefined): Promise<PatchInput> {
+  const raw = await readRawInput(filePath);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('Invalid JSON: could not parse the patch input.');
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(
+      'Invalid patch input: expected a JSON object with domain keys (e.g. {"layout": [...], "folders": [...]}).',
+    );
+  }
+
+  return parsed as PatchInput;
+}
+
+export function toPlannedOps(
+  domain: Exclude<LayoutDomain, 'workflows'>,
+  rawOps: RawOp[],
+): PlannedOp[] {
+  return rawOps.map((raw, i) => {
+    if (!['add', 'replace', 'remove', 'test'].includes(raw.op)) {
+      throw new Error(`[${domain}][${i}]: unknown op "${raw.op}".`);
+    }
+    if (typeof raw.path !== 'string' || !raw.path.startsWith('/')) {
+      throw new Error(`[${domain}][${i}]: path must be a string starting with "/".`);
+    }
+    if (!matchesWhitelist(domain, raw)) {
+      throw new Error(
+        `[${domain}][${i}]: path "${raw.path}" is not allowed by the server whitelist.`,
+      );
+    }
+
+    return {
+      domain,
+      jsonPath: raw.path,
+      label: `${raw.op} ${raw.path}`,
+      op: raw.op as PlannedOp['op'],
+      path: raw.path,
+      value: raw.value,
+    };
+  });
+}
+
+export function buildAllOps(input: PatchInput): PlannedOp[] {
+  if (input.workflows !== undefined) {
+    throw new Error(
+      'The "workflows" domain is not supported by `forest layout patch`: creating a workflow ' +
+        'also needs a BPMN upload, not just a layout PATCH. Use `forest layout apply` for workflows.',
+    );
+  }
+
+  return PATCH_DOMAINS.flatMap(domain => {
+    const rawOps = input[domain];
+    if (!rawOps) return [];
+    if (!Array.isArray(rawOps)) {
+      throw new Error(`"${domain}" must be an array of patch operations.`);
+    }
+
+    return toPlannedOps(domain, rawOps);
+  });
+}
+
+export function formatOps(allOps: PlannedOp[]): string {
+  return PATCH_DOMAINS.flatMap(domain => {
+    const domainOps = allOps.filter(op => op.domain === domain);
+    if (domainOps.length === 0) return [];
+
+    return [
+      `${domain} (${domainOps.length} op${domainOps.length > 1 ? 's' : ''})`,
+      ...domainOps.map(op => `  ${OP_PREFIX[op.op] ?? '·'} ${op.label}`),
+    ];
+  }).join('\n');
+}
+
+/**
+ * `forest layout patch` — send a JSON-Patch array straight to the environment,
+ * exactly like the frontend does when you tweak a collection: a single
+ * `PATCH /api/:domain` per domain, no `pull`/`diff`/`apply` round-trip.
+ *
+ * Scope: the layout-only domains (`layout`, `folders`). `workflows` is out of
+ * scope here — see {@link buildAllOps}.
+ *
+ * Input format (file or stdin):
+ * {
+ *   "layout":  [{ "op": "replace", "path": "/collections/orders/displayName", "value": "Orders" }],
+ *   "folders": [{ "op": "add",     "path": "/folders/<mainId>/children/-",     "value": {...} }]
+ * }
+ */
+export default class LayoutPatchCommand extends AbstractAuthenticatedCommand {
+  private readonly env: { FOREST_SERVER_URL: string } & Record<string, unknown>;
+
+  static override args = {
+    file: Args.string({
+      description: 'JSON patch file to apply. Use "-" or omit to read from stdin.',
+      required: false,
+    }),
+  };
+
+  static override description =
+    'Patch the layout directly (single PATCH per domain, like the front — no pull/apply).';
+
+  static override flags = {
+    'dry-run': Flags.boolean({
+      description: 'Print operations without sending them.',
+    }),
+    env: Flags.string({
+      char: 'e',
+      description: 'Environment name or id.',
+    }),
+    projectId: Flags.integer({
+      char: 'p',
+      description: 'Project id.',
+    }),
+    team: Flags.string({
+      char: 't',
+      description: 'Team name or id.',
+    }),
+  };
+
+  constructor(argv: string[], config: Config, plan?) {
+    super(argv, config, plan);
+    const { assertPresent, env } = this.context;
+    assertPresent({ env });
+    this.env = env;
+  }
+
+  protected async runAuthenticated(): Promise<void> {
+    const { args, flags } = await this.parse(LayoutPatchCommand);
+
+    const allOps = buildAllOps(await readInput(args.file));
+
+    if (allOps.length === 0) {
+      this.logger.success('Nothing to patch: input contains no operations.');
+      return;
+    }
+
+    if (flags['dry-run']) {
+      this.log(formatOps(allOps));
+      this.log('\n(dry-run: nothing sent)');
+      return;
+    }
+
+    const scope = await resolveCommandScope({
+      baseEnv: this.env,
+      flags: { env: flags.env, projectId: flags.projectId, team: flags.team },
+    });
+
+    this.log(formatOps(allOps));
+
+    const manager = new LayoutManager();
+
+    // eslint-disable-next-line no-restricted-syntax -- sequential: one atomic PATCH per domain
+    for (const domain of PATCH_DOMAINS) {
+      const domainOps = allOps.filter(op => op.domain === domain);
+      if (domainOps.length === 0) continue; // eslint-disable-line no-continue
+
+      try {
+        // eslint-disable-next-line no-await-in-loop -- intentional: atomic, ordered per-domain patches
+        await manager.patchDomain(domain, domainOps, scope);
+      } catch (error) {
+        if (error instanceof LayoutApiError && error.status !== 401) {
+          // Scope the error to this domain so path correlation in explainApiError is accurate.
+          this.logger.error(explainApiError(error, domainOps));
+          this.exit(2);
+        }
+
+        throw error;
+      }
+    }
+
+    this.logger.success(
+      `Patched ${allOps.length} op${allOps.length > 1 ? 's' : ''} on ${this.chalk.bold(
+        scope.environmentName,
+      )} / ${this.chalk.bold(scope.teamName)}.`,
+    );
+  }
+}

--- a/src/commands/layout/patch.ts
+++ b/src/commands/layout/patch.ts
@@ -30,11 +30,24 @@ const STDIN_FIRST_BYTE_TIMEOUT_MS = 10_000;
 function readStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
     let data = '';
+    let timeout: ReturnType<typeof setTimeout>;
+
+    // Detach our listeners and release stdin on every exit path: a lingering
+    // flowing-mode listener would keep the event loop alive and hang the CLI.
+    const cleanup = () => {
+      clearTimeout(timeout);
+      process.stdin.removeAllListeners('data');
+      process.stdin.removeAllListeners('end');
+      process.stdin.removeAllListeners('error');
+      process.stdin.pause();
+    };
+
     // In a spawned process with an open-but-silent stdin, `isTTY` is undefined
     // and `end` never fires (oclif's own parser defends against the same hang):
     // give the FIRST byte a deadline, then let a slow-but-real pipe stream for
     // as long as it needs.
-    const timeout = setTimeout(() => {
+    timeout = setTimeout(() => {
+      cleanup();
       reject(
         new Error(
           `No data received on stdin after ${STDIN_FIRST_BYTE_TIMEOUT_MS / 1000}s. ` +
@@ -49,11 +62,11 @@ function readStdin(): Promise<string> {
       data += chunk;
     });
     process.stdin.on('end', () => {
-      clearTimeout(timeout);
+      cleanup();
       resolve(data);
     });
     process.stdin.on('error', error => {
-      clearTimeout(timeout);
+      cleanup();
       reject(error);
     });
   });

--- a/src/commands/layout/patch.ts
+++ b/src/commands/layout/patch.ts
@@ -204,6 +204,10 @@ export default class LayoutPatchCommand extends AbstractAuthenticatedCommand {
   static override args = {
     file: Args.string({
       description: 'JSON patch file to apply. Use "-" or omit to read from stdin.',
+      // Without this, oclif fills a missing positional FROM stdin (parser/parse.js),
+      // so `echo '{...}' | forest layout patch` would readFile() the JSON as a filename.
+      // Stdin must stay untouched for our own reader (multi-line JSON, explicit guard).
+      ignoreStdin: true,
       required: false,
     }),
   };

--- a/src/commands/layout/patch.ts
+++ b/src/commands/layout/patch.ts
@@ -11,6 +11,7 @@ import LayoutManager from '../../services/layout/layout-manager';
 import { matchesWhitelist } from '../../services/layout/patch-rules';
 import { explainApiError } from '../../services/layout/plan-format';
 import { resolveCommandScope } from '../../services/layout/resolve-command-scope';
+import { LAYOUT_DOMAINS } from '../../services/layout/types';
 
 /**
  * Domains this command accepts. Scoped to the layout-only domains on purpose:
@@ -76,6 +77,9 @@ export function toPlannedOps(
   rawOps: RawOp[],
 ): PlannedOp[] {
   return rawOps.map((raw, i) => {
+    if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+      throw new Error(`[${domain}][${i}]: each operation must be a JSON object.`);
+    }
     if (!['add', 'replace', 'remove', 'test'].includes(raw.op)) {
       throw new Error(`[${domain}][${i}]: unknown op "${raw.op}".`);
     }
@@ -100,6 +104,16 @@ export function toPlannedOps(
 }
 
 export function buildAllOps(input: PatchInput): PlannedOp[] {
+  const unknownDomains = Object.keys(input).filter(
+    key => !LAYOUT_DOMAINS.includes(key as LayoutDomain),
+  );
+  if (unknownDomains.length > 0) {
+    throw new Error(
+      `Unknown domain key${unknownDomains.length > 1 ? 's' : ''}: ${unknownDomains.join(', ')}. ` +
+        `Supported domains are: ${PATCH_DOMAINS.join(', ')}.`,
+    );
+  }
+
   if (input.workflows !== undefined) {
     throw new Error(
       'The "workflows" domain is not supported by `forest layout patch`: creating a workflow ' +

--- a/src/commands/layout/patch.ts
+++ b/src/commands/layout/patch.ts
@@ -43,7 +43,7 @@ async function readRawInput(filePath: string | undefined): Promise<string> {
       throw new Error(
         'No input provided. Pass a JSON file or pipe the patch via stdin.\n' +
           '  Example: forest layout patch ops.json --env Production\n' +
-          '  Example: echo \'{"layout":[...]}\' | forest layout patch --env Production',
+          '  Example: echo \'{"layout":[...]}\' | forest layout patch --force -p 42 -e Production -t Operations',
       );
     }
 
@@ -138,6 +138,33 @@ export function buildAllOps(input: PatchInput): PlannedOp[] {
   });
 }
 
+/**
+ * Piped input consumes stdin, so no inquirer prompt (project, environment,
+ * team, confirmation) can run afterwards: it would read from an already-closed
+ * pipe and hang or crash. Stdin mode therefore requires the full scope and
+ * `--force` up front — fail fast, listing exactly what is missing.
+ */
+export function assertNonInteractiveFlags(
+  flags: { env?: string; force?: boolean; projectId?: number; team?: string },
+  hasEnvSecret: boolean,
+): void {
+  const missing: string[] = [];
+  if (!hasEnvSecret) {
+    if (!flags.env) missing.push('-e/--env');
+    if (flags.projectId === undefined) missing.push('-p/--projectId');
+  }
+  if (!flags.team) missing.push('-t/--team');
+  if (!flags.force) missing.push('--force');
+
+  if (missing.length > 0) {
+    throw new Error(
+      'Reading the patch from stdin consumes the interactive input, so prompts ' +
+        `(project, environment, team, confirmation) cannot run. Missing: ${missing.join(', ')}. ` +
+        'Set FOREST_ENV_SECRET to omit -e/-p, or use --dry-run to preview without a scope.',
+    );
+  }
+}
+
 export function formatOps(allOps: PlannedOp[]): string {
   return PATCH_DOMAINS.flatMap(domain => {
     const domainOps = allOps.filter(op => op.domain === domain);
@@ -163,9 +190,14 @@ export function formatOps(allOps: PlannedOp[]): string {
  *   "layout":  [{ "op": "replace", "path": "/collections/orders/displayName", "value": "Orders" }],
  *   "folders": [{ "op": "add",     "path": "/folders/<mainId>/children/-",     "value": {...} }]
  * }
+ *
+ * Stdin mode is non-interactive by construction (the pipe IS the input): it
+ * requires the full scope flags and `--force` — see {@link assertNonInteractiveFlags}.
  */
 export default class LayoutPatchCommand extends AbstractAuthenticatedCommand {
   private readonly env: { FOREST_SERVER_URL: string } & Record<string, unknown>;
+
+  private readonly inquirer: { prompt(questions: unknown): Promise<{ confirm: boolean }> };
 
   static override args = {
     file: Args.string({
@@ -185,6 +217,10 @@ export default class LayoutPatchCommand extends AbstractAuthenticatedCommand {
       char: 'e',
       description: 'Environment name or id.',
     }),
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Skip the confirmation prompt (required when reading from stdin).',
+    }),
     projectId: Flags.integer({
       char: 'p',
       description: 'Project id.',
@@ -197,13 +233,19 @@ export default class LayoutPatchCommand extends AbstractAuthenticatedCommand {
 
   constructor(argv: string[], config: Config, plan?) {
     super(argv, config, plan);
-    const { assertPresent, env } = this.context;
-    assertPresent({ env });
+    const { assertPresent, env, inquirer } = this.context;
+    assertPresent({ env, inquirer });
     this.env = env;
+    this.inquirer = inquirer;
   }
 
   protected async runAuthenticated(): Promise<void> {
     const { args, flags } = await this.parse(LayoutPatchCommand);
+
+    const fromStdin = !args.file || args.file === '-';
+    if (fromStdin && !flags['dry-run']) {
+      assertNonInteractiveFlags(flags, Boolean(this.env.FOREST_ENV_SECRET));
+    }
 
     const allOps = buildAllOps(await readInput(args.file));
 
@@ -225,7 +267,30 @@ export default class LayoutPatchCommand extends AbstractAuthenticatedCommand {
 
     this.log(formatOps(allOps));
 
-    const manager = new LayoutManager();
+    if (
+      !flags.force &&
+      !(await this.confirm(scope.environmentName, scope.teamName, allOps.length))
+    ) {
+      this.logger.info('Aborted: nothing was patched.');
+      return;
+    }
+
+    await this.sendPatches(new LayoutManager(), scope, allOps);
+
+    this.logger.success(
+      `Patched ${allOps.length} op${allOps.length > 1 ? 's' : ''} on ${this.chalk.bold(
+        scope.environmentName,
+      )} / ${this.chalk.bold(scope.teamName)}.`,
+    );
+  }
+
+  /** One atomic PATCH per domain, in stable order. Exits 2 on a recoverable API error. */
+  private async sendPatches(
+    manager: LayoutManager,
+    scope: Awaited<ReturnType<typeof resolveCommandScope>>,
+    allOps: PlannedOp[],
+  ): Promise<void> {
+    const applied: LayoutDomain[] = [];
 
     // eslint-disable-next-line no-restricted-syntax -- sequential: one atomic PATCH per domain
     for (const domain of PATCH_DOMAINS) {
@@ -235,21 +300,43 @@ export default class LayoutPatchCommand extends AbstractAuthenticatedCommand {
       try {
         // eslint-disable-next-line no-await-in-loop -- intentional: atomic, ordered per-domain patches
         await manager.patchDomain(domain, domainOps, scope);
+        applied.push(domain);
       } catch (error) {
         if (error instanceof LayoutApiError && error.status !== 401) {
           // Scope the error to this domain so path correlation in explainApiError is accurate.
           this.logger.error(explainApiError(error, domainOps));
+          if (applied.length > 0) {
+            // Unlike `apply`, a raw patch is NOT idempotent: replaying its "add"
+            // ops would create duplicates on the domains that already succeeded.
+            this.logger.warn(
+              `The "${applied.join('", "')}" patch was already applied before this failure. ` +
+                'Do not re-run the same input as-is: its "add" operations would be applied twice — ' +
+                'remove the applied domain(s) from the input before retrying.',
+            );
+          }
           this.exit(2);
         }
 
         throw error;
       }
     }
+  }
 
-    this.logger.success(
-      `Patched ${allOps.length} op${allOps.length > 1 ? 's' : ''} on ${this.chalk.bold(
-        scope.environmentName,
-      )} / ${this.chalk.bold(scope.teamName)}.`,
-    );
+  private async confirm(
+    environmentName: string,
+    teamName: string,
+    count: number,
+  ): Promise<boolean> {
+    const { confirm } = await this.inquirer.prompt([
+      {
+        message: `Send ${count} patch operation${
+          count > 1 ? 's' : ''
+        } to ${environmentName} / ${teamName}?`,
+        name: 'confirm',
+        type: 'confirm',
+      },
+    ]);
+
+    return confirm;
   }
 }

--- a/test/commands/layout/patch.unit.test.ts
+++ b/test/commands/layout/patch.unit.test.ts
@@ -1,4 +1,9 @@
-import { buildAllOps, formatOps, toPlannedOps } from '../../../src/commands/layout/patch';
+import {
+  assertNonInteractiveFlags,
+  buildAllOps,
+  formatOps,
+  toPlannedOps,
+} from '../../../src/commands/layout/patch';
 
 describe('toPlannedOps', () => {
   it('accepts a valid add op', () => {
@@ -101,6 +106,37 @@ describe('buildAllOps', () => {
         layuot: [{ op: 'replace', path: '/collections/orders/displayName', value: 'x' }],
       } as unknown as Parameters<typeof buildAllOps>[0]),
     ).toThrow(/Unknown domain key: layuot/);
+  });
+});
+
+describe('assertNonInteractiveFlags', () => {
+  it('passes when the full scope and --force are given', () => {
+    expect.assertions(1);
+    expect(() =>
+      assertNonInteractiveFlags(
+        { env: 'Production', force: true, projectId: 42, team: 'Operations' },
+        false,
+      ),
+    ).not.toThrow();
+  });
+
+  it('lets FOREST_ENV_SECRET stand in for --env and --projectId', () => {
+    expect.assertions(1);
+    expect(() =>
+      assertNonInteractiveFlags({ force: true, team: 'Operations' }, true),
+    ).not.toThrow();
+  });
+
+  it('lists every missing flag when nothing is provided', () => {
+    expect.assertions(1);
+    expect(() => assertNonInteractiveFlags({}, false)).toThrow(
+      /Missing: -e\/--env, -p\/--projectId, -t\/--team, --force/,
+    );
+  });
+
+  it('still requires --team and --force with FOREST_ENV_SECRET set', () => {
+    expect.assertions(1);
+    expect(() => assertNonInteractiveFlags({}, true)).toThrow(/Missing: -t\/--team, --force/);
   });
 });
 

--- a/test/commands/layout/patch.unit.test.ts
+++ b/test/commands/layout/patch.unit.test.ts
@@ -1,0 +1,103 @@
+import { buildAllOps, formatOps, toPlannedOps } from '../../../src/commands/layout/patch';
+
+describe('toPlannedOps', () => {
+  it('accepts a valid add op', () => {
+    expect.assertions(4);
+    const ops = toPlannedOps('layout', [
+      {
+        op: 'add',
+        path: '/collections/orders/layout/segments/-',
+        value: { id: 'seg1', name: 'VIP' },
+      },
+    ]);
+    expect(ops).toHaveLength(1);
+    expect(ops[0].op).toBe('add');
+    expect(ops[0].domain).toBe('layout');
+    expect(ops[0].jsonPath).toBe('/collections/orders/layout/segments/-');
+  });
+
+  it('accepts a valid replace op', () => {
+    expect.assertions(2);
+    const ops = toPlannedOps('layout', [
+      { op: 'replace', path: '/collections/orders/displayName', value: 'Orders v2' },
+    ]);
+    expect(ops[0].op).toBe('replace');
+    expect(ops[0].label).toBe('replace /collections/orders/displayName');
+  });
+
+  it('rejects an unknown op type', () => {
+    expect.assertions(1);
+    expect(() =>
+      toPlannedOps('layout', [{ op: 'upsert', path: '/collections/orders/displayName' }]),
+    ).toThrow(/unknown op "upsert"/);
+  });
+
+  it('rejects a path that does not start with "/"', () => {
+    expect.assertions(1);
+    expect(() =>
+      toPlannedOps('layout', [{ op: 'replace', path: 'collections/orders/displayName' }]),
+    ).toThrow(/path must be a string starting with/);
+  });
+
+  it('rejects a path outside the server whitelist', () => {
+    expect.assertions(1);
+    expect(() =>
+      toPlannedOps('layout', [
+        { op: 'replace', path: '/collections/orders/__internal__', value: 'x' },
+      ]),
+    ).toThrow(/not allowed by the server whitelist/);
+  });
+});
+
+describe('buildAllOps', () => {
+  it('collects ops from layout and folders in domain order', () => {
+    expect.assertions(3);
+    const ops = buildAllOps({
+      folders: [{ op: 'add', path: '/folders/12/children/-', value: { id: 'f1', name: 'Sales' } }],
+      layout: [{ op: 'replace', path: '/collections/orders/displayName', value: 'Orders v2' }],
+    });
+    expect(ops).toHaveLength(2);
+    expect(ops[0].domain).toBe('layout');
+    expect(ops[1].domain).toBe('folders');
+  });
+
+  it('returns an empty array when input has no ops', () => {
+    expect.assertions(1);
+    expect(buildAllOps({})).toHaveLength(0);
+  });
+
+  it('throws when a domain value is not an array', () => {
+    expect.assertions(1);
+    expect(() =>
+      buildAllOps({ layout: 'bad' as unknown as Array<{ op: string; path: string }> }),
+    ).toThrow(/"layout" must be an array/);
+  });
+
+  it('rejects the workflows domain (deferred to apply)', () => {
+    expect.assertions(1);
+    expect(() =>
+      buildAllOps({ workflows: [{ op: 'replace', path: '/workflows/42/isVisible', value: true }] }),
+    ).toThrow(/"workflows" domain is not supported/);
+  });
+});
+
+describe('formatOps', () => {
+  it('groups ops by domain with a singular count', () => {
+    expect.assertions(1);
+    const ops = buildAllOps({
+      layout: [{ op: 'replace', path: '/collections/orders/displayName', value: 'Orders v2' }],
+    });
+    expect(formatOps(ops)).toContain('layout (1 op)');
+  });
+
+  it('uses plural for multiple ops', () => {
+    expect.assertions(1);
+    const ops = buildAllOps({
+      layout: [
+        { op: 'replace', path: '/collections/orders/displayName', value: 'A' },
+        { op: 'replace', path: '/collections/orders/icon', value: 'truck' },
+      ],
+    });
+    expect(formatOps(ops)).toContain('layout (2 ops)');
+  });
+});

--- a/test/commands/layout/patch.unit.test.ts
+++ b/test/commands/layout/patch.unit.test.ts
@@ -32,6 +32,13 @@ describe('toPlannedOps', () => {
     ).toThrow(/unknown op "upsert"/);
   });
 
+  it('rejects an add/replace/test op with no value field', () => {
+    expect.assertions(1);
+    expect(() =>
+      toPlannedOps('layout', [{ op: 'replace', path: '/collections/orders/displayName' }]),
+    ).toThrow(/op "replace" requires a "value" field/);
+  });
+
   it('rejects a path that does not start with "/"', () => {
     expect.assertions(1);
     expect(() =>

--- a/test/commands/layout/patch.unit.test.ts
+++ b/test/commands/layout/patch.unit.test.ts
@@ -47,6 +47,13 @@ describe('toPlannedOps', () => {
       ]),
     ).toThrow(/not allowed by the server whitelist/);
   });
+
+  it('rejects a non-object operation with a user-facing error', () => {
+    expect.assertions(1);
+    expect(() => toPlannedOps('layout', [null as unknown as { op: string; path: string }])).toThrow(
+      /each operation must be a JSON object/,
+    );
+  });
 });
 
 describe('buildAllOps', () => {
@@ -78,6 +85,15 @@ describe('buildAllOps', () => {
     expect(() =>
       buildAllOps({ workflows: [{ op: 'replace', path: '/workflows/42/isVisible', value: true }] }),
     ).toThrow(/"workflows" domain is not supported/);
+  });
+
+  it('rejects an unknown domain key instead of silently dropping it', () => {
+    expect.assertions(1);
+    expect(() =>
+      buildAllOps({
+        layuot: [{ op: 'replace', path: '/collections/orders/displayName', value: 'x' }],
+      } as unknown as Parameters<typeof buildAllOps>[0]),
+    ).toThrow(/Unknown domain key: layuot/);
   });
 });
 

--- a/test/commands/layout/patch.unit.test.ts
+++ b/test/commands/layout/patch.unit.test.ts
@@ -120,10 +120,10 @@ describe('assertNonInteractiveFlags', () => {
     ).not.toThrow();
   });
 
-  it('lets FOREST_ENV_SECRET stand in for --env and --projectId', () => {
+  it('lets FOREST_ENV_SECRET stand in for --projectId only', () => {
     expect.assertions(1);
     expect(() =>
-      assertNonInteractiveFlags({ force: true, team: 'Operations' }, true),
+      assertNonInteractiveFlags({ env: 'Production', force: true, team: 'Operations' }, true),
     ).not.toThrow();
   });
 
@@ -134,9 +134,18 @@ describe('assertNonInteractiveFlags', () => {
     );
   });
 
+  it('still requires --env with FOREST_ENV_SECRET set (the secret never picks the environment)', () => {
+    expect.assertions(1);
+    expect(() => assertNonInteractiveFlags({ force: true, team: 'Operations' }, true)).toThrow(
+      /Missing: -e\/--env/,
+    );
+  });
+
   it('still requires --team and --force with FOREST_ENV_SECRET set', () => {
     expect.assertions(1);
-    expect(() => assertNonInteractiveFlags({}, true)).toThrow(/Missing: -t\/--team, --force/);
+    expect(() => assertNonInteractiveFlags({ env: 'Production' }, true)).toThrow(
+      /Missing: -t\/--team, --force/,
+    );
   });
 });
 


### PR DESCRIPTION
## What
Adds `forest layout patch` — apply a JSON-Patch directly to a layout (one PATCH per domain, mirroring the front-end), instead of the `pull → edit → apply` round-trip.

## Why
For programmatic / agent-driven layout edits where the exact ops are already known, a direct patch is simpler and atomic per domain. Complements the existing `layout pull` / `layout apply`.

## How
- reads ops from a file arg or stdin (`-`)
- validates op type + path against the server whitelist (`patch-rules`)
- `--dry-run` prints the planned ops without sending anything
- scope via `-e/--env`, `-p/--projectId`, `-t/--team` (`resolveCommandScope`)
- `workflows` domain intentionally deferred to `layout apply` (creating a workflow needs a BPMN S3 upload, not a single layout PATCH)

## Tests
- 11 unit tests (`toPlannedOps` / `buildAllOps` / `formatOps`): op validation, whitelist rejection, per-domain ordering, workflows-deferred — all green.
- `eslint` + `tsc --noEmit` clean.

## Notes
- Command is auto-discovered by oclif (`src/commands/layout/patch.ts` → `forest layout patch`); `oclif.manifest.json` and the README command list are regenerated at pack time.
- Supersedes #795 (opened from a fork, which had no access to CI secrets → the DockerHub login step failed and blocked the Test job). This one is branched inside the org repo so CI runs with secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `forest layout patch` command to apply JSON-patch operations to layout and folders
> - Adds a new `layout patch` CLI command in [patch.ts](https://github.com/ForestAdmin/toolbelt/pull/796/files#diff-2957a72e606bfe75fd4b36f7a745fffa83bff16698a0912f488937fce57f11aa) that reads patch input from a file or stdin, validates ops across the `layout` and `folders` domains, and applies one atomic PATCH per domain via `LayoutManager`.
> - Supports `--dry-run`, `--force`, `--env`, `--team`, and `--projectId` flags; non-interactive runs require all scope flags unless `FOREST_ENV_SECRET` is set.
> - Validates input as a non-null JSON object, checks each operation's shape, op type (`add`, `replace`, `remove`, `test`), and path against a whitelist before sending.
> - Prints a grouped, human-readable summary of planned ops before applying; prompts for confirmation unless `--force` is passed.
> - Risk: on a recoverable API error (`LayoutApiError` non-401), the command exits with code 2 and warns that already-applied domains may cause duplicate `add` replays if retried.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57bba44.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->