### PR TITLE
fix(layout): make CLI-compiled workflows editable in the UI

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -29,5 +29,9 @@ module.exports = {
     '^.+\\.(j|t)s$': '@swc/jest',
   },
 
+  // bpmn-moddle (used in tests to verify editor importability) and its
+  // dependency chain are published as ESM only — transpile them too.
+  transformIgnorePatterns: ['/node_modules/(?!(bpmn-moddle|moddle|moddle-xml|min-dash|saxen)/)'],
+
   testEnvironment: 'node',
 };

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/lodash": "4.14.191",
     "@typescript-eslint/eslint-plugin": "^5.9.1",
     "@typescript-eslint/parser": "^5.9.1",
+    "bpmn-moddle": "10.0.0",
     "eslint": "^8.6.0",
     "eslint-config-airbnb-base": "14.0.0",
     "eslint-config-oclif": "3.1.0",

--- a/src/services/layout/workflow-bpmn.ts
+++ b/src/services/layout/workflow-bpmn.ts
@@ -57,6 +57,23 @@ export type WorkflowSpec = {
 
 const ID_RE = /^[A-Z_a-z][\w-]*$/;
 
+/** Ids the compiler generates itself — a step id colliding with one of these
+ * (or with a generated `flow_*` sequence-flow / `*_di` diagram id) would produce
+ * duplicate XML ids, which bpmn-js refuses to import. */
+const RESERVED_IDS = new Set([
+  'Start_1',
+  'Process_1',
+  'Definitions_1',
+  'BPMNDiagram_1',
+  'BPMNPlane_1',
+]);
+
+/** The step types that compile to a `serviceTask` (the only element supporting
+ * `forest:automaticExecution`/`forest:automaticCompletion`). */
+const SERVICE_TASK_TYPES = Object.entries(STEP_TYPES)
+  .filter(([, def]) => def.element === 'serviceTask')
+  .map(([type]) => type);
+
 function xml(value: string): string {
   return value
     .replace(/&/g, '&amp;')
@@ -76,6 +93,13 @@ function validateStepIdentity(step: StepSpec, seen: Set<string>): void {
   if (!step.id || !ID_RE.test(step.id)) {
     throw new WorkflowSpecError(
       `Each step needs an \`id\` matching ${ID_RE} (got "${step.id ?? ''}").`,
+    );
+  }
+
+  if (RESERVED_IDS.has(step.id) || step.id.startsWith('flow_') || step.id.endsWith('_di')) {
+    throw new WorkflowSpecError(
+      `Step "${step.id}": this id is reserved for generated BPMN elements ` +
+        `(${[...RESERVED_IDS].join(', ')}, \`flow_*\`, \`*_di\`).`,
     );
   }
 
@@ -117,6 +141,13 @@ function validateLinkStep(step: StepSpec): void {
 
 function validateStep(step: StepSpec, seen: Set<string>): void {
   validateStepIdentity(step, seen);
+
+  if ((step.auto || step.autoComplete) && STEP_TYPES[step.type].element !== 'serviceTask') {
+    throw new WorkflowSpecError(
+      `Step "${step.id}": \`auto\`/\`autoComplete\` are only supported on ` +
+        `${SERVICE_TASK_TYPES.join(', ')} steps.`,
+    );
+  }
 
   if (step.type === 'end') {
     if (step.next || step.branches) {
@@ -167,9 +198,23 @@ export function validateWorkflowSpec(spec: Partial<WorkflowSpec>): WorkflowSpec 
   };
 }
 
-function flowId(source: string, target: string): string {
-  return `flow_${source}_${target}`;
+/**
+ * Allocate a unique, deterministic sequence-flow id. `flow_${source}_${target}`
+ * alone is not unique — two condition branches can point at the same target, and
+ * underscores in step ids can make distinct pairs render the same string — so
+ * collisions get a stable numeric suffix (`_2`, `_3`, …) in spec order.
+ */
+function allocateFlowId(source: string, target: string, used: Set<string>): string {
+  const base = `flow_${source}_${target}`;
+  let id = base;
+  for (let n = 2; used.has(id); n += 1) id = `${base}_${n}`;
+  used.add(id);
+
+  return id;
 }
+
+/** A sequence flow with its allocated id (shared by the element, flow and DI edge). */
+type FlowSpec = { branch: BranchSpec; id: string; source: string };
 
 /** The outgoing transitions of a step: a condition's branches, else its `next`. */
 function branchesOf(step: StepSpec): BranchSpec[] {
@@ -179,14 +224,11 @@ function branchesOf(step: StepSpec): BranchSpec[] {
 }
 
 /** One `<bpmn:sequenceFlow>` (template only, no concatenation). */
-function renderFlow(stepId: string, branch: BranchSpec): string {
-  const nameAttr = branch.answer ? ` name="${xml(branch.answer)}"` : '';
-  const colorAttr = branch.color ? ` forest:buttonColor="${xml(branch.color)}"` : '';
+function renderFlow(flow: FlowSpec): string {
+  const nameAttr = flow.branch.answer ? ` name="${xml(flow.branch.answer)}"` : '';
+  const colorAttr = flow.branch.color ? ` forest:buttonColor="${xml(flow.branch.color)}"` : '';
 
-  return `    <bpmn:sequenceFlow id="${flowId(
-    stepId,
-    branch.next,
-  )}" sourceRef="${stepId}" targetRef="${branch.next}"${nameAttr}${colorAttr} />`;
+  return `    <bpmn:sequenceFlow id="${flow.id}" sourceRef="${flow.source}" targetRef="${flow.branch.next}"${nameAttr}${colorAttr} />`;
 }
 
 /** The `forest:*` attribute string for a step element. */
@@ -211,19 +253,16 @@ function stepAttributes(step: StepSpec): string {
 }
 
 /** Build the BPMN element + its outgoing sequenceFlows for one step. */
-function renderStep(step: StepSpec): { element: string; flows: string[] } {
+function renderStep(step: StepSpec, flowSpecs: FlowSpec[]): { element: string; flows: string[] } {
   const name = xml(step.title ?? step.id);
-  const branches = branchesOf(step);
-  const flows = branches.map(branch => renderFlow(step.id, branch));
+  const flows = flowSpecs.map(flow => renderFlow(flow));
 
   if (step.type === 'end') {
     return { element: `    <bpmn:endEvent id="${step.id}" name="${name}"></bpmn:endEvent>`, flows };
   }
 
   const tag = STEP_TYPES[step.type].element;
-  const outgoing = branches
-    .map(branch => `<bpmn:outgoing>${flowId(step.id, branch.next)}</bpmn:outgoing>`)
-    .join('');
+  const outgoing = flowSpecs.map(flow => `<bpmn:outgoing>${flow.id}</bpmn:outgoing>`).join('');
   const element = `    <bpmn:${tag} id="${step.id}" name="${name}"${stepAttributes(
     step,
   )}>${outgoing}</bpmn:${tag}>`;
@@ -298,30 +337,30 @@ export function compileWorkflowToBpmn(input: Partial<WorkflowSpec>): string {
   const spec = validateWorkflowSpec(input);
   const entryId = spec.start as string;
 
+  const usedFlowIds = new Set<string>();
+  const entryFlowId = allocateFlowId('Start_1', entryId, usedFlowIds);
+
   const nodes: DiagramNode[] = [{ id: 'Start_1', tag: 'startEvent' }];
-  const edges: DiagramEdge[] = [
-    { id: flowId('Start_1', entryId), source: 'Start_1', target: entryId },
-  ];
+  const edges: DiagramEdge[] = [{ id: entryFlowId, source: 'Start_1', target: entryId }];
   const elements: string[] = [
-    `    <bpmn:startEvent id="Start_1"><bpmn:outgoing>${flowId(
-      'Start_1',
-      entryId,
-    )}</bpmn:outgoing></bpmn:startEvent>`,
+    `    <bpmn:startEvent id="Start_1"><bpmn:outgoing>${entryFlowId}</bpmn:outgoing></bpmn:startEvent>`,
   ];
   const flows: string[] = [
-    `    <bpmn:sequenceFlow id="${flowId(
-      'Start_1',
-      entryId,
-    )}" sourceRef="Start_1" targetRef="${entryId}" />`,
+    `    <bpmn:sequenceFlow id="${entryFlowId}" sourceRef="Start_1" targetRef="${entryId}" />`,
   ];
 
   spec.steps.forEach(step => {
-    const rendered = renderStep(step);
+    const flowSpecs: FlowSpec[] = branchesOf(step).map(branch => ({
+      branch,
+      id: allocateFlowId(step.id, branch.next, usedFlowIds),
+      source: step.id,
+    }));
+    const rendered = renderStep(step, flowSpecs);
     elements.push(rendered.element);
     flows.push(...rendered.flows);
     nodes.push({ id: step.id, tag: STEP_TYPES[step.type].element });
-    branchesOf(step).forEach(branch => {
-      edges.push({ id: flowId(step.id, branch.next), source: step.id, target: branch.next });
+    flowSpecs.forEach(flow => {
+      edges.push({ id: flow.id, source: step.id, target: flow.branch.next });
     });
   });
 

--- a/src/services/layout/workflow-bpmn.ts
+++ b/src/services/layout/workflow-bpmn.ts
@@ -194,8 +194,13 @@ function stepAttributes(step: StepSpec): string {
   const def = STEP_TYPES[step.type];
   const attrs: string[] = [];
   if ('alternative' in def) attrs.push(`forest:alternative="${def.alternative}"`);
-  if (step.auto) attrs.push('forest:automaticExecution="true"');
-  if (step.autoComplete) attrs.push('forest:automaticCompletion="true"');
+  // `automaticExecution`/`automaticCompletion` are only meaningful on serviceTask
+  // steps — a `guidance` step is a manual userTask the UI cannot auto-complete, so
+  // emitting the flag there produces BPMN the editor can't round-trip.
+  if (def.element === 'serviceTask') {
+    if (step.auto) attrs.push('forest:automaticExecution="true"');
+    if (step.autoComplete) attrs.push('forest:automaticCompletion="true"');
+  }
   if (step.prompt) attrs.push(`forest:description="${xml(step.prompt)}"`);
   if (step.type === 'mcp' && step.mcpServerId)
     attrs.push(`forest:mcpServerId="${xml(step.mcpServerId)}"`);

--- a/src/services/layout/workflow-bpmn.ts
+++ b/src/services/layout/workflow-bpmn.ts
@@ -226,11 +226,77 @@ function renderStep(step: StepSpec): { element: string; flows: string[] } {
   return { element, flows };
 }
 
+type DiagramNode = { id: string; tag: string };
+type DiagramEdge = { id: string; source: string; target: string };
+type Bounds = { h: number; w: number; x: number; y: number };
+
+/** BPMN element footprint by shape kind (events / gateways / tasks). */
+function elementSize(tag: string): { h: number; w: number } {
+  if (tag.endsWith('Event')) return { h: 36, w: 36 };
+  if (tag === 'exclusiveGateway') return { h: 50, w: 50 };
+
+  return { h: 80, w: 100 };
+}
+
+/**
+ * A minimal left-to-right BPMN-DI diagram. bpmn-js (the workflow editor) refuses
+ * to import a `definitions` with no `<bpmndi:BPMNDiagram>` ("Import BPMN Error"),
+ * so every element needs a shape and every sequence flow an edge — a naive layout
+ * the user can rearrange is enough to make the workflow editable.
+ */
+function renderDiagram(nodes: DiagramNode[], edges: DiagramEdge[]): string[] {
+  const laneCenter = 160;
+  const gap = 60;
+  let cursor = 160;
+  const bounds: Record<string, Bounds> = {};
+  nodes.forEach(node => {
+    const { h, w } = elementSize(node.tag);
+    bounds[node.id] = { h, w, x: cursor, y: laneCenter - h / 2 };
+    cursor += w + gap;
+  });
+
+  const shapes = nodes
+    .map(node => {
+      const b = bounds[node.id];
+      if (!b) return '';
+
+      return `      <bpmndi:BPMNShape id="${node.id}_di" bpmnElement="${node.id}"><dc:Bounds x="${b.x}" y="${b.y}" width="${b.w}" height="${b.h}" /></bpmndi:BPMNShape>`;
+    })
+    .filter(Boolean);
+
+  const flowEdges = edges
+    .map(edge => {
+      const from = bounds[edge.source];
+      const to = bounds[edge.target];
+      if (!from || !to) return '';
+      const x1 = from.x + from.w;
+      const y1 = from.y + from.h / 2;
+      const x2 = to.x;
+      const y2 = to.y + to.h / 2;
+
+      return `      <bpmndi:BPMNEdge id="${edge.id}_di" bpmnElement="${edge.id}"><di:waypoint x="${x1}" y="${y1}" /><di:waypoint x="${x2}" y="${y2}" /></bpmndi:BPMNEdge>`;
+    })
+    .filter(Boolean);
+
+  return [
+    '  <bpmndi:BPMNDiagram id="BPMNDiagram_1">',
+    '    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">',
+    ...shapes,
+    ...flowEdges,
+    '    </bpmndi:BPMNPlane>',
+    '  </bpmndi:BPMNDiagram>',
+  ];
+}
+
 /** Compile a workflow `steps` spec into BPMN XML (validates first). */
 export function compileWorkflowToBpmn(input: Partial<WorkflowSpec>): string {
   const spec = validateWorkflowSpec(input);
   const entryId = spec.start as string;
 
+  const nodes: DiagramNode[] = [{ id: 'Start_1', tag: 'startEvent' }];
+  const edges: DiagramEdge[] = [
+    { id: flowId('Start_1', entryId), source: 'Start_1', target: entryId },
+  ];
   const elements: string[] = [
     `    <bpmn:startEvent id="Start_1"><bpmn:outgoing>${flowId(
       'Start_1',
@@ -248,15 +314,20 @@ export function compileWorkflowToBpmn(input: Partial<WorkflowSpec>): string {
     const rendered = renderStep(step);
     elements.push(rendered.element);
     flows.push(...rendered.flows);
+    nodes.push({ id: step.id, tag: STEP_TYPES[step.type].element });
+    branchesOf(step).forEach(branch => {
+      edges.push({ id: flowId(step.id, branch.next), source: step.id, target: branch.next });
+    });
   });
 
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
-    '<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:forest="https://forestadmin.com">',
+    '<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:forest="https://app.forestadmin.com" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">',
     '  <bpmn:process id="Process_1" isExecutable="true">',
     ...elements,
     ...flows,
     '  </bpmn:process>',
+    ...renderDiagram(nodes, edges),
     '</bpmn:definitions>',
     '',
   ].join('\n');

--- a/test/services/layout/workflow-bpmn.unit.test.ts
+++ b/test/services/layout/workflow-bpmn.unit.test.ts
@@ -1,3 +1,7 @@
+// bpmn-moddle only publishes an `exports` map (no `main`), invisible to the legacy node resolver.
+// eslint-disable-next-line import/no-unresolved
+import { BpmnModdle } from 'bpmn-moddle';
+
 import {
   WorkflowSpecError,
   compileWorkflowToBpmn,
@@ -19,6 +23,53 @@ const validSpec = {
     { id: 'done', type: 'end' as const },
   ],
 };
+
+/** Two condition branches converging on the same target step. */
+const convergingSpec = {
+  collection: 'cards',
+  name: 'Branchy',
+  start: 'cond1',
+  steps: [
+    {
+      branches: [
+        { answer: 'Yes', next: 'done' },
+        { answer: 'No', next: 'done' },
+      ],
+      id: 'cond1',
+      type: 'condition' as const,
+    },
+    { id: 'done', type: 'end' as const },
+  ],
+};
+
+/** One step of every supported type. */
+const allTypesSpec = {
+  collection: 'cards',
+  name: 'Everything',
+  start: 'act1',
+  steps: [
+    { auto: true, id: 'act1', next: 'cond1', type: 'action' as const },
+    {
+      branches: [
+        { answer: 'Yes', next: 'esc1' },
+        { answer: 'No', next: 'guide1' },
+      ],
+      id: 'cond1',
+      type: 'condition' as const,
+    },
+    { id: 'esc1', inboxId: 'inbox-1', next: 'load1', type: 'escalation' as const },
+    { id: 'guide1', next: 'load1', prompt: 'Check it', type: 'guidance' as const },
+    { id: 'load1', next: 'mcp1', type: 'load-related' as const },
+    { id: 'mcp1', mcpServerId: 'srv-1', next: 'read1', type: 'mcp' as const },
+    { autoComplete: true, id: 'read1', next: 'upd1', type: 'read' as const },
+    { id: 'upd1', next: 'done', type: 'update' as const },
+    { id: 'done', type: 'end' as const },
+  ],
+};
+
+function allXmlIds(bpmn: string): string[] {
+  return [...bpmn.matchAll(/ id="([^"]+)"/g)].map(match => match[1]);
+}
 
 describe('compileWorkflowToBpmn', () => {
   it('emits a BPMN process with start, steps and sequence flows', () => {
@@ -71,6 +122,82 @@ describe('compileWorkflowToBpmn', () => {
     });
     expect(bpmn).toContain('name="A &amp; B &lt;x&gt;"');
   });
+
+  it('declares the forest namespace and a diagram interchange section', () => {
+    expect.assertions(3);
+    const bpmn = compileWorkflowToBpmn(validSpec);
+    expect(bpmn).toContain('xmlns:forest="https://app.forestadmin.com"');
+    expect(bpmn).toContain('<bpmndi:BPMNDiagram id="BPMNDiagram_1">');
+    expect(bpmn).toContain('<bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">');
+  });
+
+  it('emits one BPMNShape per element and one BPMNEdge per sequence flow', () => {
+    expect.assertions(4);
+    const bpmn = compileWorkflowToBpmn(validSpec);
+    // start event + read1 + guide1 + done
+    expect(bpmn.match(/<bpmndi:BPMNShape /g)).toHaveLength(4);
+    expect(bpmn).toContain('<bpmndi:BPMNShape id="Start_1_di" bpmnElement="Start_1">');
+    // start→read1, read1→guide1, guide1→done
+    expect(bpmn.match(/<bpmn:sequenceFlow /g)).toHaveLength(3);
+    expect(bpmn.match(/<bpmndi:BPMNEdge /g)).toHaveLength(3);
+  });
+
+  it('gives converging condition branches distinct flow ids (elements and DI edges)', () => {
+    expect.assertions(4);
+    const bpmn = compileWorkflowToBpmn(convergingSpec);
+    expect(bpmn).toContain(
+      '<bpmn:sequenceFlow id="flow_cond1_done" sourceRef="cond1" targetRef="done" name="Yes" />',
+    );
+    expect(bpmn).toContain(
+      '<bpmn:sequenceFlow id="flow_cond1_done_2" sourceRef="cond1" targetRef="done" name="No" />',
+    );
+    expect(bpmn).toContain(
+      '<bpmndi:BPMNEdge id="flow_cond1_done_di" bpmnElement="flow_cond1_done">',
+    );
+    expect(bpmn).toContain(
+      '<bpmndi:BPMNEdge id="flow_cond1_done_2_di" bpmnElement="flow_cond1_done_2">',
+    );
+  });
+
+  it.each([
+    ['simple', validSpec],
+    ['converging branches', convergingSpec],
+    ['all step types', allTypesSpec],
+  ])('never emits duplicate xml ids (%s)', (_label, spec) => {
+    expect.assertions(1);
+    const ids = allXmlIds(compileWorkflowToBpmn(spec));
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('emits auto/autoComplete flags on serviceTask steps', () => {
+    expect.assertions(3);
+    const bpmn = compileWorkflowToBpmn(allTypesSpec);
+    expect(bpmn).toContain(
+      '<bpmn:serviceTask id="act1" name="act1" forest:alternative="trigger-action" forest:automaticExecution="true">',
+    );
+    expect(bpmn).toContain(
+      '<bpmn:serviceTask id="read1" name="read1" forest:alternative="get-data" forest:automaticCompletion="true">',
+    );
+    // the flags never leak onto non-serviceTask elements
+    const offendingLines = bpmn
+      .split('\n')
+      .filter(line => line.includes('forest:automatic') && !line.includes('<bpmn:serviceTask '));
+    expect(offendingLines).toStrictEqual([]);
+  });
+});
+
+describe('bpmn-js importability (bpmn-moddle)', () => {
+  it.each([
+    ['simple', validSpec],
+    ['converging branches', convergingSpec],
+    ['all step types', allTypesSpec],
+  ])('imports the compiled BPMN without errors or warnings (%s)', async (_label, spec) => {
+    expect.assertions(2);
+    const moddle = new BpmnModdle();
+    const { rootElement, warnings } = await moddle.fromXML(compileWorkflowToBpmn(spec));
+    expect(warnings).toStrictEqual([]);
+    expect(rootElement.id).toBe('Definitions_1');
+  });
 });
 
 describe('validateWorkflowSpec', () => {
@@ -99,6 +226,37 @@ describe('validateWorkflowSpec', () => {
     [
       { collection: 'c', name: 'N', steps: [{ id: 'a', next: 'a', type: 'read' }] },
       'at least one `end`',
+    ],
+    [
+      {
+        collection: 'c',
+        name: 'N',
+        steps: [
+          { auto: true, id: 'g', next: 'e', type: 'guidance' },
+          { id: 'e', type: 'end' },
+        ],
+      },
+      '`auto`/`autoComplete` are only supported on action, load-related, mcp, read, update steps',
+    ],
+    [
+      { collection: 'c', name: 'N', steps: [{ autoComplete: true, id: 'e', type: 'end' }] },
+      '`auto`/`autoComplete` are only supported on',
+    ],
+    [
+      { collection: 'c', name: 'N', steps: [{ id: 'Start_1', type: 'end' }] },
+      'reserved for generated BPMN elements',
+    ],
+    [
+      { collection: 'c', name: 'N', steps: [{ id: 'Process_1', type: 'end' }] },
+      'reserved for generated BPMN elements',
+    ],
+    [
+      { collection: 'c', name: 'N', steps: [{ id: 'flow_a_b', type: 'end' }] },
+      'reserved for generated BPMN elements',
+    ],
+    [
+      { collection: 'c', name: 'N', steps: [{ id: 'done_di', type: 'end' }] },
+      'reserved for generated BPMN elements',
     ],
   ])('rejects an invalid spec (%#)', (spec, message) => {
     expect.assertions(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4839,6 +4839,15 @@ bowser@^2.11.0:
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.12.1.tgz#f9ad78d7aebc472feb63dd9635e3ce2337e0e2c1"
   integrity sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==
 
+bpmn-moddle@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/bpmn-moddle/-/bpmn-moddle-10.0.0.tgz#b1ad5457ac6190babf27b0cb38469f5e39a01be7"
+  integrity sha512-vXePD5jkatcILmM3zwJG/m6IIHIghTGB7WvgcdEraEw8E8VdJHrTgrvBUhbzqaXJpnsGQz15QS936xeBY6l9aA==
+  dependencies:
+    min-dash "^5.0.0"
+    moddle "^8.0.0"
+    moddle-xml "^12.0.0"
+
 brace-expansion@^1.1.7:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
@@ -9303,6 +9312,11 @@ mimic-response@^4.0.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-4.0.0.tgz#35468b19e7c75d10f5165ea25e75a5ceea7cf70f"
   integrity sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==
 
+min-dash@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/min-dash/-/min-dash-5.0.0.tgz#213550a03f4818a85feae4c308bb4c83a5290dc4"
+  integrity sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw==
+
 min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
@@ -9422,6 +9436,21 @@ mock-stdin@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mock-stdin/-/mock-stdin-1.0.0.tgz#efcfaf4b18077e14541742fd758b9cae4e5365ea"
   integrity sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q==
+
+moddle-xml@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/moddle-xml/-/moddle-xml-12.0.0.tgz#9d7ca1358d44b6defb80d2c75f7f215aed2838ae"
+  integrity sha512-NJc2+sCe4tvuGlaUBcoZcYf6j9f+z+qxHOyGm/LB3ZrlJXVPPHoBTg/KXgDRCufdBJhJ3AheFs3QU/abABNzRg==
+  dependencies:
+    min-dash "^5.0.0"
+    saxen "^11.0.2"
+
+moddle@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/moddle/-/moddle-8.1.0.tgz#7042b33c616c0484a54d8c75e463742c14b5be13"
+  integrity sha512-dBddc1CNuZHgro8nQWwfPZ2BkyLWdnxoNpPu9d+XKPN96DAiiBOeBw527ft++ebDuFez5PMdaR3pgUgoOaUGrA==
+  dependencies:
+    min-dash "^5.0.0"
 
 moment-timezone@^0.5.43:
   version "0.5.48"
@@ -11055,6 +11084,11 @@ sax@>=0.6.0:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.4.1.tgz#44cc8988377f126304d3b3fc1010c733b929ef0f"
   integrity sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==
 
+saxen@^11.0.2:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/saxen/-/saxen-11.0.2.tgz#14405adb2b72ad127102379744d93ed0fc599b5e"
+  integrity sha512-WDb4gqac8uiJzOdOdVpr9NWh9NrJMm7Brn5GX2Poj+mjE/QTXqYQENr8T/mom54dDDgbd3QjwTg23TRHYiWXRA==
+
 semantic-release-slack-bot@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/semantic-release-slack-bot/-/semantic-release-slack-bot-4.0.2.tgz#7e4f7e04fbbf355c64fb8791df8870cdcda4dd35"
@@ -11596,7 +11630,7 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11612,6 +11646,15 @@ string-width@^2.1.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -11677,7 +11720,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11697,6 +11740,13 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.2"
@@ -12645,7 +12695,7 @@ wordwrap@>=0.0.2, wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12658,6 +12708,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## What

`compileWorkflowToBpmn` now emits BPMN that the Forest workflow **editor** (bpmn-js) accepts, not just BPMN the engine can execute:

- **Diagram Interchange** (`<bpmndi:BPMNDiagram>` — shapes + edges with `dc:Bounds`/`di:waypoint`), which bpmn-js requires to render a graph. Without it, opening a CLI-authored workflow in the UI showed an empty/broken canvas.
- **`forest` namespace fixed** to `https://app.forestadmin.com` (was `https://forestadmin.com`). The editor keys off this exact URI, so with the wrong namespace the step prompts, subtype (`forest:alternative`) and execution flags (`automaticExecution`/`automaticCompletion`) were silently dropped.

## Why

Workflows authored/compiled by the CLI must be **round-trippable through the UI** — a user should be able to open, inspect and edit them. Verified against a captured editor request trace and confirmed live: prompts, subtypes and completion flags now all show up correctly.

## Notes

`automaticExecution`/`automaticCompletion` only apply to `serviceTask` step types — a `guidance` step is a manual `userTask` and cannot auto-complete (confirmed via HAR).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add BPMN-DI diagram output to make CLI-compiled workflows editable in the UI
> - Adds a `renderDiagram` function to [workflow-bpmn.ts](https://github.com/ForestAdmin/toolbelt/pull/798/files#diff-701c1528f8369370f27c900296ea63a77d831bf308e55e4ebf5e960500df6299) that generates a minimal BPMN-DI section (shapes and edges), positioning nodes left-to-right with fixed spacing.
> - Allocates deterministic, collision-safe sequence flow IDs using a new `allocateFlowId` function that appends numeric suffixes on duplicate source-target pairs.
> - Restricts `forest:automaticExecution` and `forest:automaticCompletion` attributes to `serviceTask` elements only, and validates that steps using `auto`/`autoComplete` are of a service task type.
> - Adds reserved ID set (`Start_1`, `Process_1`, `Definitions_1`, etc.) and validation to prevent generated element ID collisions.
> - Adds `bpmn-moddle` as a dependency to support BPMN parsing in tests, with Jest configured to transpile it and related ESM-only packages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0cb0db9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

Part of [PRD-715 — Workflows in CLI](https://linear.app/forestadmin/issue/PRD-715/workflows-in-cli).