### PR TITLE
feat(workflow): `forest workflow apply` — author a workflow from a JSON steps spec

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -29,5 +29,9 @@ module.exports = {
     '^.+\\.(j|t)s$': '@swc/jest',
   },
 
+  // bpmn-moddle (used in tests to verify editor importability) and its
+  // dependency chain are published as ESM only — transpile them too.
+  transformIgnorePatterns: ['/node_modules/(?!(bpmn-moddle|moddle|moddle-xml|min-dash|saxen)/)'],
+
   testEnvironment: 'node',
 };

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/lodash": "4.14.191",
     "@typescript-eslint/eslint-plugin": "^5.9.1",
     "@typescript-eslint/parser": "^5.9.1",
+    "bpmn-moddle": "10.0.0",
     "eslint": "^8.6.0",
     "eslint-config-airbnb-base": "14.0.0",
     "eslint-config-oclif": "3.1.0",

--- a/src/commands/workflow/apply.ts
+++ b/src/commands/workflow/apply.ts
@@ -1,5 +1,9 @@
 import type { LayoutScope } from '../../services/layout/types';
-import type { WorkflowSpec } from '../../services/layout/workflow-bpmn';
+import type {
+  RemoteWorkflow,
+  ShellChange,
+  WorkflowApplySpec,
+} from '../../services/layout/workflow-apply';
 import type { Config } from '@oclif/core';
 
 import { Args, Flags } from '@oclif/core';
@@ -11,9 +15,13 @@ import { LayoutApiError } from '../../services/layout/errors';
 import LayoutManager from '../../services/layout/layout-manager';
 import { explainApiError } from '../../services/layout/plan-format';
 import { resolveCommandScope } from '../../services/layout/resolve-command-scope';
-import { compileWorkflowToBpmn } from '../../services/layout/workflow-bpmn';
-
-type RemoteWorkflow = { collectionId: string; id: string; name: string };
+import { planWorkflowBpmn } from '../../services/layout/sync';
+import {
+  findWorkflowMatches,
+  parseWorkflowSpec,
+  planShellUpdate,
+} from '../../services/layout/workflow-apply';
+import { WorkflowSpecError, compileWorkflowToBpmn } from '../../services/layout/workflow-bpmn';
 
 function readStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -27,23 +35,32 @@ function readStdin(): Promise<string> {
   });
 }
 
+/** Read the spec: from the file when given, else from the (non-TTY) stdin pipe. */
 async function readInput(filePath: string | undefined): Promise<string> {
-  if (!filePath || filePath === '-') return readStdin();
+  if (!filePath) return readStdin();
 
-  return readFile(filePath, 'utf8');
+  try {
+    return await readFile(filePath, 'utf8');
+  } catch (error) {
+    const reason =
+      (error as NodeJS.ErrnoException).code === 'ENOENT'
+        ? 'no such file'
+        : (error as Error).message;
+    throw new WorkflowSpecError(`Cannot read spec file "${filePath}": ${reason}.`);
+  }
 }
 
-/** Find the workflow to upsert: by explicit `id`, else by name + collection. */
-function findWorkflowMatch(
-  existing: RemoteWorkflow[],
-  id: string | undefined,
-  name: string,
-  collection: string,
-): RemoteWorkflow | undefined {
-  if (id) return existing.find(workflow => workflow.id === id);
-
-  return existing.find(workflow => workflow.name === name && workflow.collectionId === collection);
-}
+/** What one run decided to do, resolved before anything is sent (and shown as the plan). */
+type ApplyPlan = {
+  bpmn: string;
+  bpmnChanged: boolean;
+  /** Append position for a created workflow (when the spec pins none). */
+  existingCount: number;
+  id: string;
+  match?: RemoteWorkflow;
+  renderingId: number;
+  shellChanges: ShellChange[];
+};
 
 /** Add a new (BPMN-less) workflow shell to the layout. */
 function addWorkflowShell(
@@ -72,98 +89,78 @@ function addWorkflowShell(
 }
 
 /**
- * Upload the compiled BPMN and link it to the workflow. If this fails right
- * after a new shell was created, roll the shell back (best-effort) so no
- * unusable, BPMN-less workflow is left behind (an existing workflow is left as
- * is — its previous BPMN stays linked and re-applying converges).
- */
-async function uploadAndLinkBpmn(
-  manager: LayoutManager,
-  scope: LayoutScope,
-  params: { bpmn: string; collection: string; created: boolean; id: string },
-): Promise<void> {
-  try {
-    const renderingId = await manager.getRenderingId(scope);
-    const version = await manager.uploadWorkflowBpmn(
-      scope,
-      params.id,
-      params.collection,
-      renderingId,
-      params.bpmn,
-    );
-    await manager.patchDomain(
-      'workflows',
-      [{ op: 'replace', path: `/workflows/${params.id}/bpmnAwsS3Identifier`, value: version }],
-      scope,
-    );
-  } catch (uploadError) {
-    if (params.created) {
-      await manager
-        .patchDomain('workflows', [{ op: 'remove', path: `/workflows/${params.id}` }], scope)
-        .catch(() => undefined);
-    }
-
-    throw uploadError;
-  }
-}
-
-/**
  * `forest workflow apply` — create-or-update ONE workflow from a JSON `steps`
  * spec, without touching the rest of the layout. The spec is the source of
  * truth: editing a workflow (e.g. adding a step) means editing the JSON and
- * re-applying — the whole BPMN is recompiled and re-uploaded (it is atomic;
- * there is no per-step patch). Upsert is matched by explicit `id`, else by
- * name + collection.
+ * re-applying — the whole BPMN is recompiled and re-uploaded when it differs
+ * (it is atomic; there is no per-step patch), and the shell metadata (name,
+ * segments, position when pinned) is converged with `replace` patches. Upsert
+ * is matched by explicit `id`, else by name + collection.
  *
- * Sequence: compile steps -> BPMN; PATCH add the workflow (if new); upload the
- * BPMN to the env's S3 (presigned); PATCH the returned `bpmnAwsS3Identifier`.
+ * Sequence: compile steps -> BPMN; show the plan and confirm; PATCH the shell
+ * (add if new, metadata replaces otherwise); upload the BPMN to the env's S3
+ * (presigned) when it changed; PATCH the returned `bpmnAwsS3Identifier`.
  */
 export default class WorkflowApplyCommand extends AbstractAuthenticatedCommand {
   private readonly env: { FOREST_SERVER_URL: string } & Record<string, unknown>;
 
+  private readonly inquirer: { prompt(questions: unknown): Promise<{ confirm: boolean }> };
+
   static override args = {
     file: Args.string({
       description:
-        'JSON workflow spec ({ name, collection, steps, id?, segments? }). "-" or omit to read stdin.',
+        'JSON workflow spec ({ name, collection, steps, id?, segments?, position?, version? }). "-" or omit to read stdin.',
       required: false,
     }),
   };
 
   static override description =
-    'Create or update a workflow from a JSON steps spec (compiles to BPMN and uploads it).';
+    'Create or update a workflow from a JSON steps spec (compiles to BPMN and uploads it). ' +
+    'Reading the spec from stdin disables prompts: pass -p/-e/-t and --force explicitly.';
 
   static override flags = {
-    'dry-run': Flags.boolean({ description: 'Compile and validate only; do not send anything.' }),
+    'dry-run': Flags.boolean({
+      description: 'Resolve the scope, match the workflow and print the plan; send nothing.',
+    }),
     env: Flags.string({ char: 'e', description: 'Environment name or id.' }),
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Skip the confirmation prompt (required when the spec is read from stdin).',
+    }),
     projectId: Flags.integer({ char: 'p', description: 'Project id.' }),
     team: Flags.string({ char: 't', description: 'Team name or id.' }),
   };
 
   constructor(argv: string[], config: Config, plan?) {
     super(argv, config, plan);
-    const { assertPresent, env } = this.context;
-    assertPresent({ env });
+    const { assertPresent, env, inquirer } = this.context;
+    assertPresent({ env, inquirer });
     this.env = env;
+    this.inquirer = inquirer;
   }
 
   protected async runAuthenticated(): Promise<void> {
     const { args, flags } = await this.parse(WorkflowApplyCommand);
+    const fromStdin = !args.file || args.file === '-';
 
-    const spec = JSON.parse(await readInput(args.file)) as Partial<WorkflowSpec> & { id?: string };
-
-    // compileWorkflowToBpmn validates the spec (name/collection/steps) and throws WorkflowSpecError.
-    const bpmn = compileWorkflowToBpmn(spec);
-    const collection = spec.collection as string;
-    const name = spec.name as string;
-    const stepCount = (spec.steps ?? []).length;
-
-    if (flags['dry-run']) {
-      this.log(
-        `workflow "${name}" on ${collection}: ${stepCount} steps → ${bpmn.length} bytes of BPMN`,
-      );
-      this.log('\n(dry-run: nothing sent)');
-
+    if (!this.checkStdinUsage(fromStdin, flags)) {
+      this.exit(2);
       return;
+    }
+
+    let spec: WorkflowApplySpec;
+    let bpmn: string;
+    try {
+      spec = parseWorkflowSpec(await readInput(fromStdin ? undefined : args.file));
+      bpmn = compileWorkflowToBpmn(spec);
+    } catch (error) {
+      if (error instanceof WorkflowSpecError) {
+        this.logger.error(error.message);
+        this.exit(2);
+        return;
+      }
+
+      throw error;
     }
 
     const scope = await resolveCommandScope({
@@ -174,41 +171,24 @@ export default class WorkflowApplyCommand extends AbstractAuthenticatedCommand {
     const manager = new LayoutManager();
 
     try {
-      const existing = (await manager.getLayoutDomain('workflows', scope)) as RemoteWorkflow[];
-      const match = findWorkflowMatch(existing, spec.id, name, collection);
+      const plan = await this.planApply(manager, scope, spec, bpmn);
 
-      // `collectionId` is add-only server-side: matching an existing workflow by
-      // `id` but pointing it at a different collection would upload BPMN for the
-      // new collection against the old shell, silently corrupting it. Reject it.
-      if (match && match.collectionId !== collection) {
-        throw new Error(
-          `Workflow "${match.id}" is on collection "${match.collectionId}", not "${collection}". ` +
-            'A workflow cannot change collection — remove the `id`/rename to create a new one.',
-        );
+      if (plan.match && !plan.bpmnChanged && plan.shellChanges.length === 0) {
+        this.logger.success('Nothing to apply: the workflow already matches the spec.');
+        return;
       }
 
-      const id = match?.id ?? spec.id ?? randomUUID();
-      const created = !match;
+      this.printPlan(plan, spec, scope, flags['dry-run']);
 
-      if (created) {
-        await addWorkflowShell(manager, scope, {
-          collection,
-          id,
-          name,
-          position: existing.length,
-          segments: spec.segments ?? [],
-        });
+      if (flags['dry-run']) {
+        this.log('\n(dry-run: nothing sent)');
+        return;
       }
 
-      await uploadAndLinkBpmn(manager, scope, { bpmn, collection, created, id });
+      if (!flags.force && !(await this.confirmOrBail(fromStdin, scope))) return;
 
-      this.logger.success(
-        `${match ? 'Updated' : 'Created'} workflow ${this.chalk.bold(
-          name,
-        )} (${stepCount} steps) on ${this.chalk.bold(scope.environmentName)} / ${this.chalk.bold(
-          scope.teamName,
-        )}.`,
-      );
+      await this.executePlan(manager, scope, spec, plan);
+      this.printOutcome(plan, spec, scope);
     } catch (error) {
       if (error instanceof LayoutApiError && error.status !== 401) {
         this.logger.error(explainApiError(error, []));
@@ -217,5 +197,221 @@ export default class WorkflowApplyCommand extends AbstractAuthenticatedCommand {
 
       throw error;
     }
+  }
+
+  /** M2 guards: no silent hang on a TTY, no interactive prompt when stdin carries the spec. */
+  private checkStdinUsage(
+    fromStdin: boolean,
+    flags: { env?: string; projectId?: number; team?: string },
+  ): boolean {
+    if (!fromStdin) return true;
+
+    if (process.stdin.isTTY) {
+      this.logger.error(
+        'Missing spec: pass a file path, or pipe JSON via stdin (e.g. `forest workflow apply spec.json`).',
+      );
+      return false;
+    }
+
+    if (flags.projectId === undefined || !flags.env || !flags.team) {
+      this.logger.error(
+        'Reading the spec from stdin disables interactive prompts: pass -p, -e and -t explicitly.',
+      );
+      return false;
+    }
+
+    return true;
+  }
+
+  /** Resolve everything the apply needs (match, metadata diff, BPMN diff) — read-only. */
+  private async planApply(
+    manager: LayoutManager,
+    scope: LayoutScope,
+    spec: WorkflowApplySpec,
+    bpmn: string,
+  ): Promise<ApplyPlan> {
+    const existing = (await manager.getLayoutDomain('workflows', scope)) as RemoteWorkflow[];
+    const matches = findWorkflowMatches(existing, spec);
+
+    if (matches.length > 1) {
+      this.logger.warn(
+        `${matches.length} workflows named "${spec.name}" exist on collection ${spec.collection} — updating the first (id ${matches[0].id}).`,
+      );
+    }
+
+    const match = matches[0];
+    if (match && match.collectionId !== spec.collection) {
+      throw new Error(
+        `Workflow "${match.id}" is on collection "${match.collectionId}", not "${spec.collection}". ` +
+          'A workflow cannot change collection — remove the `id`/rename to create a new one.',
+      );
+    }
+
+    const id = match?.id ?? spec.id ?? randomUUID();
+    const renderingId = await manager.getRenderingId(scope);
+    // Reuses the layout-apply idempotency brick: byte-compare the compiled BPMN
+    // against the stored version, so an unchanged spec uploads nothing (and a
+    // re-apply is a true no-op).
+    const [bpmnPlan] = match
+      ? await planWorkflowBpmn(
+          manager,
+          scope,
+          [
+            {
+              collectionId: spec.collection as string,
+              id,
+              name: spec.name as string,
+              segmentIds: spec.segments,
+              steps: spec.steps as unknown[],
+            },
+          ],
+          existing as never,
+          renderingId,
+        )
+      : [{ bpmn, changed: true }];
+
+    return {
+      bpmn: bpmnPlan.bpmn,
+      bpmnChanged: bpmnPlan.changed,
+      existingCount: existing.length,
+      id,
+      match,
+      renderingId,
+      shellChanges: match ? planShellUpdate(match, spec) : [],
+    };
+  }
+
+  /** Say what is about to happen (or would, on --dry-run) before doing anything. */
+  private printPlan(
+    plan: ApplyPlan,
+    spec: WorkflowApplySpec,
+    scope: LayoutScope,
+    dryRun: boolean,
+  ): void {
+    const verb = dryRun ? 'Would' : 'Will';
+    const target = `${scope.environmentName} / ${scope.teamName}`;
+    const stepCount = (spec.steps ?? []).length;
+
+    if (!plan.match) {
+      this.log(
+        `${verb} CREATE workflow "${spec.name}" on collection ${spec.collection} (${stepCount} steps) on ${target}.`,
+      );
+      return;
+    }
+
+    this.log(`${verb} UPDATE workflow "${plan.match.name}" (id ${plan.match.id}) on ${target}:`);
+    plan.shellChanges.forEach(change => this.log(`  ~ ${change.label}`));
+    this.log(
+      plan.bpmnChanged
+        ? `  ~ BPMN: recompiled and replaced (${stepCount} steps) — the current BPMN and its layout edits will be overwritten`
+        : '  = BPMN unchanged, upload will be skipped',
+    );
+  }
+
+  /** Interactive confirmation — impossible when stdin carries the spec (require --force). */
+  private async confirmOrBail(fromStdin: boolean, scope: LayoutScope): Promise<boolean> {
+    if (fromStdin) {
+      this.logger.error(
+        'Cannot ask for confirmation when the spec is read from stdin: pass --force to apply.',
+      );
+      this.exit(2);
+      return false;
+    }
+
+    const { confirm } = await this.inquirer.prompt([
+      {
+        message: `Apply this workflow to ${scope.environmentName} / ${scope.teamName}?`,
+        name: 'confirm',
+        type: 'confirm',
+      },
+    ]);
+
+    if (!confirm) this.logger.info('Aborted: nothing was applied.');
+
+    return confirm;
+  }
+
+  private async executePlan(
+    manager: LayoutManager,
+    scope: LayoutScope,
+    spec: WorkflowApplySpec,
+    plan: ApplyPlan,
+  ): Promise<void> {
+    if (!plan.match) {
+      await addWorkflowShell(manager, scope, {
+        collection: spec.collection as string,
+        id: plan.id,
+        name: spec.name as string,
+        position: spec.position ?? plan.existingCount,
+        segments: spec.segments ?? [],
+      });
+    } else if (plan.shellChanges.length > 0) {
+      await manager.patchDomain(
+        'workflows',
+        plan.shellChanges.map(change => change.op),
+        scope,
+      );
+    }
+
+    if (plan.bpmnChanged) await this.uploadAndLinkBpmn(manager, scope, spec, plan);
+  }
+
+  /**
+   * Upload the compiled BPMN and link it to the workflow. If this fails right
+   * after a new shell was created, roll the shell back so no unusable,
+   * BPMN-less workflow is left behind (an existing workflow is left as is —
+   * its previous BPMN stays linked and re-applying converges). A failed
+   * rollback is warned about, never swallowed.
+   */
+  private async uploadAndLinkBpmn(
+    manager: LayoutManager,
+    scope: LayoutScope,
+    spec: WorkflowApplySpec,
+    plan: ApplyPlan,
+  ): Promise<void> {
+    try {
+      const version = await manager.uploadWorkflowBpmn(
+        scope,
+        plan.id,
+        spec.collection as string,
+        plan.renderingId,
+        plan.bpmn,
+      );
+      await manager.patchDomain(
+        'workflows',
+        [{ op: 'replace', path: `/workflows/${plan.id}/bpmnAwsS3Identifier`, value: version }],
+        scope,
+      );
+    } catch (uploadError) {
+      if (!plan.match) {
+        await manager
+          .patchDomain('workflows', [{ op: 'remove', path: `/workflows/${plan.id}` }], scope)
+          .catch(() => {
+            this.logger.warn(
+              `Failed to roll back workflow shell ${plan.id}: a workflow without BPMN may remain — delete it from the UI.`,
+            );
+          });
+      }
+
+      throw uploadError;
+    }
+  }
+
+  /** Success message reflecting what actually changed. */
+  private printOutcome(plan: ApplyPlan, spec: WorkflowApplySpec, scope: LayoutScope): void {
+    const name = this.chalk.bold(spec.name as string);
+    const target = `${this.chalk.bold(scope.environmentName)} / ${this.chalk.bold(scope.teamName)}`;
+    const stepCount = (spec.steps ?? []).length;
+
+    if (!plan.match) {
+      this.logger.success(`Created workflow ${name} (${stepCount} steps) on ${target}.`);
+      return;
+    }
+
+    const details = [
+      ...plan.shellChanges.map(change => change.field),
+      plan.bpmnChanged ? `BPMN uploaded (${stepCount} steps)` : 'BPMN unchanged, skipped',
+    ];
+    this.logger.success(`Updated workflow ${name} on ${target} (${details.join(', ')}).`);
   }
 }

--- a/src/commands/workflow/apply.ts
+++ b/src/commands/workflow/apply.ts
@@ -1,0 +1,155 @@
+import type { WorkflowSpec } from '../../services/layout/workflow-bpmn';
+import type { Config } from '@oclif/core';
+
+import { Args, Flags } from '@oclif/core';
+import { randomUUID } from 'crypto';
+import { readFile } from 'fs/promises';
+
+import AbstractAuthenticatedCommand from '../../abstract-authenticated-command';
+import { LayoutApiError } from '../../services/layout/errors';
+import LayoutManager from '../../services/layout/layout-manager';
+import { explainApiError } from '../../services/layout/plan-format';
+import { resolveCommandScope } from '../../services/layout/resolve-command-scope';
+import { compileWorkflowToBpmn } from '../../services/layout/workflow-bpmn';
+
+type RemoteWorkflow = { collectionId: string; id: string; name: string };
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', chunk => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+async function readInput(filePath: string | undefined): Promise<string> {
+  if (!filePath || filePath === '-') return readStdin();
+
+  return readFile(filePath, 'utf8');
+}
+
+/**
+ * `forest workflow apply` — create-or-update ONE workflow from a JSON `steps`
+ * spec, without touching the rest of the layout. The spec is the source of
+ * truth: editing a workflow (e.g. adding a step) means editing the JSON and
+ * re-applying — the whole BPMN is recompiled and re-uploaded (it is atomic;
+ * there is no per-step patch). Upsert is matched by explicit `id`, else by
+ * name + collection.
+ *
+ * Sequence: compile steps -> BPMN; PATCH add the workflow (if new); upload the
+ * BPMN to the env's S3 (presigned); PATCH the returned `bpmnAwsS3Identifier`.
+ */
+export default class WorkflowApplyCommand extends AbstractAuthenticatedCommand {
+  private readonly env: { FOREST_SERVER_URL: string } & Record<string, unknown>;
+
+  static override args = {
+    file: Args.string({
+      description:
+        'JSON workflow spec ({ name, collection, steps, id?, segments? }). "-" or omit to read stdin.',
+      required: false,
+    }),
+  };
+
+  static override description =
+    'Create or update a workflow from a JSON steps spec (compiles to BPMN and uploads it).';
+
+  static override flags = {
+    'dry-run': Flags.boolean({ description: 'Compile and validate only; do not send anything.' }),
+    env: Flags.string({ char: 'e', description: 'Environment name or id.' }),
+    projectId: Flags.integer({ char: 'p', description: 'Project id.' }),
+    team: Flags.string({ char: 't', description: 'Team name or id.' }),
+  };
+
+  constructor(argv: string[], config: Config, plan?) {
+    super(argv, config, plan);
+    const { assertPresent, env } = this.context;
+    assertPresent({ env });
+    this.env = env;
+  }
+
+  protected async runAuthenticated(): Promise<void> {
+    const { args, flags } = await this.parse(WorkflowApplyCommand);
+
+    const spec = JSON.parse(await readInput(args.file)) as Partial<WorkflowSpec> & { id?: string };
+
+    // compileWorkflowToBpmn validates the spec (name/collection/steps) and throws WorkflowSpecError.
+    const bpmn = compileWorkflowToBpmn(spec);
+    const collection = spec.collection as string;
+    const name = spec.name as string;
+    const stepCount = (spec.steps ?? []).length;
+
+    if (flags['dry-run']) {
+      this.log(
+        `workflow "${name}" on ${collection}: ${stepCount} steps → ${bpmn.length} bytes of BPMN`,
+      );
+      this.log('\n(dry-run: nothing sent)');
+
+      return;
+    }
+
+    const scope = await resolveCommandScope({
+      baseEnv: this.env,
+      flags: { env: flags.env, projectId: flags.projectId, team: flags.team },
+    });
+
+    const manager = new LayoutManager();
+
+    try {
+      const existing = (await manager.getLayoutDomain('workflows', scope)) as RemoteWorkflow[];
+      const match = existing.find(workflow =>
+        spec.id
+          ? workflow.id === spec.id
+          : workflow.name === name && workflow.collectionId === collection,
+      );
+      const id = match?.id ?? spec.id ?? randomUUID();
+
+      if (!match) {
+        await manager.patchDomain(
+          'workflows',
+          [
+            {
+              op: 'add',
+              path: '/workflows/-',
+              value: {
+                collectionId: collection,
+                id,
+                isVisible: true,
+                name,
+                position: existing.length,
+                segmentIds: spec.segments ?? [],
+              },
+            },
+          ],
+          scope,
+        );
+      }
+
+      const renderingId = await manager.getRenderingId(scope);
+      const version = await manager.uploadWorkflowBpmn(scope, id, collection, renderingId, bpmn);
+      await manager.patchDomain(
+        'workflows',
+        [{ op: 'replace', path: `/workflows/${id}/bpmnAwsS3Identifier`, value: version }],
+        scope,
+      );
+
+      this.logger.success(
+        `${match ? 'Updated' : 'Created'} workflow ${this.chalk.bold(
+          name,
+        )} (${stepCount} steps) on ${this.chalk.bold(scope.environmentName)} / ${this.chalk.bold(
+          scope.teamName,
+        )}.`,
+      );
+    } catch (error) {
+      if (error instanceof LayoutApiError && error.status !== 401) {
+        this.logger.error(explainApiError(error, []));
+        this.exit(2);
+      }
+
+      throw error;
+    }
+  }
+}

--- a/src/commands/workflow/apply.ts
+++ b/src/commands/workflow/apply.ts
@@ -95,7 +95,8 @@ function addWorkflowShell(
  * re-applying — the whole BPMN is recompiled and re-uploaded when it differs
  * (it is atomic; there is no per-step patch), and the shell metadata (name,
  * segments, position when pinned) is converged with `replace` patches. Upsert
- * is matched by explicit `id`, else by name + collection.
+ * is matched by explicit `id` (which must exist — a stale id is an error, not
+ * a create), else by name + collection.
  *
  * Sequence: compile steps -> BPMN; show the plan and confirm; PATCH the shell
  * (add if new, metadata replaces otherwise); upload the BPMN to the env's S3
@@ -109,7 +110,7 @@ export default class WorkflowApplyCommand extends AbstractAuthenticatedCommand {
   static override args = {
     file: Args.string({
       description:
-        'JSON workflow spec ({ name, collection, steps, id?, segments?, position?, version? }). "-" or omit to read stdin.',
+        'JSON workflow spec ({ name, collection, steps, id?, segments?, position?, start?, version? }). "-" or omit to read stdin.',
       required: false,
     }),
   };
@@ -154,12 +155,7 @@ export default class WorkflowApplyCommand extends AbstractAuthenticatedCommand {
       spec = parseWorkflowSpec(await readInput(fromStdin ? undefined : args.file));
       bpmn = compileWorkflowToBpmn(spec);
     } catch (error) {
-      if (error instanceof WorkflowSpecError) {
-        this.logger.error(error.message);
-        this.exit(2);
-        return;
-      }
-
+      if (this.reportSpecError(error)) return;
       throw error;
     }
 
@@ -171,25 +167,12 @@ export default class WorkflowApplyCommand extends AbstractAuthenticatedCommand {
     const manager = new LayoutManager();
 
     try {
-      const plan = await this.planApply(manager, scope, spec, bpmn);
-
-      if (plan.match && !plan.bpmnChanged && plan.shellChanges.length === 0) {
-        this.logger.success('Nothing to apply: the workflow already matches the spec.');
-        return;
-      }
-
-      this.printPlan(plan, spec, scope, flags['dry-run']);
-
-      if (flags['dry-run']) {
-        this.log('\n(dry-run: nothing sent)');
-        return;
-      }
-
-      if (!flags.force && !(await this.confirmOrBail(fromStdin, scope))) return;
-
-      await this.executePlan(manager, scope, spec, plan);
-      this.printOutcome(plan, spec, scope);
+      await this.planAndExecute(manager, scope, spec, bpmn, flags, fromStdin);
     } catch (error) {
+      // Planning-time spec/environment mismatches (e.g. an `id` matching no
+      // remote workflow) get the same clean-error treatment as parse errors.
+      if (this.reportSpecError(error)) return;
+
       if (error instanceof LayoutApiError && error.status !== 401) {
         this.logger.error(explainApiError(error, []));
         this.exit(2);
@@ -197,6 +180,44 @@ export default class WorkflowApplyCommand extends AbstractAuthenticatedCommand {
 
       throw error;
     }
+  }
+
+  private async planAndExecute(
+    manager: LayoutManager,
+    scope: LayoutScope,
+    spec: WorkflowApplySpec,
+    bpmn: string,
+    flags: { 'dry-run': boolean; force: boolean },
+    fromStdin: boolean,
+  ): Promise<void> {
+    const plan = await this.planApply(manager, scope, spec, bpmn);
+
+    if (plan.match && !plan.bpmnChanged && plan.shellChanges.length === 0) {
+      this.logger.success('Nothing to apply: the workflow already matches the spec.');
+      return;
+    }
+
+    this.printPlan(plan, spec, scope, flags['dry-run']);
+
+    if (flags['dry-run']) {
+      this.log('\n(dry-run: nothing sent)');
+      return;
+    }
+
+    if (!flags.force && !(await this.confirmOrBail(fromStdin, scope))) return;
+
+    await this.executePlan(manager, scope, spec, plan);
+    this.printOutcome(plan, spec, scope);
+  }
+
+  private reportSpecError(error: unknown): boolean {
+    if (error instanceof WorkflowSpecError) {
+      this.logger.error(error.message);
+      this.exit(2);
+      return true;
+    }
+
+    return false;
   }
 
   /** M2 guards: no silent hang on a TTY, no interactive prompt when stdin carries the spec. */
@@ -233,6 +254,15 @@ export default class WorkflowApplyCommand extends AbstractAuthenticatedCommand {
     const existing = (await manager.getLayoutDomain('workflows', scope)) as RemoteWorkflow[];
     const matches = findWorkflowMatches(existing, spec);
 
+    // An explicit `id` means "update that workflow" — silently creating a new
+    // one (reusing a stale/mistyped id) would bypass the name+collection upsert.
+    if (spec.id !== undefined && matches.length === 0) {
+      throw new WorkflowSpecError(
+        `No workflow with id "${spec.id}" found in this environment. ` +
+          'Remove `id` from the spec to create a new workflow, or fix it to update an existing one.',
+      );
+    }
+
     if (matches.length > 1) {
       this.logger.warn(
         `${matches.length} workflows named "${spec.name}" exist on collection ${spec.collection} — updating the first (id ${matches[0].id}).`,
@@ -247,7 +277,7 @@ export default class WorkflowApplyCommand extends AbstractAuthenticatedCommand {
       );
     }
 
-    const id = match?.id ?? spec.id ?? randomUUID();
+    const id = match?.id ?? randomUUID();
     const renderingId = await manager.getRenderingId(scope);
     // Reuses the layout-apply idempotency brick: byte-compare the compiled BPMN
     // against the stored version, so an unchanged spec uploads nothing (and a
@@ -262,6 +292,7 @@ export default class WorkflowApplyCommand extends AbstractAuthenticatedCommand {
               id,
               name: spec.name as string,
               segmentIds: spec.segments,
+              start: spec.start,
               steps: spec.steps as unknown[],
             },
           ],

--- a/src/commands/workflow/apply.ts
+++ b/src/commands/workflow/apply.ts
@@ -1,3 +1,4 @@
+import type { LayoutScope } from '../../services/layout/types';
 import type { WorkflowSpec } from '../../services/layout/workflow-bpmn';
 import type { Config } from '@oclif/core';
 
@@ -30,6 +31,80 @@ async function readInput(filePath: string | undefined): Promise<string> {
   if (!filePath || filePath === '-') return readStdin();
 
   return readFile(filePath, 'utf8');
+}
+
+/** Find the workflow to upsert: by explicit `id`, else by name + collection. */
+function findWorkflowMatch(
+  existing: RemoteWorkflow[],
+  id: string | undefined,
+  name: string,
+  collection: string,
+): RemoteWorkflow | undefined {
+  if (id) return existing.find(workflow => workflow.id === id);
+
+  return existing.find(workflow => workflow.name === name && workflow.collectionId === collection);
+}
+
+/** Add a new (BPMN-less) workflow shell to the layout. */
+function addWorkflowShell(
+  manager: LayoutManager,
+  scope: LayoutScope,
+  shell: { collection: string; id: string; name: string; position: number; segments: string[] },
+): Promise<void> {
+  return manager.patchDomain(
+    'workflows',
+    [
+      {
+        op: 'add',
+        path: '/workflows/-',
+        value: {
+          collectionId: shell.collection,
+          id: shell.id,
+          isVisible: true,
+          name: shell.name,
+          position: shell.position,
+          segmentIds: shell.segments,
+        },
+      },
+    ],
+    scope,
+  );
+}
+
+/**
+ * Upload the compiled BPMN and link it to the workflow. If this fails right
+ * after a new shell was created, roll the shell back (best-effort) so no
+ * unusable, BPMN-less workflow is left behind (an existing workflow is left as
+ * is — its previous BPMN stays linked and re-applying converges).
+ */
+async function uploadAndLinkBpmn(
+  manager: LayoutManager,
+  scope: LayoutScope,
+  params: { bpmn: string; collection: string; created: boolean; id: string },
+): Promise<void> {
+  try {
+    const renderingId = await manager.getRenderingId(scope);
+    const version = await manager.uploadWorkflowBpmn(
+      scope,
+      params.id,
+      params.collection,
+      renderingId,
+      params.bpmn,
+    );
+    await manager.patchDomain(
+      'workflows',
+      [{ op: 'replace', path: `/workflows/${params.id}/bpmnAwsS3Identifier`, value: version }],
+      scope,
+    );
+  } catch (uploadError) {
+    if (params.created) {
+      await manager
+        .patchDomain('workflows', [{ op: 'remove', path: `/workflows/${params.id}` }], scope)
+        .catch(() => undefined);
+    }
+
+    throw uploadError;
+  }
 }
 
 /**
@@ -100,41 +175,32 @@ export default class WorkflowApplyCommand extends AbstractAuthenticatedCommand {
 
     try {
       const existing = (await manager.getLayoutDomain('workflows', scope)) as RemoteWorkflow[];
-      const match = existing.find(workflow =>
-        spec.id
-          ? workflow.id === spec.id
-          : workflow.name === name && workflow.collectionId === collection,
-      );
-      const id = match?.id ?? spec.id ?? randomUUID();
+      const match = findWorkflowMatch(existing, spec.id, name, collection);
 
-      if (!match) {
-        await manager.patchDomain(
-          'workflows',
-          [
-            {
-              op: 'add',
-              path: '/workflows/-',
-              value: {
-                collectionId: collection,
-                id,
-                isVisible: true,
-                name,
-                position: existing.length,
-                segmentIds: spec.segments ?? [],
-              },
-            },
-          ],
-          scope,
+      // `collectionId` is add-only server-side: matching an existing workflow by
+      // `id` but pointing it at a different collection would upload BPMN for the
+      // new collection against the old shell, silently corrupting it. Reject it.
+      if (match && match.collectionId !== collection) {
+        throw new Error(
+          `Workflow "${match.id}" is on collection "${match.collectionId}", not "${collection}". ` +
+            'A workflow cannot change collection — remove the `id`/rename to create a new one.',
         );
       }
 
-      const renderingId = await manager.getRenderingId(scope);
-      const version = await manager.uploadWorkflowBpmn(scope, id, collection, renderingId, bpmn);
-      await manager.patchDomain(
-        'workflows',
-        [{ op: 'replace', path: `/workflows/${id}/bpmnAwsS3Identifier`, value: version }],
-        scope,
-      );
+      const id = match?.id ?? spec.id ?? randomUUID();
+      const created = !match;
+
+      if (created) {
+        await addWorkflowShell(manager, scope, {
+          collection,
+          id,
+          name,
+          position: existing.length,
+          segments: spec.segments ?? [],
+        });
+      }
+
+      await uploadAndLinkBpmn(manager, scope, { bpmn, collection, created, id });
 
       this.logger.success(
         `${match ? 'Updated' : 'Created'} workflow ${this.chalk.bold(

--- a/src/services/layout/sync.ts
+++ b/src/services/layout/sync.ts
@@ -39,6 +39,8 @@ export type StepWorkflow = {
   id: string;
   name: string;
   segmentIds?: string[];
+  /** Entry step id — must reach the compiler, which otherwise falls back to the first step. */
+  start?: string;
   steps: unknown[];
 };
 
@@ -58,6 +60,7 @@ export function stepWorkflows(local: LayoutFileDoc): StepWorkflow[] {
         id: String(workflow.id),
         name: String(workflow.name),
         segmentIds: workflow.segmentIds as string[] | undefined,
+        start: typeof workflow.start === 'string' ? workflow.start : undefined,
         steps: workflow.steps as unknown[],
       };
     });
@@ -85,6 +88,7 @@ export async function planWorkflowBpmn(
         collection: workflow.collectionId,
         name: workflow.name,
         segments: workflow.segmentIds,
+        start: workflow.start,
         steps: workflow.steps as never,
       });
 

--- a/src/services/layout/workflow-apply.ts
+++ b/src/services/layout/workflow-apply.ts
@@ -1,0 +1,242 @@
+/**
+ * Pure logic behind `forest workflow apply`: strict parsing of the JSON spec
+ * (which `forest-layout.json` deliberately does NOT get — that file is a
+ * machine round-trip, this one is hand-authored), upsert matching against the
+ * remote workflows document, and the metadata `replace` plan for updates.
+ * Kept free of IO so it is unit-testable; the command provides the glue.
+ */
+import type { JsonPatchOp } from './types';
+import type { WorkflowSpec } from './workflow-bpmn';
+
+import { WorkflowSpecError } from './workflow-bpmn';
+
+/** The hand-authored apply spec: a {@link WorkflowSpec} plus upsert extras. */
+export type WorkflowApplySpec = Partial<WorkflowSpec> & {
+  id?: string;
+  position?: number;
+  version?: number;
+};
+
+/** A workflow as returned by `GET /api/workflows/...` (patchable document). */
+export type RemoteWorkflow = {
+  bpmnAwsS3Identifier?: string;
+  collectionId: string;
+  id: string;
+  name: string;
+  position?: number;
+  segmentIds?: string[];
+};
+
+/** One planned metadata change on an existing workflow (`replace` + display label). */
+export type ShellChange = {
+  field: 'name' | 'position' | 'segments';
+  label: string;
+  op: JsonPatchOp;
+};
+
+const TOP_LEVEL_FIELDS = [
+  'collection',
+  'id',
+  'name',
+  'position',
+  'segments',
+  'start',
+  'steps',
+  'version',
+];
+
+const STEP_FIELDS = [
+  'auto',
+  'autoComplete',
+  'branches',
+  'id',
+  'inboxId',
+  'mcpServerId',
+  'next',
+  'prompt',
+  'title',
+  'type',
+];
+
+const BRANCH_FIELDS = ['answer', 'color', 'next'];
+
+/** Mirrors the server patch whitelist (`patch-rules.ts` NUM_OR_UUID): a workflow id is numeric or a UUID. */
+const WORKFLOW_ID_RE = /^([0-9]+|[0-9a-fA-F-]{36})$/;
+
+/** Case-insensitive Levenshtein distance, for "did you mean" suggestions. */
+function editDistance(from: string, to: string): number {
+  const a = from.toLowerCase();
+  const b = to.toLowerCase();
+  let previous = Array.from({ length: b.length + 1 }, (unused, j) => j);
+
+  for (let i = 1; i <= a.length; i += 1) {
+    const current = [i];
+    for (let j = 1; j <= b.length; j += 1) {
+      current[j] = Math.min(
+        previous[j] + 1,
+        current[j - 1] + 1,
+        previous[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1),
+      );
+    }
+    previous = current;
+  }
+
+  return previous[b.length];
+}
+
+function unknownFieldError(key: string, validFields: string[], where: string): WorkflowSpecError {
+  const [best] = validFields
+    .map(candidate => ({ candidate, distance: editDistance(key, candidate) }))
+    .sort((left, right) => left.distance - right.distance);
+
+  const hint =
+    best && best.distance <= 2
+      ? `did you mean \`${best.candidate}\`?`
+      : `valid fields: ${validFields.join(', ')}.`;
+
+  return new WorkflowSpecError(`Unknown field "${key}"${where} — ${hint}`);
+}
+
+function assertKnownFields(
+  value: Record<string, unknown>,
+  validFields: string[],
+  where: string,
+): void {
+  Object.keys(value).forEach(key => {
+    if (!validFields.includes(key)) throw unknownFieldError(key, validFields, where);
+  });
+}
+
+function assertStepsShape(steps: unknown): void {
+  if (!Array.isArray(steps)) return; // validateWorkflowSpec produces the canonical error.
+
+  steps.forEach((step, index) => {
+    if (!step || typeof step !== 'object' || Array.isArray(step)) {
+      throw new WorkflowSpecError(`\`steps[${index}]\` must be a JSON object.`);
+    }
+
+    const record = step as Record<string, unknown>;
+    const stepWhere = ` in step "${record.id ?? `#${index}`}"`;
+    assertKnownFields(record, STEP_FIELDS, stepWhere);
+
+    if (Array.isArray(record.branches)) {
+      (record.branches as unknown[]).forEach(branch => {
+        if (branch && typeof branch === 'object' && !Array.isArray(branch)) {
+          assertKnownFields(branch as Record<string, unknown>, BRANCH_FIELDS, stepWhere);
+        }
+      });
+    }
+  });
+}
+
+function assertUpsertExtras(spec: WorkflowApplySpec): void {
+  if (spec.version !== undefined && spec.version !== 1) {
+    throw new WorkflowSpecError(
+      `Unsupported spec \`version\` ${JSON.stringify(
+        spec.version,
+      )} — this toolbelt supports version 1 (or omit it).`,
+    );
+  }
+
+  if (spec.id !== undefined && (typeof spec.id !== 'string' || !WORKFLOW_ID_RE.test(spec.id))) {
+    throw new WorkflowSpecError(
+      `\`id\` must be an existing workflow id — a number or a UUID (got ${JSON.stringify(
+        spec.id,
+      )}). Omit it to match by name + collection.`,
+    );
+  }
+
+  if (
+    spec.position !== undefined &&
+    (typeof spec.position !== 'number' || !Number.isInteger(spec.position) || spec.position < 0)
+  ) {
+    throw new WorkflowSpecError(
+      `\`position\` must be a non-negative integer (got ${JSON.stringify(spec.position)}).`,
+    );
+  }
+}
+
+/**
+ * Parse the raw JSON of a `workflow apply` spec, strictly: clean JSON errors,
+ * top-level/step/branch fields are whitelisted (typo-safe: "did you mean?"),
+ * `version` is absent-or-1 and `id`/`position` are format-checked. Semantic
+ * validation of the step graph stays in `validateWorkflowSpec` (shared with
+ * the layout path, which must remain lenient about extra keys).
+ */
+export function parseWorkflowSpec(raw: string): WorkflowApplySpec {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new WorkflowSpecError(
+      `Invalid JSON in spec: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new WorkflowSpecError(
+      'The spec must be a JSON object: { name, collection, steps, id?, segments?, position?, version? }.',
+    );
+  }
+
+  const spec = parsed as WorkflowApplySpec;
+  assertKnownFields(parsed as Record<string, unknown>, TOP_LEVEL_FIELDS, '');
+  assertStepsShape(spec.steps);
+  assertUpsertExtras(spec);
+
+  return spec;
+}
+
+/**
+ * The workflows the spec designates, in remote order: all of them by explicit
+ * `id`, else by name + collection. More than one match means the environment
+ * holds duplicates — the caller warns and updates the first.
+ */
+export function findWorkflowMatches(
+  existing: RemoteWorkflow[],
+  spec: WorkflowApplySpec,
+): RemoteWorkflow[] {
+  if (spec.id) return existing.filter(workflow => String(workflow.id) === spec.id);
+
+  return existing.filter(
+    workflow => workflow.name === spec.name && workflow.collectionId === spec.collection,
+  );
+}
+
+/**
+ * The metadata `replace` ops an update needs so the spec stays the source of
+ * truth: `name` and `segments` are always converged (an omitted `segments`
+ * means "no segments"); `position` only when the spec pins one — the remote
+ * ordering is otherwise left alone.
+ */
+export function planShellUpdate(current: RemoteWorkflow, spec: WorkflowApplySpec): ShellChange[] {
+  const changes: ShellChange[] = [];
+  const base = `/workflows/${current.id}`;
+
+  if (spec.name !== undefined && spec.name !== current.name) {
+    changes.push({
+      field: 'name',
+      label: `name: "${current.name}" → "${spec.name}"`,
+      op: { op: 'replace', path: `${base}/name`, value: spec.name },
+    });
+  }
+
+  const segments = spec.segments ?? [];
+  if (JSON.stringify(segments) !== JSON.stringify(current.segmentIds ?? [])) {
+    changes.push({
+      field: 'segments',
+      label: `segments: [${(current.segmentIds ?? []).join(', ')}] → [${segments.join(', ')}]`,
+      op: { op: 'replace', path: `${base}/segmentIds`, value: segments },
+    });
+  }
+
+  if (spec.position !== undefined && spec.position !== current.position) {
+    changes.push({
+      field: 'position',
+      label: `position: ${current.position ?? '?'} → ${spec.position}`,
+      op: { op: 'replace', path: `${base}/position`, value: spec.position },
+    });
+  }
+
+  return changes;
+}

--- a/src/services/layout/workflow-apply.ts
+++ b/src/services/layout/workflow-apply.ts
@@ -60,6 +60,37 @@ const STEP_FIELDS = [
 
 const BRANCH_FIELDS = ['answer', 'color', 'next'];
 
+/**
+ * Primitive type of each whitelisted field (per level). Checked at parse time
+ * so a wrongly-typed value (e.g. `mcpServerId: 123`) fails with a clean
+ * `WorkflowSpecError` instead of crashing inside the BPMN compiler.
+ * `steps`/`branches` (arrays of objects), `segments` (array of strings) and
+ * the upsert extras `id`/`position`/`version` have dedicated checks.
+ */
+const TOP_LEVEL_FIELD_TYPES: Record<string, 'boolean' | 'string'> = {
+  collection: 'string',
+  name: 'string',
+  start: 'string',
+};
+
+const STEP_FIELD_TYPES: Record<string, 'boolean' | 'string'> = {
+  auto: 'boolean',
+  autoComplete: 'boolean',
+  id: 'string',
+  inboxId: 'string',
+  mcpServerId: 'string',
+  next: 'string',
+  prompt: 'string',
+  title: 'string',
+  type: 'string',
+};
+
+const BRANCH_FIELD_TYPES: Record<string, 'boolean' | 'string'> = {
+  answer: 'string',
+  color: 'string',
+  next: 'string',
+};
+
 /** Mirrors the server patch whitelist (`patch-rules.ts` NUM_OR_UUID): a workflow id is numeric or a UUID. */
 const WORKFLOW_ID_RE = /^([0-9]+|[0-9a-fA-F-]{36})$/;
 
@@ -107,6 +138,40 @@ function assertKnownFields(
   });
 }
 
+function assertFieldTypes(
+  value: Record<string, unknown>,
+  types: Record<string, 'boolean' | 'string'>,
+  where: string,
+): void {
+  Object.entries(types).forEach(([key, expected]) => {
+    const actual = value[key];
+    if (actual !== undefined && typeof actual !== expected) {
+      throw new WorkflowSpecError(
+        `\`${key}\` must be a ${expected}${where} (got ${JSON.stringify(actual)}).`,
+      );
+    }
+  });
+}
+
+function assertBranchesShape(branches: unknown, stepWhere: string): void {
+  if (branches === undefined) return;
+
+  if (!Array.isArray(branches)) {
+    throw new WorkflowSpecError(
+      `\`branches\` must be an array${stepWhere} (got ${JSON.stringify(branches)}).`,
+    );
+  }
+
+  branches.forEach((branch, index) => {
+    if (!branch || typeof branch !== 'object' || Array.isArray(branch)) {
+      throw new WorkflowSpecError(`\`branches[${index}]\` must be a JSON object${stepWhere}.`);
+    }
+
+    assertKnownFields(branch as Record<string, unknown>, BRANCH_FIELDS, stepWhere);
+    assertFieldTypes(branch as Record<string, unknown>, BRANCH_FIELD_TYPES, stepWhere);
+  });
+}
+
 function assertStepsShape(steps: unknown): void {
   if (!Array.isArray(steps)) return; // validateWorkflowSpec produces the canonical error.
 
@@ -118,15 +183,25 @@ function assertStepsShape(steps: unknown): void {
     const record = step as Record<string, unknown>;
     const stepWhere = ` in step "${record.id ?? `#${index}`}"`;
     assertKnownFields(record, STEP_FIELDS, stepWhere);
-
-    if (Array.isArray(record.branches)) {
-      (record.branches as unknown[]).forEach(branch => {
-        if (branch && typeof branch === 'object' && !Array.isArray(branch)) {
-          assertKnownFields(branch as Record<string, unknown>, BRANCH_FIELDS, stepWhere);
-        }
-      });
-    }
+    assertFieldTypes(record, STEP_FIELD_TYPES, stepWhere);
+    assertBranchesShape(record.branches, stepWhere);
   });
+}
+
+function assertTopLevelShape(spec: Record<string, unknown>): void {
+  assertFieldTypes(spec, TOP_LEVEL_FIELD_TYPES, '');
+
+  if (
+    spec.segments !== undefined &&
+    (!Array.isArray(spec.segments) ||
+      (spec.segments as unknown[]).some(segment => typeof segment !== 'string'))
+  ) {
+    throw new WorkflowSpecError(
+      `\`segments\` must be an array of segment ids (strings) (got ${JSON.stringify(
+        spec.segments,
+      )}).`,
+    );
+  }
 }
 
 function assertUpsertExtras(spec: WorkflowApplySpec): void {
@@ -158,8 +233,9 @@ function assertUpsertExtras(spec: WorkflowApplySpec): void {
 
 /**
  * Parse the raw JSON of a `workflow apply` spec, strictly: clean JSON errors,
- * top-level/step/branch fields are whitelisted (typo-safe: "did you mean?"),
- * `version` is absent-or-1 and `id`/`position` are format-checked. Semantic
+ * top-level/step/branch fields are whitelisted (typo-safe: "did you mean?")
+ * and type-checked, `version` is absent-or-1 and `id`/`position` are
+ * format-checked. Semantic
  * validation of the step graph stays in `validateWorkflowSpec` (shared with
  * the layout path, which must remain lenient about extra keys).
  */
@@ -175,12 +251,13 @@ export function parseWorkflowSpec(raw: string): WorkflowApplySpec {
 
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new WorkflowSpecError(
-      'The spec must be a JSON object: { name, collection, steps, id?, segments?, position?, version? }.',
+      'The spec must be a JSON object: { name, collection, steps, id?, segments?, position?, start?, version? }.',
     );
   }
 
   const spec = parsed as WorkflowApplySpec;
   assertKnownFields(parsed as Record<string, unknown>, TOP_LEVEL_FIELDS, '');
+  assertTopLevelShape(parsed as Record<string, unknown>);
   assertStepsShape(spec.steps);
   assertUpsertExtras(spec);
 

--- a/src/services/layout/workflow-bpmn.ts
+++ b/src/services/layout/workflow-bpmn.ts
@@ -57,6 +57,23 @@ export type WorkflowSpec = {
 
 const ID_RE = /^[A-Z_a-z][\w-]*$/;
 
+/** Ids the compiler generates itself — a step id colliding with one of these
+ * (or with a generated `flow_*` sequence-flow / `*_di` diagram id) would produce
+ * duplicate XML ids, which bpmn-js refuses to import. */
+const RESERVED_IDS = new Set([
+  'Start_1',
+  'Process_1',
+  'Definitions_1',
+  'BPMNDiagram_1',
+  'BPMNPlane_1',
+]);
+
+/** The step types that compile to a `serviceTask` (the only element supporting
+ * `forest:automaticExecution`/`forest:automaticCompletion`). */
+const SERVICE_TASK_TYPES = Object.entries(STEP_TYPES)
+  .filter(([, def]) => def.element === 'serviceTask')
+  .map(([type]) => type);
+
 function xml(value: string): string {
   return value
     .replace(/&/g, '&amp;')
@@ -76,6 +93,13 @@ function validateStepIdentity(step: StepSpec, seen: Set<string>): void {
   if (!step.id || !ID_RE.test(step.id)) {
     throw new WorkflowSpecError(
       `Each step needs an \`id\` matching ${ID_RE} (got "${step.id ?? ''}").`,
+    );
+  }
+
+  if (RESERVED_IDS.has(step.id) || step.id.startsWith('flow_') || step.id.endsWith('_di')) {
+    throw new WorkflowSpecError(
+      `Step "${step.id}": this id is reserved for generated BPMN elements ` +
+        `(${[...RESERVED_IDS].join(', ')}, \`flow_*\`, \`*_di\`).`,
     );
   }
 
@@ -117,6 +141,13 @@ function validateLinkStep(step: StepSpec): void {
 
 function validateStep(step: StepSpec, seen: Set<string>): void {
   validateStepIdentity(step, seen);
+
+  if ((step.auto || step.autoComplete) && STEP_TYPES[step.type].element !== 'serviceTask') {
+    throw new WorkflowSpecError(
+      `Step "${step.id}": \`auto\`/\`autoComplete\` are only supported on ` +
+        `${SERVICE_TASK_TYPES.join(', ')} steps.`,
+    );
+  }
 
   if (step.type === 'end') {
     if (step.next || step.branches) {
@@ -167,9 +198,23 @@ export function validateWorkflowSpec(spec: Partial<WorkflowSpec>): WorkflowSpec 
   };
 }
 
-function flowId(source: string, target: string): string {
-  return `flow_${source}_${target}`;
+/**
+ * Allocate a unique, deterministic sequence-flow id. `flow_${source}_${target}`
+ * alone is not unique — two condition branches can point at the same target, and
+ * underscores in step ids can make distinct pairs render the same string — so
+ * collisions get a stable numeric suffix (`_2`, `_3`, …) in spec order.
+ */
+function allocateFlowId(source: string, target: string, used: Set<string>): string {
+  const base = `flow_${source}_${target}`;
+  let id = base;
+  for (let n = 2; used.has(id); n += 1) id = `${base}_${n}`;
+  used.add(id);
+
+  return id;
 }
+
+/** A sequence flow with its allocated id (shared by the element, flow and DI edge). */
+type FlowSpec = { branch: BranchSpec; id: string; source: string };
 
 /** The outgoing transitions of a step: a condition's branches, else its `next`. */
 function branchesOf(step: StepSpec): BranchSpec[] {
@@ -179,14 +224,11 @@ function branchesOf(step: StepSpec): BranchSpec[] {
 }
 
 /** One `<bpmn:sequenceFlow>` (template only, no concatenation). */
-function renderFlow(stepId: string, branch: BranchSpec): string {
-  const nameAttr = branch.answer ? ` name="${xml(branch.answer)}"` : '';
-  const colorAttr = branch.color ? ` forest:buttonColor="${xml(branch.color)}"` : '';
+function renderFlow(flow: FlowSpec): string {
+  const nameAttr = flow.branch.answer ? ` name="${xml(flow.branch.answer)}"` : '';
+  const colorAttr = flow.branch.color ? ` forest:buttonColor="${xml(flow.branch.color)}"` : '';
 
-  return `    <bpmn:sequenceFlow id="${flowId(
-    stepId,
-    branch.next,
-  )}" sourceRef="${stepId}" targetRef="${branch.next}"${nameAttr}${colorAttr} />`;
+  return `    <bpmn:sequenceFlow id="${flow.id}" sourceRef="${flow.source}" targetRef="${flow.branch.next}"${nameAttr}${colorAttr} />`;
 }
 
 /** The `forest:*` attribute string for a step element. */
@@ -211,19 +253,16 @@ function stepAttributes(step: StepSpec): string {
 }
 
 /** Build the BPMN element + its outgoing sequenceFlows for one step. */
-function renderStep(step: StepSpec): { element: string; flows: string[] } {
+function renderStep(step: StepSpec, flowSpecs: FlowSpec[]): { element: string; flows: string[] } {
   const name = xml(step.title ?? step.id);
-  const branches = branchesOf(step);
-  const flows = branches.map(branch => renderFlow(step.id, branch));
+  const flows = flowSpecs.map(flow => renderFlow(flow));
 
   if (step.type === 'end') {
     return { element: `    <bpmn:endEvent id="${step.id}" name="${name}"></bpmn:endEvent>`, flows };
   }
 
   const tag = STEP_TYPES[step.type].element;
-  const outgoing = branches
-    .map(branch => `<bpmn:outgoing>${flowId(step.id, branch.next)}</bpmn:outgoing>`)
-    .join('');
+  const outgoing = flowSpecs.map(flow => `<bpmn:outgoing>${flow.id}</bpmn:outgoing>`).join('');
   const element = `    <bpmn:${tag} id="${step.id}" name="${name}"${stepAttributes(
     step,
   )}>${outgoing}</bpmn:${tag}>`;
@@ -298,30 +337,30 @@ export function compileWorkflowToBpmn(input: Partial<WorkflowSpec>): string {
   const spec = validateWorkflowSpec(input);
   const entryId = spec.start as string;
 
+  const usedFlowIds = new Set<string>();
+  const entryFlowId = allocateFlowId('Start_1', entryId, usedFlowIds);
+
   const nodes: DiagramNode[] = [{ id: 'Start_1', tag: 'startEvent' }];
-  const edges: DiagramEdge[] = [
-    { id: flowId('Start_1', entryId), source: 'Start_1', target: entryId },
-  ];
+  const edges: DiagramEdge[] = [{ id: entryFlowId, source: 'Start_1', target: entryId }];
   const elements: string[] = [
-    `    <bpmn:startEvent id="Start_1"><bpmn:outgoing>${flowId(
-      'Start_1',
-      entryId,
-    )}</bpmn:outgoing></bpmn:startEvent>`,
+    `    <bpmn:startEvent id="Start_1"><bpmn:outgoing>${entryFlowId}</bpmn:outgoing></bpmn:startEvent>`,
   ];
   const flows: string[] = [
-    `    <bpmn:sequenceFlow id="${flowId(
-      'Start_1',
-      entryId,
-    )}" sourceRef="Start_1" targetRef="${entryId}" />`,
+    `    <bpmn:sequenceFlow id="${entryFlowId}" sourceRef="Start_1" targetRef="${entryId}" />`,
   ];
 
   spec.steps.forEach(step => {
-    const rendered = renderStep(step);
+    const flowSpecs: FlowSpec[] = branchesOf(step).map(branch => ({
+      branch,
+      id: allocateFlowId(step.id, branch.next, usedFlowIds),
+      source: step.id,
+    }));
+    const rendered = renderStep(step, flowSpecs);
     elements.push(rendered.element);
     flows.push(...rendered.flows);
     nodes.push({ id: step.id, tag: STEP_TYPES[step.type].element });
-    branchesOf(step).forEach(branch => {
-      edges.push({ id: flowId(step.id, branch.next), source: step.id, target: branch.next });
+    flowSpecs.forEach(flow => {
+      edges.push({ id: flow.id, source: step.id, target: flow.branch.next });
     });
   });
 

--- a/src/services/layout/workflow-bpmn.ts
+++ b/src/services/layout/workflow-bpmn.ts
@@ -194,8 +194,13 @@ function stepAttributes(step: StepSpec): string {
   const def = STEP_TYPES[step.type];
   const attrs: string[] = [];
   if ('alternative' in def) attrs.push(`forest:alternative="${def.alternative}"`);
-  if (step.auto) attrs.push('forest:automaticExecution="true"');
-  if (step.autoComplete) attrs.push('forest:automaticCompletion="true"');
+  // `automaticExecution`/`automaticCompletion` are only meaningful on serviceTask
+  // steps — a `guidance` step is a manual userTask the UI cannot auto-complete, so
+  // emitting the flag there produces BPMN the editor can't round-trip.
+  if (def.element === 'serviceTask') {
+    if (step.auto) attrs.push('forest:automaticExecution="true"');
+    if (step.autoComplete) attrs.push('forest:automaticCompletion="true"');
+  }
   if (step.prompt) attrs.push(`forest:description="${xml(step.prompt)}"`);
   if (step.type === 'mcp' && step.mcpServerId)
     attrs.push(`forest:mcpServerId="${xml(step.mcpServerId)}"`);

--- a/src/services/layout/workflow-bpmn.ts
+++ b/src/services/layout/workflow-bpmn.ts
@@ -226,11 +226,77 @@ function renderStep(step: StepSpec): { element: string; flows: string[] } {
   return { element, flows };
 }
 
+type DiagramNode = { id: string; tag: string };
+type DiagramEdge = { id: string; source: string; target: string };
+type Bounds = { h: number; w: number; x: number; y: number };
+
+/** BPMN element footprint by shape kind (events / gateways / tasks). */
+function elementSize(tag: string): { h: number; w: number } {
+  if (tag.endsWith('Event')) return { h: 36, w: 36 };
+  if (tag === 'exclusiveGateway') return { h: 50, w: 50 };
+
+  return { h: 80, w: 100 };
+}
+
+/**
+ * A minimal left-to-right BPMN-DI diagram. bpmn-js (the workflow editor) refuses
+ * to import a `definitions` with no `<bpmndi:BPMNDiagram>` ("Import BPMN Error"),
+ * so every element needs a shape and every sequence flow an edge — a naive layout
+ * the user can rearrange is enough to make the workflow editable.
+ */
+function renderDiagram(nodes: DiagramNode[], edges: DiagramEdge[]): string[] {
+  const laneCenter = 160;
+  const gap = 60;
+  let cursor = 160;
+  const bounds: Record<string, Bounds> = {};
+  nodes.forEach(node => {
+    const { h, w } = elementSize(node.tag);
+    bounds[node.id] = { h, w, x: cursor, y: laneCenter - h / 2 };
+    cursor += w + gap;
+  });
+
+  const shapes = nodes
+    .map(node => {
+      const b = bounds[node.id];
+      if (!b) return '';
+
+      return `      <bpmndi:BPMNShape id="${node.id}_di" bpmnElement="${node.id}"><dc:Bounds x="${b.x}" y="${b.y}" width="${b.w}" height="${b.h}" /></bpmndi:BPMNShape>`;
+    })
+    .filter(Boolean);
+
+  const flowEdges = edges
+    .map(edge => {
+      const from = bounds[edge.source];
+      const to = bounds[edge.target];
+      if (!from || !to) return '';
+      const x1 = from.x + from.w;
+      const y1 = from.y + from.h / 2;
+      const x2 = to.x;
+      const y2 = to.y + to.h / 2;
+
+      return `      <bpmndi:BPMNEdge id="${edge.id}_di" bpmnElement="${edge.id}"><di:waypoint x="${x1}" y="${y1}" /><di:waypoint x="${x2}" y="${y2}" /></bpmndi:BPMNEdge>`;
+    })
+    .filter(Boolean);
+
+  return [
+    '  <bpmndi:BPMNDiagram id="BPMNDiagram_1">',
+    '    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">',
+    ...shapes,
+    ...flowEdges,
+    '    </bpmndi:BPMNPlane>',
+    '  </bpmndi:BPMNDiagram>',
+  ];
+}
+
 /** Compile a workflow `steps` spec into BPMN XML (validates first). */
 export function compileWorkflowToBpmn(input: Partial<WorkflowSpec>): string {
   const spec = validateWorkflowSpec(input);
   const entryId = spec.start as string;
 
+  const nodes: DiagramNode[] = [{ id: 'Start_1', tag: 'startEvent' }];
+  const edges: DiagramEdge[] = [
+    { id: flowId('Start_1', entryId), source: 'Start_1', target: entryId },
+  ];
   const elements: string[] = [
     `    <bpmn:startEvent id="Start_1"><bpmn:outgoing>${flowId(
       'Start_1',
@@ -248,15 +314,20 @@ export function compileWorkflowToBpmn(input: Partial<WorkflowSpec>): string {
     const rendered = renderStep(step);
     elements.push(rendered.element);
     flows.push(...rendered.flows);
+    nodes.push({ id: step.id, tag: STEP_TYPES[step.type].element });
+    branchesOf(step).forEach(branch => {
+      edges.push({ id: flowId(step.id, branch.next), source: step.id, target: branch.next });
+    });
   });
 
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
-    '<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:forest="https://forestadmin.com">',
+    '<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:forest="https://app.forestadmin.com" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">',
     '  <bpmn:process id="Process_1" isExecutable="true">',
     ...elements,
     ...flows,
     '  </bpmn:process>',
+    ...renderDiagram(nodes, edges),
     '</bpmn:definitions>',
     '',
   ].join('\n');

--- a/test/commands/workflow/apply.test.js
+++ b/test/commands/workflow/apply.test.js
@@ -212,6 +212,67 @@ describe('workflow:apply', () => {
       }));
   });
 
+  describe('when the spec `start` is not the first step (update)', () => {
+    // The recompiled BPMN must honour `start` — dropping it would fall back to
+    // the first step, fake a diff and upload a workflow with a changed entry.
+    const startSpec = {
+      collection: 'cards',
+      name: 'Triage',
+      start: 'read1',
+      steps: [
+        { id: 'notes', next: 'done', type: 'read' },
+        { id: 'read1', next: 'notes', type: 'read' },
+        { id: 'done', type: 'end' },
+      ],
+    };
+
+    it('compares (and would upload) a BPMN starting at that step', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: WorkflowApplyCommand,
+        commandArgs: [...SCOPE_FLAGS, '-f', SPEC_FILE],
+        files: specFile(startSpec),
+        api: [...planApi([remoteWorkflow()]), ...storedBpmnApi(compileWorkflowToBpmn(startSpec))],
+        std: [{ out: 'Nothing to apply: the workflow already matches the spec.' }],
+        assertNoStdError: false,
+      }));
+  });
+
+  describe('when the spec `id` matches no workflow in the environment', () => {
+    it('errors out instead of silently creating a duplicate', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: WorkflowApplyCommand,
+        commandArgs: [...SCOPE_FLAGS, '-f', SPEC_FILE],
+        files: specFile({ ...spec, id: '999' }),
+        api: [...scopeApi, () => nock(SERVER).get(WORKFLOWS_URL).reply(200, [remoteWorkflow()])],
+        exitCode: 2,
+        std: [
+          {
+            err:
+              'No workflow with id "999" found in this environment. ' +
+              'Remove `id` from the spec to create a new workflow, or fix it to update an existing one.',
+          },
+        ],
+        assertNoStdError: false,
+      }));
+
+    it('errors out on --dry-run too (the plan cannot be resolved)', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: WorkflowApplyCommand,
+        commandArgs: [...SCOPE_FLAGS, '--dry-run', SPEC_FILE],
+        files: specFile({ ...spec, id: '999' }),
+        api: [...scopeApi, () => nock(SERVER).get(WORKFLOWS_URL).reply(200, [remoteWorkflow()])],
+        exitCode: 2,
+        std: [{ err: 'No workflow with id "999" found in this environment.' }],
+        assertNoStdError: false,
+      }));
+  });
+
   describe('with --dry-run on an existing workflow', () => {
     it('resolves the scope, prints the would-be update and sends nothing', () =>
       testCli({

--- a/test/commands/workflow/apply.test.js
+++ b/test/commands/workflow/apply.test.js
@@ -1,0 +1,306 @@
+const nock = require('nock');
+
+const testCli = require('../test-cli-helper/test-cli');
+const WorkflowApplyCommand = require('../../../src/commands/workflow/apply').default;
+const ProjectSerializer = require('../../../src/serializers/project');
+const { compileWorkflowToBpmn } = require('../../../src/services/layout/workflow-bpmn');
+const { getEnvironmentListValid, getTeamsValid } = require('../../fixtures/api');
+const { testEnvWithoutSecret } = require('../../fixtures/env');
+
+const SERVER = 'http://localhost:3001';
+const S3 = 'http://localhost:9001';
+const SPEC_FILE = 'workflow.json';
+
+// The layout HTTP path lazily loads Node's deprecated `punycode`, whose DEP0040
+// warning leaks into captured stderr. Cases that don't assert on stderr disable
+// the empty-stderr check so that environmental noise can't flake them.
+
+// `-p 2 -e name2 -t Operations` resolve to project2 / name2 / Operations,
+// so every workflow call targets /api/workflows/project2/name2/Operations.
+const WORKFLOWS_URL = '/api/workflows/project2/name2/Operations';
+const RENDERING_URL = '/api/renderings/project2/name2/Operations';
+
+const SCOPE_FLAGS = ['-p', '2', '-e', 'name2', '-t', 'Operations'];
+
+const spec = {
+  collection: 'cards',
+  name: 'Triage',
+  steps: [
+    { id: 'read1', next: 'done', type: 'read' },
+    { id: 'done', type: 'end' },
+  ],
+};
+
+const specFile = (content = spec) => [
+  { name: SPEC_FILE, content: typeof content === 'string' ? content : JSON.stringify(content) },
+];
+
+// The remote shell `forest workflow apply` upserts (as served by GET /api/workflows/...).
+const remoteWorkflow = overrides => ({
+  bpmnAwsS3Identifier: 'v0',
+  collectionId: 'cards',
+  id: '11',
+  isVisible: true,
+  name: 'Triage',
+  position: 0,
+  segmentIds: [],
+  ...overrides,
+});
+
+// The 3 calls resolveCommandScope makes (project by id, environments, teams).
+const scopeApi = [
+  () =>
+    nock(SERVER)
+      .get('/api/projects/2')
+      .reply(200, ProjectSerializer.serialize({ id: 2, name: 'project2' })),
+  () => getEnvironmentListValid(),
+  () => getTeamsValid(),
+];
+
+// planApply always reads the workflows document and the rendering id.
+const planApi = workflows => [
+  ...scopeApi,
+  () => nock(SERVER).get(WORKFLOWS_URL).reply(200, workflows),
+  () =>
+    nock(SERVER)
+      .get(RENDERING_URL)
+      .reply(200, { data: { id: '42', type: 'renderings' } }),
+];
+
+// The stored-BPMN read used for idempotency (presigned GET + S3 fetch).
+const storedBpmnApi = bpmn => [
+  () =>
+    nock(SERVER)
+      .get('/api/workflows/11/bpmn')
+      .query(true)
+      .reply(200, { signedUrl: `${S3}/stored.bpmn` }),
+  () => nock(S3).get('/stored.bpmn').reply(200, bpmn, { 'Content-Type': 'text/xml' }),
+];
+
+// The upload leg: presigned POST, S3 multipart POST, bpmnAwsS3Identifier PATCH.
+const uploadApi = [
+  () =>
+    nock(SERVER)
+      .post(/\/api\/workflows\/[^/]+\/generate-presigned-request$/)
+      .query(true)
+      .reply(200, { fields: { key: 'k' }, url: `${S3}/upload` }),
+  () => nock(S3).post('/upload').reply(201, '', { 'x-amz-version-id': 'v1' }),
+  () => nock(SERVER).patch('/api/workflows').reply(204),
+];
+
+describe('workflow:apply', () => {
+  describe('when the spec comes from stdin without an explicit scope', () => {
+    it('errors out immediately instead of prompting', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: WorkflowApplyCommand,
+        commandArgs: [],
+        api: [],
+        exitCode: 2,
+        std: [{ err: 'Reading the spec from stdin disables interactive prompts' }],
+        assertNoStdError: false,
+      }));
+  });
+
+  describe('when the spec file does not exist', () => {
+    it('errors out with a clean message, without hitting the API', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: WorkflowApplyCommand,
+        commandArgs: [...SCOPE_FLAGS, 'missing.json'],
+        api: [],
+        exitCode: 2,
+        std: [{ err: 'Cannot read spec file "missing.json": no such file' }],
+        assertNoStdError: false,
+      }));
+  });
+
+  describe('when the spec is not valid JSON', () => {
+    it('errors out with a clean message, without hitting the API', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: WorkflowApplyCommand,
+        commandArgs: [...SCOPE_FLAGS, SPEC_FILE],
+        files: specFile('{ oops'),
+        api: [],
+        exitCode: 2,
+        std: [{ err: 'Invalid JSON in spec:' }],
+        assertNoStdError: false,
+      }));
+  });
+
+  describe('when the spec has a typoed field', () => {
+    it('suggests the intended field', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: WorkflowApplyCommand,
+        commandArgs: [...SCOPE_FLAGS, SPEC_FILE],
+        files: specFile({
+          ...spec,
+          steps: [
+            { autocomplete: true, id: 'read1', next: 'done', type: 'read' },
+            { id: 'done', type: 'end' },
+          ],
+        }),
+        api: [],
+        exitCode: 2,
+        std: [{ err: 'did you mean `autoComplete`?' }],
+        assertNoStdError: false,
+      }));
+  });
+
+  describe('when no workflow matches (create) with --force', () => {
+    it('adds a shell, uploads the BPMN and links the version', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: WorkflowApplyCommand,
+        commandArgs: [...SCOPE_FLAGS, '-f', SPEC_FILE],
+        files: specFile(),
+        api: [
+          ...planApi([]),
+          () => nock(SERVER).patch('/api/workflows').reply(204), // add shell
+          ...uploadApi,
+        ],
+        std: [
+          { out: 'Will CREATE workflow "Triage" on collection cards (2 steps)' },
+          { out: 'Created workflow' },
+        ],
+        assertNoStdError: false,
+      }));
+  });
+
+  describe('when a workflow matches and the spec changes its metadata (update) with --force', () => {
+    it('patches the changed metadata and re-uploads the changed BPMN', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: WorkflowApplyCommand,
+        commandArgs: [...SCOPE_FLAGS, '-f', SPEC_FILE],
+        files: specFile({ ...spec, segments: ['vip'] }),
+        api: [
+          ...planApi([remoteWorkflow({ segmentIds: ['old-seg'] })]),
+          ...storedBpmnApi('<old-bpmn/>'),
+          () => nock(SERVER).patch('/api/workflows').reply(204), // metadata replaces
+          ...uploadApi,
+        ],
+        std: [
+          { out: 'Will UPDATE workflow "Triage" (id 11)' },
+          { out: 'segments: [old-seg] → [vip]' },
+          { out: 'BPMN: recompiled and replaced' },
+          { out: 'Updated workflow' },
+        ],
+        assertNoStdError: false,
+      }));
+  });
+
+  describe('when the workflow already matches the spec', () => {
+    it('is idempotent: uploads nothing and says so', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: WorkflowApplyCommand,
+        commandArgs: [...SCOPE_FLAGS, '-f', SPEC_FILE],
+        files: specFile(),
+        api: [...planApi([remoteWorkflow()]), ...storedBpmnApi(compileWorkflowToBpmn(spec))],
+        std: [{ out: 'Nothing to apply: the workflow already matches the spec.' }],
+        assertNoStdError: false,
+      }));
+  });
+
+  describe('with --dry-run on an existing workflow', () => {
+    it('resolves the scope, prints the would-be update and sends nothing', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: WorkflowApplyCommand,
+        commandArgs: [...SCOPE_FLAGS, '--dry-run', SPEC_FILE],
+        files: specFile({ ...spec, name: 'Triage v2', id: '11' }),
+        api: [...planApi([remoteWorkflow()]), ...storedBpmnApi('<old-bpmn/>')],
+        std: [
+          { out: 'Would UPDATE workflow "Triage" (id 11)' },
+          { out: 'name: "Triage" → "Triage v2"' },
+          { out: '(dry-run: nothing sent)' },
+        ],
+        assertNoStdError: false,
+      }));
+  });
+
+  describe('when the confirmation is declined', () => {
+    it('applies nothing and logs that it aborted', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: WorkflowApplyCommand,
+        commandArgs: [...SCOPE_FLAGS, SPEC_FILE],
+        files: specFile(),
+        api: planApi([]),
+        prompts: [
+          {
+            in: [
+              {
+                message: 'Apply this workflow to name2 / Operations?',
+                name: 'confirm',
+                type: 'confirm',
+              },
+            ],
+            out: { confirm: false },
+          },
+        ],
+        std: [{ out: 'Will CREATE workflow "Triage"' }, { out: 'Aborted' }],
+        assertNoStdError: false,
+      }));
+  });
+
+  describe('when the BPMN upload fails right after creating the shell', () => {
+    it('rolls the shell back and surfaces the server error', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: WorkflowApplyCommand,
+        commandArgs: [...SCOPE_FLAGS, '-f', SPEC_FILE],
+        files: specFile(),
+        api: [
+          ...planApi([]),
+          () => nock(SERVER).patch('/api/workflows').reply(204), // add shell
+          () =>
+            nock(SERVER)
+              .post(/\/api\/workflows\/[^/]+\/generate-presigned-request$/)
+              .query(true)
+              .reply(500, { errors: [{ detail: 'boom' }] }),
+          () => nock(SERVER).patch('/api/workflows').reply(204), // rollback remove
+        ],
+        exitCode: 2,
+        std: [{ out: 'Will CREATE workflow "Triage"' }, { err: 'Server error (500)' }],
+        assertNoStdError: false,
+      }));
+  });
+
+  describe('when the rollback itself fails', () => {
+    it('warns that a BPMN-less workflow may remain', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: WorkflowApplyCommand,
+        commandArgs: [...SCOPE_FLAGS, '-f', SPEC_FILE],
+        files: specFile(),
+        api: [
+          ...planApi([]),
+          () => nock(SERVER).patch('/api/workflows').reply(204), // add shell
+          () =>
+            nock(SERVER)
+              .post(/\/api\/workflows\/[^/]+\/generate-presigned-request$/)
+              .query(true)
+              .reply(500, { errors: [{ detail: 'boom' }] }),
+          () => nock(SERVER).patch('/api/workflows').reply(500), // rollback fails too
+        ],
+        exitCode: 2,
+        std: [{ out: 'Failed to roll back workflow shell' }, { err: 'Server error (500)' }],
+        assertNoStdError: false,
+      }));
+  });
+});

--- a/test/services/layout/sync.unit.test.ts
+++ b/test/services/layout/sync.unit.test.ts
@@ -75,6 +75,23 @@ describe('planWorkflowBpmn', () => {
     expect(getWorkflowBpmn).not.toHaveBeenCalled();
   });
 
+  it('compiles the entry flow from `start`, not from the first step', async () => {
+    expect.assertions(2);
+    const wf = makeWorkflow({
+      start: 'review',
+      steps: [
+        { id: 'notes', type: 'guidance', prompt: 'Notes', next: 'done' },
+        { id: 'review', type: 'guidance', prompt: 'Review', next: 'notes' },
+        { id: 'done', type: 'end' },
+      ],
+    });
+
+    const [plan] = await planWorkflowBpmn(managerWith(jest.fn()), scope, [wf], [], 7);
+
+    expect(plan.bpmn).toContain('sourceRef="Start_1" targetRef="review"');
+    expect(plan.bpmn).not.toContain('sourceRef="Start_1" targetRef="notes"');
+  });
+
   it('re-uploads when the stored BPMN cannot be read (rather than risk a stale skip)', async () => {
     expect.assertions(1);
     const wf = makeWorkflow();
@@ -104,6 +121,21 @@ describe('stepWorkflows', () => {
     };
 
     expect(stepWorkflows(file).map(workflow => workflow.id)).toStrictEqual(['a']);
+  });
+
+  it('passes the authored `start` through (and ignores a non-string one)', () => {
+    expect.assertions(2);
+    const file = {
+      workflows: [
+        { collectionId: 'c', id: 'a', name: 'A', start: 's', steps: [{ id: 's', type: 'end' }] },
+        { collectionId: 'c', id: 'b', name: 'B', start: 42, steps: [{ id: 's', type: 'end' }] },
+      ],
+    };
+
+    const [withStart, withBadStart] = stepWorkflows(file);
+
+    expect(withStart.start).toBe('s');
+    expect(withBadStart.start).toBeUndefined();
   });
 
   it('assigns a uuid in place to a steps-carrying workflow lacking an id', () => {

--- a/test/services/layout/workflow-apply.unit.test.ts
+++ b/test/services/layout/workflow-apply.unit.test.ts
@@ -1,0 +1,262 @@
+import type { RemoteWorkflow } from '../../../src/services/layout/workflow-apply';
+
+import {
+  findWorkflowMatches,
+  parseWorkflowSpec,
+  planShellUpdate,
+} from '../../../src/services/layout/workflow-apply';
+import { WorkflowSpecError } from '../../../src/services/layout/workflow-bpmn';
+
+const validSpec = {
+  collection: 'cards',
+  name: 'Triage',
+  steps: [
+    { id: 'read1', next: 'done', type: 'read' },
+    { id: 'done', type: 'end' },
+  ],
+};
+
+describe('parseWorkflowSpec', () => {
+  it('accepts a valid spec and returns it', () => {
+    expect.assertions(1);
+
+    expect(parseWorkflowSpec(JSON.stringify(validSpec))).toStrictEqual(validSpec);
+  });
+
+  it('accepts version 1 and the documented optional fields', () => {
+    expect.assertions(1);
+
+    const spec = {
+      ...validSpec,
+      id: '123',
+      position: 3,
+      segments: ['s1'],
+      start: 'read1',
+      version: 1,
+    };
+
+    expect(parseWorkflowSpec(JSON.stringify(spec))).toStrictEqual(spec);
+  });
+
+  it.each([
+    ['invalid JSON', '{ oops', 'Invalid JSON in spec:'],
+    ['a JSON string', '"foo"', 'The spec must be a JSON object'],
+    ['null', 'null', 'The spec must be a JSON object'],
+    ['an array', '[1, 2]', 'The spec must be a JSON object'],
+  ])('rejects %s with a clean message', (label, raw, message) => {
+    expect.assertions(2);
+
+    expect(() => parseWorkflowSpec(raw)).toThrow(WorkflowSpecError);
+    expect(() => parseWorkflowSpec(raw)).toThrow(message);
+  });
+
+  it('rejects unsupported spec versions', () => {
+    expect.assertions(1);
+
+    expect(() => parseWorkflowSpec(JSON.stringify({ ...validSpec, version: 2 }))).toThrow(
+      'Unsupported spec `version` 2',
+    );
+  });
+
+  it('rejects an unknown top-level field with a suggestion', () => {
+    expect.assertions(1);
+
+    expect(() => parseWorkflowSpec(JSON.stringify({ ...validSpec, segmentss: [] }))).toThrow(
+      'Unknown field "segmentss" — did you mean `segments`?',
+    );
+  });
+
+  it('lists the valid fields when no suggestion is close enough', () => {
+    expect.assertions(1);
+
+    expect(() => parseWorkflowSpec(JSON.stringify({ ...validSpec, whatever: 1 }))).toThrow(
+      'valid fields: collection, id, name, position, segments, start, steps, version.',
+    );
+  });
+
+  it('rejects an unknown step field with a suggestion', () => {
+    expect.assertions(1);
+
+    const spec = {
+      ...validSpec,
+      steps: [
+        { autocomplete: true, id: 'read1', next: 'done', type: 'read' },
+        { id: 'done', type: 'end' },
+      ],
+    };
+
+    expect(() => parseWorkflowSpec(JSON.stringify(spec))).toThrow(
+      'Unknown field "autocomplete" in step "read1" — did you mean `autoComplete`?',
+    );
+  });
+
+  it('rejects an unknown branch field', () => {
+    expect.assertions(1);
+
+    const spec = {
+      ...validSpec,
+      steps: [
+        {
+          branches: [
+            { answer: 'Yes', nxt: 'done' },
+            { answer: 'No', next: 'done' },
+          ],
+          id: 'cond1',
+          type: 'condition',
+        },
+        { id: 'done', type: 'end' },
+      ],
+    };
+
+    expect(() => parseWorkflowSpec(JSON.stringify(spec))).toThrow(
+      'Unknown field "nxt" in step "cond1" — did you mean `next`?',
+    );
+  });
+
+  it('rejects a non-object step', () => {
+    expect.assertions(1);
+
+    expect(() => parseWorkflowSpec(JSON.stringify({ ...validSpec, steps: ['read1'] }))).toThrow(
+      '`steps[0]` must be a JSON object.',
+    );
+  });
+
+  it.each([
+    ['a non-numeric, non-UUID id', { id: 'my-workflow' }],
+    ['a numeric id given as a number', { id: 42 }],
+  ])('rejects %s', (label, extra) => {
+    expect.assertions(1);
+
+    expect(() => parseWorkflowSpec(JSON.stringify({ ...validSpec, ...extra }))).toThrow(
+      '`id` must be an existing workflow id',
+    );
+  });
+
+  it('accepts a UUID id', () => {
+    expect.assertions(1);
+
+    const id = '6f2c48d0-9d2e-4d0a-a1de-111111111111';
+
+    expect(parseWorkflowSpec(JSON.stringify({ ...validSpec, id })).id).toBe(id);
+  });
+
+  it('rejects a negative or fractional position', () => {
+    expect.assertions(2);
+
+    expect(() => parseWorkflowSpec(JSON.stringify({ ...validSpec, position: -1 }))).toThrow(
+      '`position` must be a non-negative integer',
+    );
+    expect(() => parseWorkflowSpec(JSON.stringify({ ...validSpec, position: 1.5 }))).toThrow(
+      '`position` must be a non-negative integer',
+    );
+  });
+});
+
+describe('findWorkflowMatches', () => {
+  const existing: RemoteWorkflow[] = [
+    { collectionId: 'cards', id: '1', name: 'Triage' },
+    { collectionId: 'cards', id: '2', name: 'Triage' },
+    { collectionId: 'users', id: '3', name: 'Triage' },
+  ];
+
+  it('matches by explicit id first', () => {
+    expect.assertions(1);
+
+    expect(
+      findWorkflowMatches(existing, { collection: 'cards', id: '3', name: 'Triage' }),
+    ).toStrictEqual([existing[2]]);
+  });
+
+  it('matches by name + collection when no id is given', () => {
+    expect.assertions(1);
+
+    expect(findWorkflowMatches(existing, { collection: 'cards', name: 'Triage' })).toStrictEqual([
+      existing[0],
+      existing[1],
+    ]);
+  });
+
+  it('returns no match for an unknown name', () => {
+    expect.assertions(1);
+
+    expect(findWorkflowMatches(existing, { collection: 'cards', name: 'Nope' })).toStrictEqual([]);
+  });
+});
+
+describe('planShellUpdate', () => {
+  const current: RemoteWorkflow = {
+    collectionId: 'cards',
+    id: '7',
+    name: 'Triage',
+    position: 2,
+    segmentIds: ['s1'],
+  };
+
+  it('plans nothing when the spec matches the remote metadata', () => {
+    expect.assertions(1);
+
+    expect(
+      planShellUpdate(current, { collection: 'cards', name: 'Triage', segments: ['s1'] }),
+    ).toStrictEqual([]);
+  });
+
+  it('plans a name replace when the spec renames the workflow', () => {
+    expect.assertions(1);
+
+    const changes = planShellUpdate(current, {
+      collection: 'cards',
+      name: 'Triage v2',
+      segments: ['s1'],
+    });
+
+    expect(changes.map(change => change.op)).toStrictEqual([
+      { op: 'replace', path: '/workflows/7/name', value: 'Triage v2' },
+    ]);
+  });
+
+  it('converges segments, treating an omitted `segments` as empty', () => {
+    expect.assertions(1);
+
+    const changes = planShellUpdate(current, { collection: 'cards', name: 'Triage' });
+
+    expect(changes.map(change => change.op)).toStrictEqual([
+      { op: 'replace', path: '/workflows/7/segmentIds', value: [] },
+    ]);
+  });
+
+  it('only touches position when the spec pins one', () => {
+    expect.assertions(2);
+
+    expect(
+      planShellUpdate(current, { collection: 'cards', name: 'Triage', segments: ['s1'] }),
+    ).toStrictEqual([]);
+
+    const changes = planShellUpdate(current, {
+      collection: 'cards',
+      name: 'Triage',
+      position: 0,
+      segments: ['s1'],
+    });
+
+    expect(changes.map(change => change.op)).toStrictEqual([
+      { op: 'replace', path: '/workflows/7/position', value: 0 },
+    ]);
+  });
+
+  it('labels every change for the plan display', () => {
+    expect.assertions(1);
+
+    const changes = planShellUpdate(current, {
+      collection: 'cards',
+      name: 'Renamed',
+      position: 0,
+      segments: ['s2'],
+    });
+
+    expect(changes.map(change => change.label)).toStrictEqual([
+      'name: "Triage" → "Renamed"',
+      'segments: [s1] → [s2]',
+      'position: 2 → 0',
+    ]);
+  });
+});

--- a/test/services/layout/workflow-apply.unit.test.ts
+++ b/test/services/layout/workflow-apply.unit.test.ts
@@ -140,6 +140,121 @@ describe('parseWorkflowSpec', () => {
     expect(parseWorkflowSpec(JSON.stringify({ ...validSpec, id })).id).toBe(id);
   });
 
+  it.each([
+    ['a non-string `name`', { name: 123 }, '`name` must be a string (got 123).'],
+    [
+      'a non-string `collection`',
+      { collection: false },
+      '`collection` must be a string (got false).',
+    ],
+    ['a non-string `start`', { start: 1 }, '`start` must be a string (got 1).'],
+    [
+      'a non-array `segments`',
+      { segments: 'vip' },
+      '`segments` must be an array of segment ids (strings) (got "vip").',
+    ],
+    [
+      'a `segments` array holding non-strings',
+      { segments: [1] },
+      '`segments` must be an array of segment ids (strings) (got [1]).',
+    ],
+  ])('rejects %s', (label, extra, message) => {
+    expect.assertions(2);
+    const raw = JSON.stringify({ ...validSpec, ...extra });
+
+    expect(() => parseWorkflowSpec(raw)).toThrow(WorkflowSpecError);
+    expect(() => parseWorkflowSpec(raw)).toThrow(message);
+  });
+
+  it.each([
+    [
+      '`mcpServerId`',
+      { mcpServerId: 123 },
+      '`mcpServerId` must be a string in step "read1" (got 123).',
+    ],
+    ['`prompt`', { prompt: ['a'] }, '`prompt` must be a string in step "read1" (got ["a"]).'],
+    ['`title`', { title: 7 }, '`title` must be a string in step "read1" (got 7).'],
+    ['`next`', { next: 42 }, '`next` must be a string in step "read1" (got 42).'],
+    ['`type`', { type: 5 }, '`type` must be a string in step "read1" (got 5).'],
+    ['`inboxId`', { inboxId: {} }, '`inboxId` must be a string in step "read1" (got {}).'],
+    ['`auto`', { auto: 'yes' }, '`auto` must be a boolean in step "read1" (got "yes").'],
+    [
+      '`autoComplete`',
+      { autoComplete: 1 },
+      '`autoComplete` must be a boolean in step "read1" (got 1).',
+    ],
+  ])('rejects a wrongly-typed step %s with a clean message', (label, extra, message) => {
+    expect.assertions(2);
+    const raw = JSON.stringify({
+      ...validSpec,
+      steps: [
+        { ...validSpec.steps[0], ...extra },
+        { id: 'done', type: 'end' },
+      ],
+    });
+
+    expect(() => parseWorkflowSpec(raw)).toThrow(WorkflowSpecError);
+    expect(() => parseWorkflowSpec(raw)).toThrow(message);
+  });
+
+  it('rejects a non-array `branches`', () => {
+    expect.assertions(1);
+
+    const spec = {
+      ...validSpec,
+      steps: [
+        { branches: 'nope', id: 'cond1', type: 'condition' },
+        { id: 'done', type: 'end' },
+      ],
+    };
+
+    expect(() => parseWorkflowSpec(JSON.stringify(spec))).toThrow(
+      '`branches` must be an array in step "cond1" (got "nope").',
+    );
+  });
+
+  it('rejects a non-object branch', () => {
+    expect.assertions(1);
+
+    const spec = {
+      ...validSpec,
+      steps: [
+        { branches: ['done'], id: 'cond1', type: 'condition' },
+        { id: 'done', type: 'end' },
+      ],
+    };
+
+    expect(() => parseWorkflowSpec(JSON.stringify(spec))).toThrow(
+      '`branches[0]` must be a JSON object in step "cond1".',
+    );
+  });
+
+  it.each([
+    ['`answer`', { answer: 1, next: 'done' }, '`answer` must be a string in step "cond1" (got 1).'],
+    [
+      '`color`',
+      { answer: 'Yes', color: 0, next: 'done' },
+      '`color` must be a string in step "cond1" (got 0).',
+    ],
+    [
+      '`next`',
+      { answer: 'Yes', next: true },
+      '`next` must be a string in step "cond1" (got true).',
+    ],
+  ])('rejects a wrongly-typed branch %s with a clean message', (label, branch, message) => {
+    expect.assertions(1);
+
+    const spec = {
+      ...validSpec,
+      steps: [
+        { branches: [branch, { answer: 'No', next: 'done' }], id: 'cond1', type: 'condition' },
+        { id: 'done', type: 'end' },
+      ],
+    };
+
+    expect(() => parseWorkflowSpec(JSON.stringify(spec))).toThrow(message);
+  });
+
   it('rejects a negative or fractional position', () => {
     expect.assertions(2);
 

--- a/test/services/layout/workflow-bpmn.unit.test.ts
+++ b/test/services/layout/workflow-bpmn.unit.test.ts
@@ -1,3 +1,7 @@
+// bpmn-moddle only publishes an `exports` map (no `main`), invisible to the legacy node resolver.
+// eslint-disable-next-line import/no-unresolved
+import { BpmnModdle } from 'bpmn-moddle';
+
 import {
   WorkflowSpecError,
   compileWorkflowToBpmn,
@@ -19,6 +23,53 @@ const validSpec = {
     { id: 'done', type: 'end' as const },
   ],
 };
+
+/** Two condition branches converging on the same target step. */
+const convergingSpec = {
+  collection: 'cards',
+  name: 'Branchy',
+  start: 'cond1',
+  steps: [
+    {
+      branches: [
+        { answer: 'Yes', next: 'done' },
+        { answer: 'No', next: 'done' },
+      ],
+      id: 'cond1',
+      type: 'condition' as const,
+    },
+    { id: 'done', type: 'end' as const },
+  ],
+};
+
+/** One step of every supported type. */
+const allTypesSpec = {
+  collection: 'cards',
+  name: 'Everything',
+  start: 'act1',
+  steps: [
+    { auto: true, id: 'act1', next: 'cond1', type: 'action' as const },
+    {
+      branches: [
+        { answer: 'Yes', next: 'esc1' },
+        { answer: 'No', next: 'guide1' },
+      ],
+      id: 'cond1',
+      type: 'condition' as const,
+    },
+    { id: 'esc1', inboxId: 'inbox-1', next: 'load1', type: 'escalation' as const },
+    { id: 'guide1', next: 'load1', prompt: 'Check it', type: 'guidance' as const },
+    { id: 'load1', next: 'mcp1', type: 'load-related' as const },
+    { id: 'mcp1', mcpServerId: 'srv-1', next: 'read1', type: 'mcp' as const },
+    { autoComplete: true, id: 'read1', next: 'upd1', type: 'read' as const },
+    { id: 'upd1', next: 'done', type: 'update' as const },
+    { id: 'done', type: 'end' as const },
+  ],
+};
+
+function allXmlIds(bpmn: string): string[] {
+  return [...bpmn.matchAll(/ id="([^"]+)"/g)].map(match => match[1]);
+}
 
 describe('compileWorkflowToBpmn', () => {
   it('emits a BPMN process with start, steps and sequence flows', () => {
@@ -71,6 +122,82 @@ describe('compileWorkflowToBpmn', () => {
     });
     expect(bpmn).toContain('name="A &amp; B &lt;x&gt;"');
   });
+
+  it('declares the forest namespace and a diagram interchange section', () => {
+    expect.assertions(3);
+    const bpmn = compileWorkflowToBpmn(validSpec);
+    expect(bpmn).toContain('xmlns:forest="https://app.forestadmin.com"');
+    expect(bpmn).toContain('<bpmndi:BPMNDiagram id="BPMNDiagram_1">');
+    expect(bpmn).toContain('<bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">');
+  });
+
+  it('emits one BPMNShape per element and one BPMNEdge per sequence flow', () => {
+    expect.assertions(4);
+    const bpmn = compileWorkflowToBpmn(validSpec);
+    // start event + read1 + guide1 + done
+    expect(bpmn.match(/<bpmndi:BPMNShape /g)).toHaveLength(4);
+    expect(bpmn).toContain('<bpmndi:BPMNShape id="Start_1_di" bpmnElement="Start_1">');
+    // start→read1, read1→guide1, guide1→done
+    expect(bpmn.match(/<bpmn:sequenceFlow /g)).toHaveLength(3);
+    expect(bpmn.match(/<bpmndi:BPMNEdge /g)).toHaveLength(3);
+  });
+
+  it('gives converging condition branches distinct flow ids (elements and DI edges)', () => {
+    expect.assertions(4);
+    const bpmn = compileWorkflowToBpmn(convergingSpec);
+    expect(bpmn).toContain(
+      '<bpmn:sequenceFlow id="flow_cond1_done" sourceRef="cond1" targetRef="done" name="Yes" />',
+    );
+    expect(bpmn).toContain(
+      '<bpmn:sequenceFlow id="flow_cond1_done_2" sourceRef="cond1" targetRef="done" name="No" />',
+    );
+    expect(bpmn).toContain(
+      '<bpmndi:BPMNEdge id="flow_cond1_done_di" bpmnElement="flow_cond1_done">',
+    );
+    expect(bpmn).toContain(
+      '<bpmndi:BPMNEdge id="flow_cond1_done_2_di" bpmnElement="flow_cond1_done_2">',
+    );
+  });
+
+  it.each([
+    ['simple', validSpec],
+    ['converging branches', convergingSpec],
+    ['all step types', allTypesSpec],
+  ])('never emits duplicate xml ids (%s)', (_label, spec) => {
+    expect.assertions(1);
+    const ids = allXmlIds(compileWorkflowToBpmn(spec));
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('emits auto/autoComplete flags on serviceTask steps', () => {
+    expect.assertions(3);
+    const bpmn = compileWorkflowToBpmn(allTypesSpec);
+    expect(bpmn).toContain(
+      '<bpmn:serviceTask id="act1" name="act1" forest:alternative="trigger-action" forest:automaticExecution="true">',
+    );
+    expect(bpmn).toContain(
+      '<bpmn:serviceTask id="read1" name="read1" forest:alternative="get-data" forest:automaticCompletion="true">',
+    );
+    // the flags never leak onto non-serviceTask elements
+    const offendingLines = bpmn
+      .split('\n')
+      .filter(line => line.includes('forest:automatic') && !line.includes('<bpmn:serviceTask '));
+    expect(offendingLines).toStrictEqual([]);
+  });
+});
+
+describe('bpmn-js importability (bpmn-moddle)', () => {
+  it.each([
+    ['simple', validSpec],
+    ['converging branches', convergingSpec],
+    ['all step types', allTypesSpec],
+  ])('imports the compiled BPMN without errors or warnings (%s)', async (_label, spec) => {
+    expect.assertions(2);
+    const moddle = new BpmnModdle();
+    const { rootElement, warnings } = await moddle.fromXML(compileWorkflowToBpmn(spec));
+    expect(warnings).toStrictEqual([]);
+    expect(rootElement.id).toBe('Definitions_1');
+  });
 });
 
 describe('validateWorkflowSpec', () => {
@@ -99,6 +226,37 @@ describe('validateWorkflowSpec', () => {
     [
       { collection: 'c', name: 'N', steps: [{ id: 'a', next: 'a', type: 'read' }] },
       'at least one `end`',
+    ],
+    [
+      {
+        collection: 'c',
+        name: 'N',
+        steps: [
+          { auto: true, id: 'g', next: 'e', type: 'guidance' },
+          { id: 'e', type: 'end' },
+        ],
+      },
+      '`auto`/`autoComplete` are only supported on action, load-related, mcp, read, update steps',
+    ],
+    [
+      { collection: 'c', name: 'N', steps: [{ autoComplete: true, id: 'e', type: 'end' }] },
+      '`auto`/`autoComplete` are only supported on',
+    ],
+    [
+      { collection: 'c', name: 'N', steps: [{ id: 'Start_1', type: 'end' }] },
+      'reserved for generated BPMN elements',
+    ],
+    [
+      { collection: 'c', name: 'N', steps: [{ id: 'Process_1', type: 'end' }] },
+      'reserved for generated BPMN elements',
+    ],
+    [
+      { collection: 'c', name: 'N', steps: [{ id: 'flow_a_b', type: 'end' }] },
+      'reserved for generated BPMN elements',
+    ],
+    [
+      { collection: 'c', name: 'N', steps: [{ id: 'done_di', type: 'end' }] },
+      'reserved for generated BPMN elements',
     ],
   ])('rejects an invalid spec (%#)', (spec, message) => {
     expect.assertions(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4839,6 +4839,15 @@ bowser@^2.11.0:
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.12.1.tgz#f9ad78d7aebc472feb63dd9635e3ce2337e0e2c1"
   integrity sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==
 
+bpmn-moddle@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/bpmn-moddle/-/bpmn-moddle-10.0.0.tgz#b1ad5457ac6190babf27b0cb38469f5e39a01be7"
+  integrity sha512-vXePD5jkatcILmM3zwJG/m6IIHIghTGB7WvgcdEraEw8E8VdJHrTgrvBUhbzqaXJpnsGQz15QS936xeBY6l9aA==
+  dependencies:
+    min-dash "^5.0.0"
+    moddle "^8.0.0"
+    moddle-xml "^12.0.0"
+
 brace-expansion@^1.1.7:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
@@ -9303,6 +9312,11 @@ mimic-response@^4.0.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-4.0.0.tgz#35468b19e7c75d10f5165ea25e75a5ceea7cf70f"
   integrity sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==
 
+min-dash@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/min-dash/-/min-dash-5.0.0.tgz#213550a03f4818a85feae4c308bb4c83a5290dc4"
+  integrity sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw==
+
 min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
@@ -9422,6 +9436,21 @@ mock-stdin@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mock-stdin/-/mock-stdin-1.0.0.tgz#efcfaf4b18077e14541742fd758b9cae4e5365ea"
   integrity sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q==
+
+moddle-xml@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/moddle-xml/-/moddle-xml-12.0.0.tgz#9d7ca1358d44b6defb80d2c75f7f215aed2838ae"
+  integrity sha512-NJc2+sCe4tvuGlaUBcoZcYf6j9f+z+qxHOyGm/LB3ZrlJXVPPHoBTg/KXgDRCufdBJhJ3AheFs3QU/abABNzRg==
+  dependencies:
+    min-dash "^5.0.0"
+    saxen "^11.0.2"
+
+moddle@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/moddle/-/moddle-8.1.0.tgz#7042b33c616c0484a54d8c75e463742c14b5be13"
+  integrity sha512-dBddc1CNuZHgro8nQWwfPZ2BkyLWdnxoNpPu9d+XKPN96DAiiBOeBw527ft++ebDuFez5PMdaR3pgUgoOaUGrA==
+  dependencies:
+    min-dash "^5.0.0"
 
 moment-timezone@^0.5.43:
   version "0.5.48"
@@ -11055,6 +11084,11 @@ sax@>=0.6.0:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.4.1.tgz#44cc8988377f126304d3b3fc1010c733b929ef0f"
   integrity sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==
 
+saxen@^11.0.2:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/saxen/-/saxen-11.0.2.tgz#14405adb2b72ad127102379744d93ed0fc599b5e"
+  integrity sha512-WDb4gqac8uiJzOdOdVpr9NWh9NrJMm7Brn5GX2Poj+mjE/QTXqYQENr8T/mom54dDDgbd3QjwTg23TRHYiWXRA==
+
 semantic-release-slack-bot@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/semantic-release-slack-bot/-/semantic-release-slack-bot-4.0.2.tgz#7e4f7e04fbbf355c64fb8791df8870cdcda4dd35"
@@ -11596,7 +11630,7 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11612,6 +11646,15 @@ string-width@^2.1.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -11677,7 +11720,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11697,6 +11740,13 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.2"
@@ -12645,7 +12695,7 @@ wordwrap@>=0.0.2, wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12658,6 +12708,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
> ⚠️ **Stacked on #798** (`fix/workflow-bpmn-editor-compat`). Review/merge that first; this PR's diff is clean once the base lands.

## What

New command `forest workflow apply` — create or update (**upsert by name**) a single workflow from a declarative JSON `steps` spec. No YAML.

It reuses the existing layout plumbing end-to-end (4 calls, mirroring the UI exactly):
`PATCH /api/workflows` (add the shell) → `POST …/generate-presigned-request` → S3 multipart upload of the compiled BPMN → `PATCH …/bpmnAwsS3Identifier`.

## The `steps` DSL

9 step types → BPMN element + `forest:alternative`: `guidance`, `read`, `update`, `action`, `load-related`, `mcp`, `escalation`, `condition`, `end`. Flags `auto`/`autoComplete` map to `forest:automaticExecution`/`Completion` (serviceTask only). Per-field args and action/MCP targets are intentionally resolved at runtime by the workflow AI — the spec sets the *shape*.

Full reference lives in the DSL spec doc.

## Tested

Smoke-tested live: create + edit (re-apply with the same name → same workflow id, fresh BPMN version). Compiled workflows open cleanly in the UI (thanks to the base PR).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `forest workflow apply` command to upsert workflows from a JSON steps spec
> - Adds a new `forest workflow apply` CLI command ([apply.ts](https://github.com/ForestAdmin/toolbelt/pull/799/files#diff-04b2566684fbaf276ce71ed5738091ab8156f6b15dfaf857e0ce76959f247c92)) that compiles a JSON steps spec to BPMN and creates or updates a workflow, uploading BPMN to S3 only when content changes.
> - Introduces spec parsing, workflow matching by id or name+collection, and shell metadata diffing in [workflow-apply.ts](https://github.com/ForestAdmin/toolbelt/pull/799/files#diff-dda6abe94863058c8cb0aa2ecfbd5c8e0d76b082bed8cacee4fe4f4a77826661), generating JsonPatch ops for name, segments, and position changes.
> - Extends the BPMN compiler ([workflow-bpmn.ts](https://github.com/ForestAdmin/toolbelt/pull/799/files#diff-701c1528f8369370f27c900296ea63a77d831bf308e55e4ebf5e960500df6299)) to emit full BPMN-DI diagram shapes/edges, allocate unique sequence flow ids for converging branches, validate reserved id collisions, and restrict `auto`/`autoComplete` to service tasks.
> - Supports `--dry-run`, `--force`, and scope flags; prompts for confirmation interactively; rolls back newly created workflow shells if the S3 upload fails.
> - Risk: the BPMN compiler now produces structurally different output (new namespaces, `Start_1` entry event, DI elements, unique flow ids), which affects idempotency comparisons against any existing stored BPMN.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95a8637.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

Part of [PRD-715 — Workflows in CLI](https://linear.app/forestadmin/issue/PRD-715/workflows-in-cli).