### PR TITLE
feat(layout): round-trip workflow BPMN via `--with-workflows`

### DIFF
--- a/src/commands/layout/apply.ts
+++ b/src/commands/layout/apply.ts
@@ -2,7 +2,7 @@ import type { LayoutScope } from '../../services/layout/types';
 import type { Config } from '@oclif/core';
 
 import { Args, Flags } from '@oclif/core';
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import path from 'path';
 
 import AbstractAuthenticatedCommand from '../../abstract-authenticated-command';
@@ -50,6 +50,29 @@ async function uploadWorkflowBpmns(
   await manager.patchDomain('workflows', bpmnOps, scope);
 }
 
+/** Read `workflows/<id>.bpmn` sidecars for file workflows that carry no `steps` (steps take precedence). */
+function readWorkflowSidecars(
+  docs: { workflows?: unknown[] },
+  filePath: string,
+  stepWorkflowsList: Array<{ id: string }>,
+): Array<{ bpmn: string; workflow: { collectionId: string; id: string; name: string } }> {
+  const stepIds = new Set(stepWorkflowsList.map(workflow => workflow.id));
+  const dir = path.join(path.dirname(filePath), 'workflows');
+
+  return ((docs.workflows ?? []) as Array<{ collectionId: string; id: string; name?: string }>)
+    .filter(workflow => !stepIds.has(workflow.id))
+    .map(workflow => ({ file: path.join(dir, `${workflow.id}.bpmn`), workflow }))
+    .filter(entry => existsSync(entry.file))
+    .map(entry => ({
+      bpmn: readFileSync(entry.file, 'utf8'),
+      workflow: {
+        collectionId: entry.workflow.collectionId,
+        id: entry.workflow.id,
+        name: entry.workflow.name ?? entry.workflow.id,
+      },
+    }));
+}
+
 /**
  * `forest layout apply` — compute the JSON-Patch plan between forest-layout.json
  * and the live rendering, then PATCH it to the environment. Idempotent: an
@@ -88,6 +111,10 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
       char: 'f',
       description: 'Skip the confirmation prompt.',
     }),
+    'with-workflows': Flags.boolean({
+      description:
+        'Also upload workflow BPMN sidecars (workflows/<id>.bpmn) to the target env — the round-trip counterpart of `pull --with-workflows`.',
+    }),
   };
 
   constructor(argv: string[], config: Config, plan?) {
@@ -117,12 +144,19 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
     // BEFORE diffing, so the shell `add` and the BPMN link target the same id.
     const bpmnWorkflows = stepWorkflows(docs);
 
+    // Round-trip: workflows with a `workflows/<id>.bpmn` sidecar and no `steps` are
+    // uploaded verbatim to the target env (faithful transport, incl. UI-authored ones).
+    const sidecarPlans = flags['with-workflows']
+      ? readWorkflowSidecars(docs, filePath, bpmnWorkflows)
+      : [];
+
     const remote = await fetchRemoteDocs(manager, scope, domainsInFile(docs));
     const { ops, warnings } = diffAllDomains(remote, docs);
 
     // Compile each step-graph and skip the ones whose BPMN already matches what
     // is stored — so re-applying a file with `steps` stays idempotent.
-    const renderingId = bpmnWorkflows.length > 0 ? await manager.getRenderingId(scope) : 0;
+    const renderingId =
+      bpmnWorkflows.length > 0 || sidecarPlans.length > 0 ? await manager.getRenderingId(scope) : 0;
     const remoteWorkflows = (remote.workflows ?? []) as Array<Record<string, unknown>>;
     const bpmnPlans = await planWorkflowBpmn(
       manager,
@@ -139,8 +173,11 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
         `  ⚙ workflow « ${plan.workflow.name} »: compile + upload BPMN (${plan.workflow.steps.length} steps)`,
       ),
     );
+    sidecarPlans.forEach(plan =>
+      this.log(`  ↑ workflow « ${plan.workflow.name} »: upload BPMN sidecar`),
+    );
 
-    if (ops.length === 0 && bpmnToUpload.length === 0) {
+    if (ops.length === 0 && bpmnToUpload.length === 0 && sidecarPlans.length === 0) {
       this.logger.success('Nothing to apply: the environment already matches the file.');
       return;
     }
@@ -166,6 +203,8 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
       // BPMN authoring: shells now exist, so upload each changed step-graph and
       // link the returned versions (one patch).
       await uploadWorkflowBpmns(manager, scope, bpmnToUpload, renderingId);
+      // Round-trip: upload the sidecar BPMNs verbatim to the target env.
+      await uploadWorkflowBpmns(manager, scope, sidecarPlans, renderingId);
     } catch (error) {
       if (error instanceof LayoutApiError && error.status !== 401) {
         this.logger.error(explainApiError(error, ops));
@@ -181,7 +220,8 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
       throw error;
     }
 
-    const bpmnNote = bpmnToUpload.length > 0 ? ` + ${bpmnToUpload.length} workflow BPMN` : '';
+    const bpmnCount = bpmnToUpload.length + sidecarPlans.length;
+    const bpmnNote = bpmnCount > 0 ? ` + ${bpmnCount} workflow BPMN` : '';
     this.logger.success(
       `Applied ${ops.length} change${ops.length === 1 ? '' : 's'}${bpmnNote} to ${this.chalk.bold(
         scope.environmentName,

--- a/src/commands/layout/apply.ts
+++ b/src/commands/layout/apply.ts
@@ -1,5 +1,9 @@
 import type { LayoutScope } from '../../services/layout/types';
-import type { SidecarFile, SidecarUpload } from '../../services/layout/workflow-sidecar';
+import type {
+  MissingSidecar,
+  SidecarFile,
+  SidecarUpload,
+} from '../../services/layout/workflow-sidecar';
 import type { Config } from '@oclif/core';
 
 import { Args, Flags } from '@oclif/core';
@@ -22,6 +26,7 @@ import {
 import { LAYOUT_DOMAINS } from '../../services/layout/types';
 import {
   hasWorkflowBpmnOps,
+  partitionMissingSidecars,
   planSidecarUploads,
   resolveRemoteWorkflow,
   sidecarPath,
@@ -79,11 +84,11 @@ function readWorkflowSidecars(
   docs: { workflows?: unknown[] },
   filePath: string,
   stepWorkflowsList: Array<{ id: string }>,
-): { missing: string[]; orphaned: string[]; plans: SidecarFile[] } {
+): { missing: MissingSidecar[]; orphaned: string[]; plans: SidecarFile[] } {
   const stepIds = new Set(stepWorkflowsList.map(workflow => workflow.id));
   const dir = path.join(path.dirname(filePath), 'workflows');
   const plans: SidecarFile[] = [];
-  const missing: string[] = [];
+  const missing: MissingSidecar[] = [];
   const orphaned: string[] = [];
 
   ((docs.workflows ?? []) as FileWorkflow[])
@@ -107,7 +112,7 @@ function readWorkflowSidecars(
         });
       } else {
         // The workflow had BPMN in the source, but its bytes weren't checked in.
-        missing.push(workflow.id);
+        missing.push({ id: workflow.id, name: workflow.name ?? workflow.id });
       }
     });
 
@@ -225,7 +230,19 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
       renderingId,
     );
 
-    this.logPlan({ bpmnToUpload, ops, sidecarMissing, sidecarOrphaned, sidecarPlans, warnings });
+    // A missing sidecar is only harmless when the target workflow already exists
+    // (it keeps its own BPMN) — a workflow being ADDED by this apply would be
+    // created with no BPMN at all, which deserves its own explicit warning.
+    const sidecarMissingSplit = partitionMissingSidecars(sidecarMissing, remoteWorkflows);
+
+    this.logPlan({
+      bpmnToUpload,
+      ops,
+      sidecarMissing: sidecarMissingSplit,
+      sidecarOrphaned,
+      sidecarPlans,
+      warnings,
+    });
 
     if (ops.length === 0 && bpmnToUpload.length === 0 && sidecarPlans.length === 0) {
       this.logger.success('Nothing to apply: the environment already matches the file.');
@@ -380,16 +397,25 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
   private logPlan(preview: {
     bpmnToUpload: Array<{ workflow: { name: string; steps: unknown[] } }>;
     ops: Parameters<typeof formatPlan>[0];
-    sidecarMissing: string[];
+    sidecarMissing: { createdWithoutBpmn: MissingSidecar[]; targetKeepsOwn: MissingSidecar[] };
     sidecarOrphaned: string[];
     sidecarPlans: SidecarUpload[];
     warnings: Parameters<typeof formatPlan>[1];
   }): void {
-    if (preview.sidecarMissing.length > 0) {
+    const { createdWithoutBpmn, targetKeepsOwn } = preview.sidecarMissing;
+    if (targetKeepsOwn.length > 0) {
       this.logger.warn(
-        `${preview.sidecarMissing.length} workflow(s) have BPMN in the file but no ` +
+        `${targetKeepsOwn.length} workflow(s) have BPMN in the file but no ` +
           `workflows/<id>.bpmn sidecar — their BPMN was not transported (the target keeps its ` +
-          `own): ${preview.sidecarMissing.join(', ')}.`,
+          `own): ${targetKeepsOwn.map(workflow => workflow.name).join(', ')}.`,
+      );
+    }
+    if (createdWithoutBpmn.length > 0) {
+      this.logger.warn(
+        `${createdWithoutBpmn.length} workflow(s) will be created WITHOUT BPMN: they declare ` +
+          `BPMN in the layout file but have no workflows/<id>.bpmn sidecar and do not exist in ` +
+          `the target — run \`layout pull --with-workflows\` on the source first: ` +
+          `${createdWithoutBpmn.map(workflow => workflow.name).join(', ')}.`,
       );
     }
     if (preview.sidecarOrphaned.length > 0) {

--- a/src/commands/layout/apply.ts
+++ b/src/commands/layout/apply.ts
@@ -1,4 +1,5 @@
 import type { LayoutScope } from '../../services/layout/types';
+import type { SidecarFile, SidecarUpload } from '../../services/layout/workflow-sidecar';
 import type { Config } from '@oclif/core';
 
 import { Args, Flags } from '@oclif/core';
@@ -19,7 +20,13 @@ import {
   stepWorkflows,
 } from '../../services/layout/sync';
 import { LAYOUT_DOMAINS } from '../../services/layout/types';
-import { sidecarPath } from '../../services/layout/workflow-sidecar';
+import {
+  hasWorkflowBpmnOps,
+  planSidecarUploads,
+  resolveRemoteWorkflow,
+  sidecarPath,
+  stripWorkflowBpmnOps,
+} from '../../services/layout/workflow-sidecar';
 
 /** Upload each changed step-graph's BPMN to S3 and link the returned versions (one patch). */
 async function uploadWorkflowBpmns(
@@ -51,7 +58,6 @@ async function uploadWorkflowBpmns(
   await manager.patchDomain('workflows', bpmnOps, scope);
 }
 
-type SidecarPlan = { bpmn: string; workflow: { collectionId: string; id: string; name: string } };
 type FileWorkflow = {
   bpmnAwsS3Identifier?: string;
   collectionId: string;
@@ -61,19 +67,24 @@ type FileWorkflow = {
 
 /**
  * Read `workflows/<id>.bpmn` sidecars for file workflows that carry no `steps`
- * (steps take precedence). Returns the upload plans plus the ids of workflows
- * that had BPMN in the file but no sidecar on disk — their BPMN cannot be
- * transported, so the caller must warn and must not patch their (source) ref.
+ * (steps take precedence). Only workflows that declare BPMN in the layout
+ * (`bpmnAwsS3Identifier`) are considered:
+ * - declared BPMN + sidecar on disk → an upload plan;
+ * - declared BPMN, no sidecar → `missing`: its BPMN cannot be transported, the
+ *   caller warns and never patches the (source) ref;
+ * - sidecar on disk but NO declared BPMN → `orphaned`: a leftover file must not
+ *   silently attach BPMN to a workflow that never had one — warn and skip.
  */
 function readWorkflowSidecars(
   docs: { workflows?: unknown[] },
   filePath: string,
   stepWorkflowsList: Array<{ id: string }>,
-): { missing: string[]; plans: SidecarPlan[] } {
+): { missing: string[]; orphaned: string[]; plans: SidecarFile[] } {
   const stepIds = new Set(stepWorkflowsList.map(workflow => workflow.id));
   const dir = path.join(path.dirname(filePath), 'workflows');
-  const plans: SidecarPlan[] = [];
+  const plans: SidecarFile[] = [];
   const missing: string[] = [];
+  const orphaned: string[] = [];
 
   ((docs.workflows ?? []) as FileWorkflow[])
     .filter(workflow => !stepIds.has(workflow.id))
@@ -81,86 +92,26 @@ function readWorkflowSidecars(
       // `sidecarPath` returns null for a traversal-unsafe id, so a crafted layout
       // file can never make apply read a file outside the workflows/ directory.
       const file = sidecarPath(dir, workflow.id);
-      if (file && existsSync(file)) {
+      const hasSidecar = file !== null && existsSync(file);
+
+      if (!workflow.bpmnAwsS3Identifier) {
+        if (hasSidecar) orphaned.push(workflow.id);
+      } else if (hasSidecar) {
         plans.push({
-          bpmn: readFileSync(file, 'utf8'),
+          bpmn: readFileSync(file as string, 'utf8'),
           workflow: {
             collectionId: workflow.collectionId,
             id: workflow.id,
             name: workflow.name ?? workflow.id,
           },
         });
-      } else if (workflow.bpmnAwsS3Identifier) {
+      } else {
         // The workflow had BPMN in the source, but its bytes weren't checked in.
         missing.push(workflow.id);
       }
     });
 
-  return { missing, plans };
-}
-
-/**
- * Skip sidecar uploads whose bytes already match the BPMN stored in the target
- * (mirrors `planWorkflowBpmn` for step graphs) so re-applying an unchanged file
- * stays a no-op instead of minting a fresh S3 version every time.
- */
-async function planSidecarUploads(
-  manager: LayoutManager,
-  scope: LayoutScope,
-  plans: SidecarPlan[],
-  remoteWorkflows: Array<Record<string, unknown>>,
-  renderingId: number,
-): Promise<SidecarPlan[]> {
-  const decided = await Promise.all(
-    plans.map(async plan => {
-      const current = remoteWorkflows.find(remote => String(remote.id) === plan.workflow.id);
-      const version = current?.bpmnAwsS3Identifier;
-      if (typeof version !== 'string' || !version) return { changed: true, plan };
-
-      try {
-        const stored = await manager.getWorkflowBpmn(
-          scope,
-          plan.workflow.id,
-          plan.workflow.collectionId,
-          version,
-          renderingId,
-        );
-
-        return { changed: stored !== plan.bpmn, plan };
-      } catch (error) {
-        // Auth/permission failures must surface, not be reframed as "changed".
-        if (error instanceof LayoutApiError && (error.status === 401 || error.status === 403)) {
-          throw error;
-        }
-
-        return { changed: true, plan };
-      }
-    }),
-  );
-
-  return decided.filter(entry => entry.changed).map(entry => entry.plan);
-}
-
-/**
- * When `--with-workflows`, BPMN transport is owned by the sidecar upload, not by
- * the JSON patch: `bpmnAwsS3Identifier` is a per-environment S3 pointer and is not
- * portable. Drop it from the diff so a pulled file never patches a target workflow
- * to the source env's (nonexistent) version — for workflows with a sidecar the
- * upload links the fresh id; for those without, the target keeps its own BPMN.
- */
-function stripWorkflowBpmnOps<T extends { op: string; path: string; value?: unknown }>(
-  ops: T[],
-): T[] {
-  return ops
-    .filter(op => !/\/bpmnAwsS3Identifier$/.test(op.path))
-    .map(op => {
-      if (op.op !== 'add' || !op.value || typeof op.value !== 'object') return op;
-
-      const value = { ...(op.value as Record<string, unknown>) };
-      delete value.bpmnAwsS3Identifier;
-
-      return { ...op, value };
-    });
+  return { missing, orphaned, plans };
 }
 
 /**
@@ -219,7 +170,7 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
     const { args, flags } = await this.parse(LayoutApplyCommand);
 
     const filePath = path.resolve(process.cwd(), args.file);
-    const { docs } = parseLayoutFile(readFileSync(filePath, 'utf8'));
+    const { docs, scope: fileScope } = parseLayoutFile(readFileSync(filePath, 'utf8'));
 
     // The file header is provenance only: the target env/team is chosen here
     // (flags or interactive prompt), never defaulted to where the file was pulled
@@ -236,9 +187,13 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
 
     // Round-trip: workflows with a `workflows/<id>.bpmn` sidecar and no `steps` are
     // uploaded verbatim to the target env (faithful transport, incl. UI-authored ones).
-    const { missing: sidecarMissing, plans: sidecarAll } = flags['with-workflows']
+    const {
+      missing: sidecarMissing,
+      orphaned: sidecarOrphaned,
+      plans: sidecarAll,
+    } = flags['with-workflows']
       ? readWorkflowSidecars(docs, filePath, bpmnWorkflows)
-      : { missing: [], plans: [] };
+      : { missing: [], orphaned: [], plans: [] };
 
     const remote = await fetchRemoteDocs(manager, scope, domainsInFile(docs));
     const diff = diffAllDomains(remote, docs);
@@ -246,6 +201,8 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
     // With --with-workflows the sidecar upload owns each workflow's BPMN pointer,
     // so the non-portable `bpmnAwsS3Identifier` must never be patched from the file.
     const ops = flags['with-workflows'] ? stripWorkflowBpmnOps(diff.ops) : diff.ops;
+
+    this.warnOnCrossEnvBpmnRefs(flags['with-workflows'], ops, fileScope.environmentId, scope);
 
     // Compile each step-graph and skip the ones whose BPMN already matches what
     // is stored — so re-applying a file with `steps` (or a sidecar) stays idempotent.
@@ -268,7 +225,7 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
       renderingId,
     );
 
-    this.logPlan({ bpmnToUpload, ops, sidecarMissing, sidecarPlans, warnings });
+    this.logPlan({ bpmnToUpload, ops, sidecarMissing, sidecarOrphaned, sidecarPlans, warnings });
 
     if (ops.length === 0 && bpmnToUpload.length === 0 && sidecarPlans.length === 0) {
       this.logger.success('Nothing to apply: the environment already matches the file.');
@@ -298,6 +255,30 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
   }
 
   /**
+   * Applying a file pulled from ANOTHER environment without `--with-workflows`
+   * would patch its `bpmnAwsS3Identifier` pointers into the target, where the
+   * S3 objects do not exist (the pointer is env-local). The ops are kept — a
+   * same-env restore legitimately rewrites its own pointers, and the header may
+   * be wrong or hand-edited — but the user is warned loudly beforehand.
+   */
+  private warnOnCrossEnvBpmnRefs(
+    withWorkflows: boolean,
+    ops: Array<{ op: string; path: string; value?: unknown }>,
+    fileEnvironmentId: number | undefined,
+    scope: LayoutScope,
+  ): void {
+    if (withWorkflows || !hasWorkflowBpmnOps(ops)) return;
+    if (fileEnvironmentId === undefined || fileEnvironmentId === scope.environmentId) return;
+
+    this.logger.warn(
+      'This file was pulled from a different environment and the plan patches workflow BPMN ' +
+        'references (`bpmnAwsS3Identifier`), which are NOT portable across environments — the ' +
+        'target would point at S3 objects that do not exist there. Use `pull --with-workflows` ' +
+        'then `apply --with-workflows` to transport the BPMN itself.',
+    );
+  }
+
+  /**
    * Push the plan: one atomic PATCH per domain (stable order), then the step and
    * sidecar BPMN uploads. Returns false (and exits 2) on a recoverable API error;
    * re-running converges since each domain patch is atomic.
@@ -309,7 +290,7 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
       bpmnToUpload: Parameters<typeof uploadWorkflowBpmns>[2];
       ops: ReturnType<typeof diffAllDomains>['ops'];
       renderingId: number;
-      sidecarPlans: SidecarPlan[];
+      sidecarPlans: SidecarUpload[];
     },
   ): Promise<boolean> {
     try {
@@ -326,9 +307,17 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
         );
       }
 
-      // Shells now exist, so upload each changed step-graph, then the sidecars.
+      // Shells now exist, so upload each changed step-graph, then the sidecars —
+      // each sidecar to its TARGET-env workflow id (resolved after the patches
+      // for workflows this apply just added).
       await uploadWorkflowBpmns(manager, scope, plan.bpmnToUpload, plan.renderingId);
-      await uploadWorkflowBpmns(manager, scope, plan.sidecarPlans, plan.renderingId);
+      const sidecarUploads = await this.resolveSidecarTargets(manager, scope, plan.sidecarPlans);
+      await uploadWorkflowBpmns(
+        manager,
+        scope,
+        sidecarUploads.map(upload => ({ bpmn: upload.bpmn, workflow: upload.target })),
+        plan.renderingId,
+      );
 
       return true;
     } catch (error) {
@@ -346,12 +335,54 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
     }
   }
 
-  /** Print the human-readable plan preview (diff + workflow uploads + missing-sidecar warning). */
+  /**
+   * Resolve the sidecars whose target workflow did not exist before the domain
+   * patches (they were `add`ed by this very apply): re-fetch the workflows
+   * document once and match id-then-name. Still-unmatched sidecars are skipped
+   * with a warning — never uploaded under a nonexistent id.
+   */
+  private async resolveSidecarTargets(
+    manager: LayoutManager,
+    scope: LayoutScope,
+    plans: SidecarUpload[],
+  ): Promise<Array<SidecarUpload & { target: { collectionId: string; id: string } }>> {
+    const unresolved = plans.some(plan => plan.target === null);
+    const refreshed = unresolved
+      ? ((await manager.getLayoutDomain('workflows', scope)) as Array<Record<string, unknown>>)
+      : [];
+
+    return plans.flatMap(plan => {
+      if (plan.target) return [{ ...plan, target: plan.target }];
+
+      const remote = resolveRemoteWorkflow(refreshed, plan.workflow);
+      if (!remote) {
+        this.logger.warn(
+          `Workflow « ${plan.workflow.name} » was not found in the target environment after ` +
+            'the patch — its BPMN sidecar was not uploaded.',
+        );
+
+        return [];
+      }
+
+      return [
+        {
+          ...plan,
+          target: {
+            collectionId: String(remote.collectionId ?? plan.workflow.collectionId),
+            id: String(remote.id),
+          },
+        },
+      ];
+    });
+  }
+
+  /** Print the human-readable plan preview (diff + workflow uploads + sidecar warnings). */
   private logPlan(preview: {
     bpmnToUpload: Array<{ workflow: { name: string; steps: unknown[] } }>;
     ops: Parameters<typeof formatPlan>[0];
     sidecarMissing: string[];
-    sidecarPlans: SidecarPlan[];
+    sidecarOrphaned: string[];
+    sidecarPlans: SidecarUpload[];
     warnings: Parameters<typeof formatPlan>[1];
   }): void {
     if (preview.sidecarMissing.length > 0) {
@@ -359,6 +390,14 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
         `${preview.sidecarMissing.length} workflow(s) have BPMN in the file but no ` +
           `workflows/<id>.bpmn sidecar — their BPMN was not transported (the target keeps its ` +
           `own): ${preview.sidecarMissing.join(', ')}.`,
+      );
+    }
+    if (preview.sidecarOrphaned.length > 0) {
+      this.logger.warn(
+        `${preview.sidecarOrphaned.length} sidecar file(s) match a workflow that declares no ` +
+          `BPMN in the layout file — skipped (not uploaded): ${preview.sidecarOrphaned.join(
+            ', ',
+          )}.`,
       );
     }
 

--- a/src/commands/layout/apply.ts
+++ b/src/commands/layout/apply.ts
@@ -51,33 +51,116 @@ async function uploadWorkflowBpmns(
   await manager.patchDomain('workflows', bpmnOps, scope);
 }
 
-/** Read `workflows/<id>.bpmn` sidecars for file workflows that carry no `steps` (steps take precedence). */
+type SidecarPlan = { bpmn: string; workflow: { collectionId: string; id: string; name: string } };
+type FileWorkflow = {
+  bpmnAwsS3Identifier?: string;
+  collectionId: string;
+  id: string;
+  name?: string;
+};
+
+/**
+ * Read `workflows/<id>.bpmn` sidecars for file workflows that carry no `steps`
+ * (steps take precedence). Returns the upload plans plus the ids of workflows
+ * that had BPMN in the file but no sidecar on disk — their BPMN cannot be
+ * transported, so the caller must warn and must not patch their (source) ref.
+ */
 function readWorkflowSidecars(
   docs: { workflows?: unknown[] },
   filePath: string,
   stepWorkflowsList: Array<{ id: string }>,
-): Array<{ bpmn: string; workflow: { collectionId: string; id: string; name: string } }> {
+): { missing: string[]; plans: SidecarPlan[] } {
   const stepIds = new Set(stepWorkflowsList.map(workflow => workflow.id));
   const dir = path.join(path.dirname(filePath), 'workflows');
+  const plans: SidecarPlan[] = [];
+  const missing: string[] = [];
 
-  return (
-    ((docs.workflows ?? []) as Array<{ collectionId: string; id: string; name?: string }>)
-      .filter(workflow => !stepIds.has(workflow.id))
+  ((docs.workflows ?? []) as FileWorkflow[])
+    .filter(workflow => !stepIds.has(workflow.id))
+    .forEach(workflow => {
       // `sidecarPath` returns null for a traversal-unsafe id, so a crafted layout
       // file can never make apply read a file outside the workflows/ directory.
-      .map(workflow => ({ file: sidecarPath(dir, workflow.id), workflow }))
-      .filter((entry): entry is { file: string; workflow: (typeof entry)['workflow'] } =>
-        Boolean(entry.file && existsSync(entry.file)),
-      )
-      .map(entry => ({
-        bpmn: readFileSync(entry.file, 'utf8'),
-        workflow: {
-          collectionId: entry.workflow.collectionId,
-          id: entry.workflow.id,
-          name: entry.workflow.name ?? entry.workflow.id,
-        },
-      }))
+      const file = sidecarPath(dir, workflow.id);
+      if (file && existsSync(file)) {
+        plans.push({
+          bpmn: readFileSync(file, 'utf8'),
+          workflow: {
+            collectionId: workflow.collectionId,
+            id: workflow.id,
+            name: workflow.name ?? workflow.id,
+          },
+        });
+      } else if (workflow.bpmnAwsS3Identifier) {
+        // The workflow had BPMN in the source, but its bytes weren't checked in.
+        missing.push(workflow.id);
+      }
+    });
+
+  return { missing, plans };
+}
+
+/**
+ * Skip sidecar uploads whose bytes already match the BPMN stored in the target
+ * (mirrors `planWorkflowBpmn` for step graphs) so re-applying an unchanged file
+ * stays a no-op instead of minting a fresh S3 version every time.
+ */
+async function planSidecarUploads(
+  manager: LayoutManager,
+  scope: LayoutScope,
+  plans: SidecarPlan[],
+  remoteWorkflows: Array<Record<string, unknown>>,
+  renderingId: number,
+): Promise<SidecarPlan[]> {
+  const decided = await Promise.all(
+    plans.map(async plan => {
+      const current = remoteWorkflows.find(remote => String(remote.id) === plan.workflow.id);
+      const version = current?.bpmnAwsS3Identifier;
+      if (typeof version !== 'string' || !version) return { changed: true, plan };
+
+      try {
+        const stored = await manager.getWorkflowBpmn(
+          scope,
+          plan.workflow.id,
+          plan.workflow.collectionId,
+          version,
+          renderingId,
+        );
+
+        return { changed: stored !== plan.bpmn, plan };
+      } catch (error) {
+        // Auth/permission failures must surface, not be reframed as "changed".
+        if (error instanceof LayoutApiError && (error.status === 401 || error.status === 403)) {
+          throw error;
+        }
+
+        return { changed: true, plan };
+      }
+    }),
   );
+
+  return decided.filter(entry => entry.changed).map(entry => entry.plan);
+}
+
+/**
+ * When `--with-workflows`, BPMN transport is owned by the sidecar upload, not by
+ * the JSON patch: `bpmnAwsS3Identifier` is a per-environment S3 pointer and is not
+ * portable. Drop it from the diff so a pulled file never patches a target workflow
+ * to the source env's (nonexistent) version — for workflows with a sidecar the
+ * upload links the fresh id; for those without, the target keeps its own BPMN.
+ */
+function stripWorkflowBpmnOps<T extends { op: string; path: string; value?: unknown }>(
+  ops: T[],
+): T[] {
+  return ops
+    .filter(op => !/\/bpmnAwsS3Identifier$/.test(op.path))
+    .map(op => {
+      if (op.op !== 'add' || !op.value || typeof op.value !== 'object') return op;
+
+      const value = { ...(op.value as Record<string, unknown>) };
+      delete value.bpmnAwsS3Identifier;
+
+      return { ...op, value };
+    });
 }
 
 /**
@@ -153,17 +236,21 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
 
     // Round-trip: workflows with a `workflows/<id>.bpmn` sidecar and no `steps` are
     // uploaded verbatim to the target env (faithful transport, incl. UI-authored ones).
-    const sidecarPlans = flags['with-workflows']
+    const { missing: sidecarMissing, plans: sidecarAll } = flags['with-workflows']
       ? readWorkflowSidecars(docs, filePath, bpmnWorkflows)
-      : [];
+      : { missing: [], plans: [] };
 
     const remote = await fetchRemoteDocs(manager, scope, domainsInFile(docs));
-    const { ops, warnings } = diffAllDomains(remote, docs);
+    const diff = diffAllDomains(remote, docs);
+    const { warnings } = diff;
+    // With --with-workflows the sidecar upload owns each workflow's BPMN pointer,
+    // so the non-portable `bpmnAwsS3Identifier` must never be patched from the file.
+    const ops = flags['with-workflows'] ? stripWorkflowBpmnOps(diff.ops) : diff.ops;
 
     // Compile each step-graph and skip the ones whose BPMN already matches what
-    // is stored — so re-applying a file with `steps` stays idempotent.
+    // is stored — so re-applying a file with `steps` (or a sidecar) stays idempotent.
     const renderingId =
-      bpmnWorkflows.length > 0 || sidecarPlans.length > 0 ? await manager.getRenderingId(scope) : 0;
+      bpmnWorkflows.length > 0 || sidecarAll.length > 0 ? await manager.getRenderingId(scope) : 0;
     const remoteWorkflows = (remote.workflows ?? []) as Array<Record<string, unknown>>;
     const bpmnPlans = await planWorkflowBpmn(
       manager,
@@ -173,16 +260,15 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
       renderingId,
     );
     const bpmnToUpload = bpmnPlans.filter(plan => plan.changed);
+    const sidecarPlans = await planSidecarUploads(
+      manager,
+      scope,
+      sidecarAll,
+      remoteWorkflows,
+      renderingId,
+    );
 
-    this.log(formatPlan(ops, warnings));
-    bpmnToUpload.forEach(plan =>
-      this.log(
-        `  ⚙ workflow « ${plan.workflow.name} »: compile + upload BPMN (${plan.workflow.steps.length} steps)`,
-      ),
-    );
-    sidecarPlans.forEach(plan =>
-      this.log(`  ↑ workflow « ${plan.workflow.name} »: upload BPMN sidecar`),
-    );
+    this.logPlan({ bpmnToUpload, ops, sidecarMissing, sidecarPlans, warnings });
 
     if (ops.length === 0 && bpmnToUpload.length === 0 && sidecarPlans.length === 0) {
       this.logger.success('Nothing to apply: the environment already matches the file.');
@@ -194,38 +280,13 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
       return;
     }
 
-    try {
-      // One atomic PATCH per domain, in a stable order; ops are already add→replace→remove.
-      const domainsToPatch = LAYOUT_DOMAINS.filter(domain => ops.some(op => op.domain === domain));
-      // eslint-disable-next-line no-restricted-syntax -- sequential awaits: domains patched one at a time
-      for (const domain of domainsToPatch) {
-        // eslint-disable-next-line no-await-in-loop -- intentional: atomic, ordered per-domain patches
-        await manager.patchDomain(
-          domain,
-          ops.filter(op => op.domain === domain),
-          scope,
-        );
-      }
-
-      // BPMN authoring: shells now exist, so upload each changed step-graph and
-      // link the returned versions (one patch).
-      await uploadWorkflowBpmns(manager, scope, bpmnToUpload, renderingId);
-      // Round-trip: upload the sidecar BPMNs verbatim to the target env.
-      await uploadWorkflowBpmns(manager, scope, sidecarPlans, renderingId);
-    } catch (error) {
-      if (error instanceof LayoutApiError && error.status !== 401) {
-        this.logger.error(explainApiError(error, ops));
-        // Patches are atomic per domain, not across the whole apply: earlier domains
-        // (or BPMN uploads) may already be committed. Re-running converges safely.
-        this.logger.warn(
-          '`forest layout apply` is idempotent — some changes may already be applied; re-run it to converge.',
-        );
-        this.exit(2);
-        return;
-      }
-
-      throw error;
-    }
+    const applied = await this.pushChanges(manager, scope, {
+      bpmnToUpload,
+      ops,
+      renderingId,
+      sidecarPlans,
+    });
+    if (!applied) return;
 
     const bpmnCount = bpmnToUpload.length + sidecarPlans.length;
     const bpmnNote = bpmnCount > 0 ? ` + ${bpmnCount} workflow BPMN` : '';
@@ -233,6 +294,82 @@ export default class LayoutApplyCommand extends AbstractAuthenticatedCommand {
       `Applied ${ops.length} change${ops.length === 1 ? '' : 's'}${bpmnNote} to ${this.chalk.bold(
         scope.environmentName,
       )} / ${this.chalk.bold(scope.teamName)}.`,
+    );
+  }
+
+  /**
+   * Push the plan: one atomic PATCH per domain (stable order), then the step and
+   * sidecar BPMN uploads. Returns false (and exits 2) on a recoverable API error;
+   * re-running converges since each domain patch is atomic.
+   */
+  private async pushChanges(
+    manager: LayoutManager,
+    scope: LayoutScope,
+    plan: {
+      bpmnToUpload: Parameters<typeof uploadWorkflowBpmns>[2];
+      ops: ReturnType<typeof diffAllDomains>['ops'];
+      renderingId: number;
+      sidecarPlans: SidecarPlan[];
+    },
+  ): Promise<boolean> {
+    try {
+      const domainsToPatch = LAYOUT_DOMAINS.filter(domain =>
+        plan.ops.some(op => op.domain === domain),
+      );
+      // eslint-disable-next-line no-restricted-syntax -- sequential awaits: domains patched one at a time
+      for (const domain of domainsToPatch) {
+        // eslint-disable-next-line no-await-in-loop -- intentional: atomic, ordered per-domain patches
+        await manager.patchDomain(
+          domain,
+          plan.ops.filter(op => op.domain === domain),
+          scope,
+        );
+      }
+
+      // Shells now exist, so upload each changed step-graph, then the sidecars.
+      await uploadWorkflowBpmns(manager, scope, plan.bpmnToUpload, plan.renderingId);
+      await uploadWorkflowBpmns(manager, scope, plan.sidecarPlans, plan.renderingId);
+
+      return true;
+    } catch (error) {
+      if (error instanceof LayoutApiError && error.status !== 401) {
+        this.logger.error(explainApiError(error, plan.ops));
+        this.logger.warn(
+          '`forest layout apply` is idempotent — some changes may already be applied; re-run it to converge.',
+        );
+        this.exit(2);
+
+        return false;
+      }
+
+      throw error;
+    }
+  }
+
+  /** Print the human-readable plan preview (diff + workflow uploads + missing-sidecar warning). */
+  private logPlan(preview: {
+    bpmnToUpload: Array<{ workflow: { name: string; steps: unknown[] } }>;
+    ops: Parameters<typeof formatPlan>[0];
+    sidecarMissing: string[];
+    sidecarPlans: SidecarPlan[];
+    warnings: Parameters<typeof formatPlan>[1];
+  }): void {
+    if (preview.sidecarMissing.length > 0) {
+      this.logger.warn(
+        `${preview.sidecarMissing.length} workflow(s) have BPMN in the file but no ` +
+          `workflows/<id>.bpmn sidecar — their BPMN was not transported (the target keeps its ` +
+          `own): ${preview.sidecarMissing.join(', ')}.`,
+      );
+    }
+
+    this.log(formatPlan(preview.ops, preview.warnings));
+    preview.bpmnToUpload.forEach(plan =>
+      this.log(
+        `  ⚙ workflow « ${plan.workflow.name} »: compile + upload BPMN (${plan.workflow.steps.length} steps)`,
+      ),
+    );
+    preview.sidecarPlans.forEach(plan =>
+      this.log(`  ↑ workflow « ${plan.workflow.name} »: upload BPMN sidecar`),
     );
   }
 

--- a/src/commands/layout/apply.ts
+++ b/src/commands/layout/apply.ts
@@ -19,6 +19,7 @@ import {
   stepWorkflows,
 } from '../../services/layout/sync';
 import { LAYOUT_DOMAINS } from '../../services/layout/types';
+import { sidecarPath } from '../../services/layout/workflow-sidecar';
 
 /** Upload each changed step-graph's BPMN to S3 and link the returned versions (one patch). */
 async function uploadWorkflowBpmns(
@@ -59,18 +60,24 @@ function readWorkflowSidecars(
   const stepIds = new Set(stepWorkflowsList.map(workflow => workflow.id));
   const dir = path.join(path.dirname(filePath), 'workflows');
 
-  return ((docs.workflows ?? []) as Array<{ collectionId: string; id: string; name?: string }>)
-    .filter(workflow => !stepIds.has(workflow.id))
-    .map(workflow => ({ file: path.join(dir, `${workflow.id}.bpmn`), workflow }))
-    .filter(entry => existsSync(entry.file))
-    .map(entry => ({
-      bpmn: readFileSync(entry.file, 'utf8'),
-      workflow: {
-        collectionId: entry.workflow.collectionId,
-        id: entry.workflow.id,
-        name: entry.workflow.name ?? entry.workflow.id,
-      },
-    }));
+  return (
+    ((docs.workflows ?? []) as Array<{ collectionId: string; id: string; name?: string }>)
+      .filter(workflow => !stepIds.has(workflow.id))
+      // `sidecarPath` returns null for a traversal-unsafe id, so a crafted layout
+      // file can never make apply read a file outside the workflows/ directory.
+      .map(workflow => ({ file: sidecarPath(dir, workflow.id), workflow }))
+      .filter((entry): entry is { file: string; workflow: (typeof entry)['workflow'] } =>
+        Boolean(entry.file && existsSync(entry.file)),
+      )
+      .map(entry => ({
+        bpmn: readFileSync(entry.file, 'utf8'),
+        workflow: {
+          collectionId: entry.workflow.collectionId,
+          id: entry.workflow.id,
+          name: entry.workflow.name ?? entry.workflow.id,
+        },
+      }))
+  );
 }
 
 /**

--- a/src/commands/layout/pull.ts
+++ b/src/commands/layout/pull.ts
@@ -2,7 +2,7 @@ import type { LayoutScope } from '../../services/layout/types';
 import type { Config } from '@oclif/core';
 
 import { Flags } from '@oclif/core';
-import { mkdirSync, readdirSync, unlinkSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readdirSync, unlinkSync, writeFileSync } from 'fs';
 import path from 'path';
 
 import AbstractAuthenticatedCommand from '../../abstract-authenticated-command';
@@ -11,7 +11,11 @@ import { serializeLayoutFile } from '../../services/layout/layout-file';
 import LayoutManager from '../../services/layout/layout-manager';
 import { PULL_DOMAINS, fetchRemoteDocs, summarize } from '../../services/layout/read';
 import { resolveCommandScope } from '../../services/layout/resolve-command-scope';
-import { sidecarPath } from '../../services/layout/workflow-sidecar';
+import {
+  isSafeWorkflowId,
+  selectStaleSidecars,
+  sidecarPath,
+} from '../../services/layout/workflow-sidecar';
 
 /** An unresolvable BPMN ref: the S3 version is gone (404), not an auth/network error. */
 function isDeadBpmnRef(error: unknown): boolean {
@@ -44,18 +48,36 @@ async function downloadWorkflowSidecar(
   }
 }
 
-/** Remove `<id>.bpmn` files that were not (re)written this pull, so a mirror stays a mirror. */
-function pruneStaleSidecars(dir: string, keep: Set<string>): string[] {
-  const pruned: string[] = [];
-  readdirSync(dir).forEach(entry => {
-    const match = entry.match(/^(.+)\.bpmn$/);
-    if (match && !keep.has(match[1])) {
-      unlinkSync(path.join(dir, entry));
-      pruned.push(match[1]);
-    }
-  });
+type WorkflowRef = { bpmnAwsS3Identifier?: string; collectionId: string; id: string };
+type SidecarDownloads = { downloads: Array<{ bpmn: string; id: string }>; skipped: string[] };
 
-  return pruned;
+/** Download each workflow's stored BPMN into memory (no disk write here). */
+async function downloadWorkflowBpmns(
+  manager: LayoutManager,
+  scope: LayoutScope,
+  workflows: WorkflowRef[],
+): Promise<SidecarDownloads> {
+  const downloads: Array<{ bpmn: string; id: string }> = [];
+  const skipped: string[] = [];
+
+  const withBpmn = workflows.filter(workflow => workflow.bpmnAwsS3Identifier);
+  if (withBpmn.length === 0) return { downloads, skipped };
+
+  const renderingId = await manager.getRenderingId(scope);
+  // eslint-disable-next-line no-restricted-syntax -- sequential: one signed download at a time
+  for (const workflow of withBpmn) {
+    // A workflow id becomes a filename — reject traversal before touching disk.
+    if (!isSafeWorkflowId(workflow.id)) {
+      skipped.push(String(workflow.id));
+    } else {
+      // eslint-disable-next-line no-await-in-loop -- intentional sequential downloads
+      const bpmn = await downloadWorkflowSidecar(manager, scope, workflow, renderingId);
+      if (bpmn) downloads.push({ bpmn, id: workflow.id });
+      else skipped.push(workflow.id);
+    }
+  }
+
+  return { downloads, skipped };
 }
 
 const DEFAULT_OUTPUT = 'forest-layout.json';
@@ -115,79 +137,77 @@ export default class LayoutPullCommand extends AbstractAuthenticatedCommand {
     const manager = new LayoutManager();
     const docs = await fetchRemoteDocs(manager, scope, PULL_DOMAINS);
     const content = serializeLayoutFile(scope, docs, () => new Date());
+    const workflows = (docs.workflows ?? []) as WorkflowRef[];
+
+    // Download every BPMN into memory BEFORE writing anything, so a mid-pull
+    // network error leaves the previous layout + sidecars fully intact instead
+    // of a fresh layout mixed with stale, unpruned sidecars.
+    const sidecars = flags['with-workflows']
+      ? await downloadWorkflowBpmns(manager, scope, workflows)
+      : null;
 
     const outputPath = path.resolve(process.cwd(), flags.out);
     writeFileSync(outputPath, content);
-
-    if (flags['with-workflows']) {
-      await this.pullWorkflowBpmns(
-        manager,
-        scope,
-        (docs.workflows ?? []) as Array<{
-          bpmnAwsS3Identifier?: string;
-          collectionId: string;
-          id: string;
-        }>,
-        outputPath,
+    if (sidecars) {
+      this.writeWorkflowSidecars(
+        path.join(path.dirname(outputPath), 'workflows'),
+        sidecars,
+        workflows,
       );
     }
 
-    const { collections, workflows } = summarize(docs);
+    const { collections, workflows: workflowCount } = summarize(docs);
     this.logger.success(
       `Pulled the layout of ${this.chalk.bold(scope.environmentName)} / ${this.chalk.bold(
         scope.teamName,
-      )} into ${this.chalk.bold(flags.out)} (${collections} collections, ${workflows} workflows).`,
+      )} into ${this.chalk.bold(
+        flags.out,
+      )} (${collections} collections, ${workflowCount} workflows).`,
     );
   }
 
-  /** Download each workflow's stored BPMN into `workflows/<id>.bpmn` next to the layout file. */
-  private async pullWorkflowBpmns(
-    manager: LayoutManager,
-    scope: LayoutScope,
-    workflows: Array<{ bpmnAwsS3Identifier?: string; collectionId: string; id: string }>,
-    outputPath: string,
-  ): Promise<void> {
-    const withBpmn = workflows.filter(workflow => workflow.bpmnAwsS3Identifier);
-    if (withBpmn.length === 0) return;
+  /**
+   * Write the downloaded sidecars, then prune the STALE ones: only files named
+   * like a managed sidecar whose workflow no longer exists in the environment.
+   * Sidecars of still-existing workflows are always kept — including those whose
+   * download was skipped (dead S3 ref): that file may be the last copy of the
+   * BPMN, and a backup tool must never destroy the backup. Every deletion is
+   * logged. The prune runs even when nothing was downloaded, so a layout whose
+   * workflows all lost their BPMN still converges to a faithful mirror.
+   */
+  private writeWorkflowSidecars(
+    dir: string,
+    sidecars: SidecarDownloads,
+    workflows: WorkflowRef[],
+  ): void {
+    if (sidecars.downloads.length === 0 && !existsSync(dir)) {
+      this.warnSkipped(sidecars.skipped);
+      return;
+    }
 
-    const renderingId = await manager.getRenderingId(scope);
-    const dir = path.join(path.dirname(outputPath), 'workflows');
     mkdirSync(dir, { recursive: true });
+    sidecars.downloads.forEach(({ bpmn, id }) =>
+      writeFileSync(sidecarPath(dir, id) as string, bpmn),
+    );
 
-    const saved: string[] = [];
-    const skipped: string[] = [];
-    // eslint-disable-next-line no-restricted-syntax -- sequential: one signed download at a time
-    for (const workflow of withBpmn) {
-      // A workflow id becomes a filename — reject traversal before touching disk.
-      const file = sidecarPath(dir, workflow.id);
-      if (!file) {
-        skipped.push(String(workflow.id));
-      } else {
-        // eslint-disable-next-line no-await-in-loop -- intentional sequential downloads
-        const bpmn = await downloadWorkflowSidecar(manager, scope, workflow, renderingId);
-        if (bpmn) {
-          writeFileSync(file, bpmn);
-          saved.push(workflow.id);
-        } else {
-          skipped.push(workflow.id);
-        }
-      }
-    }
+    const keep = new Set(workflows.map(workflow => String(workflow.id)));
+    selectStaleSidecars(readdirSync(dir), keep).forEach(entry => {
+      unlinkSync(path.join(dir, entry));
+      this.log(`  ↺ pruned stale sidecar ${entry}`);
+    });
 
-    // A pull mirrors the env: drop sidecars for workflows we did not just write
-    // (deleted, or now unresolvable) so a later apply can't re-upload stale BPMN.
-    const pruned = pruneStaleSidecars(dir, new Set(saved));
+    this.log(
+      `  ↓ ${sidecars.downloads.length} workflow BPMN → ${path.relative(process.cwd(), dir)}/`,
+    );
+    this.warnSkipped(sidecars.skipped);
+  }
 
-    this.log(`  ↓ ${saved.length} workflow BPMN → ${path.relative(process.cwd(), dir)}/`);
-    if (pruned.length > 0) this.log(`  ↺ pruned ${pruned.length} stale sidecar(s)`);
-    if (skipped.length > 0) {
-      this.logger.warn(
-        `Skipped ${
-          skipped.length
-        } workflow BPMN with an unresolvable ref (not uploaded to this env): ${skipped.join(
-          ', ',
-        )}.`,
-      );
-    }
+  private warnSkipped(skipped: string[]): void {
+    if (skipped.length === 0) return;
+
+    this.logger.warn(
+      `Skipped ${skipped.length} workflow BPMN with an unresolvable ref (not uploaded to this env) — their existing ` +
+        `sidecar files, if any, were kept: ${skipped.join(', ')}.`,
+    );
   }
 }

--- a/src/commands/layout/pull.ts
+++ b/src/commands/layout/pull.ts
@@ -1,7 +1,8 @@
+import type { LayoutScope } from '../../services/layout/types';
 import type { Config } from '@oclif/core';
 
 import { Flags } from '@oclif/core';
-import { writeFileSync } from 'fs';
+import { mkdirSync, writeFileSync } from 'fs';
 import path from 'path';
 
 import AbstractAuthenticatedCommand from '../../abstract-authenticated-command';
@@ -43,6 +44,10 @@ export default class LayoutPullCommand extends AbstractAuthenticatedCommand {
       description: `Output file path (default: ${DEFAULT_OUTPUT}).`,
       default: DEFAULT_OUTPUT,
     }),
+    'with-workflows': Flags.boolean({
+      description:
+        "Also download each workflow's BPMN into sidecar files (workflows/<id>.bpmn) for round-trip.",
+    }),
   };
 
   constructor(argv: string[], config: Config, plan?) {
@@ -60,11 +65,25 @@ export default class LayoutPullCommand extends AbstractAuthenticatedCommand {
       flags: { env: flags.env, projectId: flags.projectId, team: flags.team },
     });
 
-    const docs = await fetchRemoteDocs(new LayoutManager(), scope, PULL_DOMAINS);
+    const manager = new LayoutManager();
+    const docs = await fetchRemoteDocs(manager, scope, PULL_DOMAINS);
     const content = serializeLayoutFile(scope, docs, () => new Date());
 
     const outputPath = path.resolve(process.cwd(), flags.out);
     writeFileSync(outputPath, content);
+
+    if (flags['with-workflows']) {
+      await this.pullWorkflowBpmns(
+        manager,
+        scope,
+        (docs.workflows ?? []) as Array<{
+          bpmnAwsS3Identifier?: string;
+          collectionId: string;
+          id: string;
+        }>,
+        outputPath,
+      );
+    }
 
     const { collections, workflows } = summarize(docs);
     this.logger.success(
@@ -72,5 +91,58 @@ export default class LayoutPullCommand extends AbstractAuthenticatedCommand {
         scope.teamName,
       )} into ${this.chalk.bold(flags.out)} (${collections} collections, ${workflows} workflows).`,
     );
+  }
+
+  /** Download each workflow's stored BPMN into `workflows/<id>.bpmn` next to the layout file. */
+  private async pullWorkflowBpmns(
+    manager: LayoutManager,
+    scope: LayoutScope,
+    workflows: Array<{ bpmnAwsS3Identifier?: string; collectionId: string; id: string }>,
+    outputPath: string,
+  ): Promise<void> {
+    const withBpmn = workflows.filter(workflow => workflow.bpmnAwsS3Identifier);
+    if (withBpmn.length === 0) return;
+
+    const renderingId = await manager.getRenderingId(scope);
+    const dir = path.join(path.dirname(outputPath), 'workflows');
+    mkdirSync(dir, { recursive: true });
+
+    let saved = 0;
+    const skipped: string[] = [];
+    // eslint-disable-next-line no-restricted-syntax -- sequential: one signed download at a time
+    for (const workflow of withBpmn) {
+      try {
+        // eslint-disable-next-line no-await-in-loop -- intentional sequential downloads
+        const bpmn = await manager.getWorkflowBpmn(
+          scope,
+          workflow.id,
+          workflow.collectionId,
+          workflow.bpmnAwsS3Identifier as string,
+          renderingId,
+        );
+        if (bpmn) {
+          writeFileSync(path.join(dir, `${workflow.id}.bpmn`), bpmn);
+          saved += 1;
+        } else {
+          skipped.push(workflow.id);
+        }
+      } catch {
+        // A workflow can carry a `bpmnAwsS3Identifier` that no longer resolves to
+        // an S3 version (e.g. a ref baked by a demo/seed but never uploaded to this
+        // project's bucket). Skip it — a dead ref must not abort the whole pull.
+        skipped.push(workflow.id);
+      }
+    }
+
+    this.log(`  ↓ ${saved} workflow BPMN → ${path.relative(process.cwd(), dir)}/`);
+    if (skipped.length > 0) {
+      this.logger.warn(
+        `Skipped ${
+          skipped.length
+        } workflow BPMN with an unresolvable ref (not uploaded to this env): ${skipped.join(
+          ', ',
+        )}.`,
+      );
+    }
   }
 }

--- a/src/commands/layout/pull.ts
+++ b/src/commands/layout/pull.ts
@@ -146,8 +146,10 @@ export default class LayoutPullCommand extends AbstractAuthenticatedCommand {
       ? await downloadWorkflowBpmns(manager, scope, workflows)
       : null;
 
+    // Sidecars first, layout last: the layout file is the source of truth, so it
+    // only replaces the previous snapshot once the sidecars have converged. A
+    // sidecar write failure leaves the old layout + old sidecars intact.
     const outputPath = path.resolve(process.cwd(), flags.out);
-    writeFileSync(outputPath, content);
     if (sidecars) {
       this.writeWorkflowSidecars(
         path.join(path.dirname(outputPath), 'workflows'),
@@ -155,6 +157,7 @@ export default class LayoutPullCommand extends AbstractAuthenticatedCommand {
         workflows,
       );
     }
+    writeFileSync(outputPath, content);
 
     const { collections, workflows: workflowCount } = summarize(docs);
     this.logger.success(

--- a/src/commands/layout/pull.ts
+++ b/src/commands/layout/pull.ts
@@ -2,14 +2,61 @@ import type { LayoutScope } from '../../services/layout/types';
 import type { Config } from '@oclif/core';
 
 import { Flags } from '@oclif/core';
-import { mkdirSync, writeFileSync } from 'fs';
+import { mkdirSync, readdirSync, unlinkSync, writeFileSync } from 'fs';
 import path from 'path';
 
 import AbstractAuthenticatedCommand from '../../abstract-authenticated-command';
+import { LayoutApiError } from '../../services/layout/errors';
 import { serializeLayoutFile } from '../../services/layout/layout-file';
 import LayoutManager from '../../services/layout/layout-manager';
 import { PULL_DOMAINS, fetchRemoteDocs, summarize } from '../../services/layout/read';
 import { resolveCommandScope } from '../../services/layout/resolve-command-scope';
+import { sidecarPath } from '../../services/layout/workflow-sidecar';
+
+/** An unresolvable BPMN ref: the S3 version is gone (404), not an auth/network error. */
+function isDeadBpmnRef(error: unknown): boolean {
+  return error instanceof LayoutApiError && error.status === 404;
+}
+
+/**
+ * Download one workflow's BPMN, returning '' when the ref is dead (a version
+ * baked but never uploaded to this bucket). Genuine failures (auth, network,
+ * server) propagate so an incomplete pull is never mistaken for a clean one.
+ */
+async function downloadWorkflowSidecar(
+  manager: LayoutManager,
+  scope: LayoutScope,
+  workflow: { bpmnAwsS3Identifier?: string; collectionId: string; id: string },
+  renderingId: number,
+): Promise<string> {
+  try {
+    return await manager.getWorkflowBpmn(
+      scope,
+      workflow.id,
+      workflow.collectionId,
+      workflow.bpmnAwsS3Identifier as string,
+      renderingId,
+    );
+  } catch (error) {
+    if (isDeadBpmnRef(error)) return '';
+
+    throw error;
+  }
+}
+
+/** Remove `<id>.bpmn` files that were not (re)written this pull, so a mirror stays a mirror. */
+function pruneStaleSidecars(dir: string, keep: Set<string>): string[] {
+  const pruned: string[] = [];
+  readdirSync(dir).forEach(entry => {
+    const match = entry.match(/^(.+)\.bpmn$/);
+    if (match && !keep.has(match[1])) {
+      unlinkSync(path.join(dir, entry));
+      pruned.push(match[1]);
+    }
+  });
+
+  return pruned;
+}
 
 const DEFAULT_OUTPUT = 'forest-layout.json';
 
@@ -107,34 +154,32 @@ export default class LayoutPullCommand extends AbstractAuthenticatedCommand {
     const dir = path.join(path.dirname(outputPath), 'workflows');
     mkdirSync(dir, { recursive: true });
 
-    let saved = 0;
+    const saved: string[] = [];
     const skipped: string[] = [];
     // eslint-disable-next-line no-restricted-syntax -- sequential: one signed download at a time
     for (const workflow of withBpmn) {
-      try {
+      // A workflow id becomes a filename — reject traversal before touching disk.
+      const file = sidecarPath(dir, workflow.id);
+      if (!file) {
+        skipped.push(String(workflow.id));
+      } else {
         // eslint-disable-next-line no-await-in-loop -- intentional sequential downloads
-        const bpmn = await manager.getWorkflowBpmn(
-          scope,
-          workflow.id,
-          workflow.collectionId,
-          workflow.bpmnAwsS3Identifier as string,
-          renderingId,
-        );
+        const bpmn = await downloadWorkflowSidecar(manager, scope, workflow, renderingId);
         if (bpmn) {
-          writeFileSync(path.join(dir, `${workflow.id}.bpmn`), bpmn);
-          saved += 1;
+          writeFileSync(file, bpmn);
+          saved.push(workflow.id);
         } else {
           skipped.push(workflow.id);
         }
-      } catch {
-        // A workflow can carry a `bpmnAwsS3Identifier` that no longer resolves to
-        // an S3 version (e.g. a ref baked by a demo/seed but never uploaded to this
-        // project's bucket). Skip it — a dead ref must not abort the whole pull.
-        skipped.push(workflow.id);
       }
     }
 
-    this.log(`  ↓ ${saved} workflow BPMN → ${path.relative(process.cwd(), dir)}/`);
+    // A pull mirrors the env: drop sidecars for workflows we did not just write
+    // (deleted, or now unresolvable) so a later apply can't re-upload stale BPMN.
+    const pruned = pruneStaleSidecars(dir, new Set(saved));
+
+    this.log(`  ↓ ${saved.length} workflow BPMN → ${path.relative(process.cwd(), dir)}/`);
+    if (pruned.length > 0) this.log(`  ↺ pruned ${pruned.length} stale sidecar(s)`);
     if (skipped.length > 0) {
       this.logger.warn(
         `Skipped ${

--- a/src/services/layout/diff.ts
+++ b/src/services/layout/diff.ts
@@ -60,8 +60,10 @@ type ItemMatch = {
 /**
  * Build the local→remote resolver: a singleton (e.g. the main folder) matches its
  * remote counterpart regardless of id/name; otherwise match by id, then by name.
+ * Exported so the sidecar upload (`workflow-sidecar.ts`) resolves its target with
+ * the EXACT same semantics as the domain patch (incl. last-wins on duplicate names).
  */
-function remoteResolver(
+export function remoteResolver(
   remoteItems: Item[],
   singletonFlag?: string,
 ): (local: Item) => Item | undefined {

--- a/src/services/layout/patch-rules.ts
+++ b/src/services/layout/patch-rules.ts
@@ -389,9 +389,11 @@ export const DOMAIN_RULES: Record<LayoutDomain, DomainRules> = {
 
 /* --------------------------- whitelist mirror ---------------------------- */
 
-// Same id classes as the server's patch-handler.
+// Same id classes as the server's patch-handler. NUM_OR_UUID is exported so the
+// sidecar prune (`workflow-sidecar.ts`) only ever deletes files named after a
+// real server id — never a user's own hand-named BPMN files.
 const ID = String.raw`[^/\s:]+`;
-const NUM_OR_UUID = String.raw`([0-9]+|[0-9a-fA-F-]{36})`;
+export const NUM_OR_UUID = String.raw`([0-9]+|[0-9a-fA-F-]{36})`;
 
 type WhitelistEntry = { ops: Array<'add' | 'remove' | 'replace' | 'test'>; pattern: RegExp };
 

--- a/src/services/layout/workflow-sidecar.ts
+++ b/src/services/layout/workflow-sidecar.ts
@@ -1,0 +1,25 @@
+import path from 'path';
+
+/**
+ * A workflow's BPMN is stored round-trip as a sidecar file named after its id
+ * (`workflows/<id>.bpmn`). Because that id comes from a layout file, a crafted
+ * file could set it to `../../.ssh/id_rsa` and make `apply --with-workflows`
+ * read an arbitrary file (or `pull` write outside the workflows dir). Only
+ * accept ids that are a single, traversal-free path segment — Forest ids are
+ * UUIDs, so this is deliberately strict.
+ */
+export function isSafeWorkflowId(id: unknown): id is string {
+  return (
+    typeof id === 'string' &&
+    id.length > 0 &&
+    !id.includes('/') &&
+    !id.includes('\\') &&
+    !id.includes('..') &&
+    path.basename(id) === id
+  );
+}
+
+/** The sidecar path for a workflow id, or null when the id is unsafe. */
+export function sidecarPath(dir: string, id: unknown): string | null {
+  return isSafeWorkflowId(id) ? path.join(dir, `${id}.bpmn`) : null;
+}

--- a/src/services/layout/workflow-sidecar.ts
+++ b/src/services/layout/workflow-sidecar.ts
@@ -1,12 +1,26 @@
+/**
+ * BPMN sidecar transport for `layout pull/apply --with-workflows`.
+ *
+ * A workflow's BPMN is not part of the patchable document — it lives in S3 and
+ * `bpmnAwsS3Identifier` is a per-environment pointer, not portable across envs.
+ * So the round-trip stores the bytes in `workflows/<id>.bpmn` files next to the
+ * layout: `pull` downloads them, `apply` re-uploads them to the target and links
+ * the fresh version. All the pure decision logic lives here (the commands only
+ * do I/O) so it can be unit-tested.
+ */
+import type LayoutManager from './layout-manager';
+import type { LayoutScope } from './types';
+
 import path from 'path';
 
+import { LayoutApiError } from './errors';
+
 /**
- * A workflow's BPMN is stored round-trip as a sidecar file named after its id
- * (`workflows/<id>.bpmn`). Because that id comes from a layout file, a crafted
- * file could set it to `../../.ssh/id_rsa` and make `apply --with-workflows`
- * read an arbitrary file (or `pull` write outside the workflows dir). Only
- * accept ids that are a single, traversal-free path segment — Forest ids are
- * UUIDs, so this is deliberately strict.
+ * A workflow id becomes a sidecar filename (`workflows/<id>.bpmn`). Because that
+ * id comes from a layout file, a crafted file could set it to `../../.ssh/id_rsa`
+ * and make `apply --with-workflows` read an arbitrary file (or `pull` write
+ * outside the workflows dir). Only accept ids that are a single, traversal-free
+ * path segment — Forest ids are UUIDs, so this is deliberately strict.
  */
 export function isSafeWorkflowId(id: unknown): id is string {
   return (
@@ -22,4 +36,150 @@ export function isSafeWorkflowId(id: unknown): id is string {
 /** The sidecar path for a workflow id, or null when the id is unsafe. */
 export function sidecarPath(dir: string, id: unknown): string | null {
   return isSafeWorkflowId(id) ? path.join(dir, `${id}.bpmn`) : null;
+}
+
+/**
+ * Resolve a file workflow to its target-env counterpart with the same
+ * id-then-name matching the diff engine uses (`remoteResolver` in diff.ts), so
+ * the sidecar upload targets the very workflow the domain patch addressed. A
+ * dev→prod promote typically matches by NAME (each env mints its own ids).
+ */
+export function resolveRemoteWorkflow(
+  remoteWorkflows: Array<Record<string, unknown>>,
+  workflow: { id: string; name?: string },
+): Record<string, unknown> | undefined {
+  return (
+    remoteWorkflows.find(
+      remote => remote.id !== undefined && remote.id !== null && String(remote.id) === workflow.id,
+    ) ??
+    (typeof workflow.name === 'string'
+      ? remoteWorkflows.find(remote => remote.name === workflow.name)
+      : undefined)
+  );
+}
+
+/**
+ * When `--with-workflows`, BPMN transport is owned by the sidecar upload, not by
+ * the JSON patch: `bpmnAwsS3Identifier` is a per-environment S3 pointer and is not
+ * portable. Drop it from the diff so a pulled file never patches a target workflow
+ * to the source env's (nonexistent) version — for workflows with a sidecar the
+ * upload links the fresh id; for those without, the target keeps its own BPMN.
+ */
+export function stripWorkflowBpmnOps<T extends { op: string; path: string; value?: unknown }>(
+  ops: T[],
+): T[] {
+  return ops
+    .filter(op => !/\/bpmnAwsS3Identifier$/.test(op.path))
+    .map(op => {
+      if (op.op !== 'add' || !op.value || typeof op.value !== 'object') return op;
+
+      const value = { ...(op.value as Record<string, unknown>) };
+      delete value.bpmnAwsS3Identifier;
+
+      return { ...op, value };
+    });
+}
+
+/**
+ * True when the plan would write a `bpmnAwsS3Identifier` into the target — either
+ * as a replace of the pointer itself or inside an added workflow. Used by `apply`
+ * WITHOUT `--with-workflows` to warn on cross-environment applies: the pointer is
+ * env-local, so patching it into another env plants a dead S3 reference.
+ */
+export function hasWorkflowBpmnOps(
+  ops: Array<{ op: string; path: string; value?: unknown }>,
+): boolean {
+  return ops.some(op => {
+    if (/\/bpmnAwsS3Identifier$/.test(op.path)) return true;
+    if (op.op !== 'add' || !op.value || typeof op.value !== 'object') return false;
+
+    const pointer = (op.value as Record<string, unknown>).bpmnAwsS3Identifier;
+
+    return pointer !== undefined && pointer !== null;
+  });
+}
+
+/** A sidecar file read from disk, keyed by the SOURCE (layout-file) workflow. */
+export type SidecarFile = {
+  bpmn: string;
+  workflow: { collectionId: string; id: string; name: string };
+};
+
+/** A sidecar that must be uploaded, with the TARGET-env workflow it links to. */
+export type SidecarUpload = SidecarFile & {
+  /**
+   * The workflow to upload to in the target env (resolved id-then-name), or
+   * null when the workflow does not exist there yet — it is being added by this
+   * very apply, so the target must be re-resolved after the domain patch.
+   */
+  target: { collectionId: string; id: string } | null;
+};
+
+/**
+ * Decide which sidecars need uploading, resolving each to its TARGET-env
+ * workflow first (id-then-name, like the diff) so that:
+ * - a same-name workflow with a different id (dev→prod promote) is uploaded
+ *   under the TARGET id, never the source one;
+ * - byte-identical BPMN is skipped (idempotent re-apply), including in that
+ *   name-matched case.
+ */
+export async function planSidecarUploads(
+  manager: LayoutManager,
+  scope: LayoutScope,
+  sidecars: SidecarFile[],
+  remoteWorkflows: Array<Record<string, unknown>>,
+  renderingId: number,
+): Promise<SidecarUpload[]> {
+  const decided = await Promise.all(
+    sidecars.map(async sidecar => {
+      const remote = resolveRemoteWorkflow(remoteWorkflows, sidecar.workflow);
+      if (!remote) return { changed: true, upload: { ...sidecar, target: null } };
+
+      const target = {
+        collectionId: String(remote.collectionId ?? sidecar.workflow.collectionId),
+        id: String(remote.id),
+      };
+      const upload = { ...sidecar, target };
+      const version = remote.bpmnAwsS3Identifier;
+      if (typeof version !== 'string' || !version) return { changed: true, upload };
+
+      try {
+        const stored = await manager.getWorkflowBpmn(
+          scope,
+          target.id,
+          target.collectionId,
+          version,
+          renderingId,
+        );
+
+        return { changed: stored !== sidecar.bpmn, upload };
+      } catch (error) {
+        // Auth/permission failures must surface, not be reframed as "changed".
+        if (error instanceof LayoutApiError && (error.status === 401 || error.status === 403)) {
+          throw error;
+        }
+
+        return { changed: true, upload };
+      }
+    }),
+  );
+
+  return decided.filter(entry => entry.changed).map(entry => entry.upload);
+}
+
+/**
+ * The sidecar filenames a pull should prune: files that LOOK like a managed
+ * sidecar (`<safe-id>.bpmn`) whose id matches no workflow left in the
+ * environment. Everything else is preserved:
+ * - files not matching the managed pattern (a user's own BPMN files);
+ * - sidecars of workflows still present in the env, even when their download
+ *   was skipped (dead S3 ref) — that sidecar may be the last copy of the BPMN,
+ *   and a backup tool must never destroy the backup.
+ */
+export function selectStaleSidecars(entries: string[], keepIds: ReadonlySet<string>): string[] {
+  return entries.filter(entry => {
+    const match = /^(.+)\.bpmn$/.exec(entry);
+
+    return match !== null && isSafeWorkflowId(match[1]) && !keepIds.has(match[1]);
+  });
 }

--- a/src/services/layout/workflow-sidecar.ts
+++ b/src/services/layout/workflow-sidecar.ts
@@ -13,7 +13,9 @@ import type { LayoutScope } from './types';
 
 import path from 'path';
 
+import { remoteResolver } from './diff';
 import { LayoutApiError } from './errors';
+import { NUM_OR_UUID } from './patch-rules';
 
 /**
  * A workflow id becomes a sidecar filename (`workflows/<id>.bpmn`). Because that
@@ -39,23 +41,44 @@ export function sidecarPath(dir: string, id: unknown): string | null {
 }
 
 /**
- * Resolve a file workflow to its target-env counterpart with the same
- * id-then-name matching the diff engine uses (`remoteResolver` in diff.ts), so
- * the sidecar upload targets the very workflow the domain patch addressed. A
+ * Resolve a file workflow to its target-env counterpart by DELEGATING to the
+ * diff engine's own resolver (`remoteResolver` in diff.ts), so the sidecar
+ * upload targets the very workflow the domain patch addressed — including on
+ * duplicate names, where the resolver's Map makes the LAST remote win. A
  * dev→prod promote typically matches by NAME (each env mints its own ids).
  */
 export function resolveRemoteWorkflow(
   remoteWorkflows: Array<Record<string, unknown>>,
   workflow: { id: string; name?: string },
 ): Record<string, unknown> | undefined {
-  return (
-    remoteWorkflows.find(
-      remote => remote.id !== undefined && remote.id !== null && String(remote.id) === workflow.id,
-    ) ??
-    (typeof workflow.name === 'string'
-      ? remoteWorkflows.find(remote => remote.name === workflow.name)
-      : undefined)
-  );
+  return remoteResolver(remoteWorkflows)(workflow);
+}
+
+/** A file workflow that declares BPMN in the layout but has no sidecar on disk. */
+export type MissingSidecar = { id: string; name: string };
+
+/**
+ * Split the missing-sidecar workflows by what actually happens to their BPMN:
+ * - `targetKeepsOwn`: the workflow exists in the target env (id-then-name), so
+ *   the strip of `bpmnAwsS3Identifier` leaves the target's own BPMN untouched;
+ * - `createdWithoutBpmn`: the workflow matches nothing in the target — this
+ *   apply `add`s it, and with its declared pointer stripped and no sidecar to
+ *   upload, it is created with NO BPMN at all. The caller must warn explicitly:
+ *   "keeps its own" would be a lie here.
+ */
+export function partitionMissingSidecars(
+  missing: MissingSidecar[],
+  remoteWorkflows: Array<Record<string, unknown>>,
+): { createdWithoutBpmn: MissingSidecar[]; targetKeepsOwn: MissingSidecar[] } {
+  const targetKeepsOwn: MissingSidecar[] = [];
+  const createdWithoutBpmn: MissingSidecar[] = [];
+
+  missing.forEach(workflow => {
+    if (resolveRemoteWorkflow(remoteWorkflows, workflow)) targetKeepsOwn.push(workflow);
+    else createdWithoutBpmn.push(workflow);
+  });
+
+  return { createdWithoutBpmn, targetKeepsOwn };
 }
 
 /**
@@ -168,18 +191,27 @@ export async function planSidecarUploads(
 }
 
 /**
- * The sidecar filenames a pull should prune: files that LOOK like a managed
- * sidecar (`<safe-id>.bpmn`) whose id matches no workflow left in the
+ * A managed sidecar filename: `<id>.bpmn` where the id has the shape of a REAL
+ * server workflow id (numeric or UUID — the same `NUM_OR_UUID` class the patch
+ * whitelist uses). Managed sidecars are the only files pull ever writes, so
+ * they are the only files it may ever delete.
+ */
+const MANAGED_SIDECAR = new RegExp(`^${NUM_OR_UUID}\\.bpmn$`);
+
+/**
+ * The sidecar filenames a pull should prune: files named after a server
+ * workflow id (`<num-or-uuid>.bpmn`) that matches no workflow left in the
  * environment. Everything else is preserved:
- * - files not matching the managed pattern (a user's own BPMN files);
+ * - files whose basename is not a server-shaped id (a user's own BPMN files,
+ *   e.g. `review.bpmn` — pull never wrote them, so pull never deletes them);
  * - sidecars of workflows still present in the env, even when their download
  *   was skipped (dead S3 ref) — that sidecar may be the last copy of the BPMN,
  *   and a backup tool must never destroy the backup.
  */
 export function selectStaleSidecars(entries: string[], keepIds: ReadonlySet<string>): string[] {
   return entries.filter(entry => {
-    const match = /^(.+)\.bpmn$/.exec(entry);
+    const match = MANAGED_SIDECAR.exec(entry);
 
-    return match !== null && isSafeWorkflowId(match[1]) && !keepIds.has(match[1]);
+    return match !== null && !keepIds.has(match[1]);
   });
 }

--- a/test/commands/layout/apply.test.js
+++ b/test/commands/layout/apply.test.js
@@ -115,6 +115,83 @@ describe('layout:apply', () => {
       }));
   });
 
+  describe('with --with-workflows and a BPMN sidecar to upload', () => {
+    const WORKFLOW_ID = 'a1b2c3d4-e5f6-4a1b-8c2d-1234567890ab';
+    const BPMN = '<bpmn:definitions />';
+    const workflow = {
+      id: WORKFLOW_ID,
+      name: 'My workflow',
+      collectionId: 'aml_alerts',
+      isVisible: true,
+      position: 0,
+      segmentIds: [],
+    };
+
+    it('uploads the sidecar and links the fresh S3 version (source ref stripped)', () =>
+      testCli({
+        env: testEnvWithoutSecret,
+        token: 'any',
+        commandClass: LayoutApplyCommand,
+        commandArgs: [
+          '-p',
+          '2',
+          '-e',
+          'name2',
+          '-t',
+          'Operations',
+          '-f',
+          '--with-workflows',
+          LAYOUT_FILE,
+        ],
+        files: [
+          {
+            name: LAYOUT_FILE,
+            content: JSON.stringify(
+              {
+                forest: { version: 1 },
+                // The source ref is env-local: it must be stripped (0 ops), and the
+                // sidecar upload must own the target's pointer instead.
+                workflows: [{ ...workflow, bpmnAwsS3Identifier: 'source-env-version' }],
+              },
+              null,
+              2,
+            ),
+          },
+          { name: `workflows/${WORKFLOW_ID}.bpmn`, content: BPMN },
+        ],
+        api: [
+          ...scopeApi,
+          () =>
+            nock(SERVER)
+              .get('/api/workflows/project2/name2/Operations')
+              // Same workflow in the target, without stored BPMN yet.
+              .reply(200, [workflow]),
+          () =>
+            nock(SERVER)
+              .get('/api/renderings/project2/name2/Operations')
+              .reply(200, { data: { id: '42', type: 'renderings' } }),
+          () =>
+            nock(SERVER)
+              .post(`/api/workflows/${WORKFLOW_ID}/generate-presigned-request`)
+              .query({ collectionId: 'aml_alerts' })
+              .reply(200, { url: `${SERVER}/s3-upload`, fields: { key: 'k' } }),
+          () => nock(SERVER).post('/s3-upload').reply(204, '', { 'x-amz-version-id': 'v-new' }),
+          () =>
+            nock(SERVER)
+              .patch('/api/workflows', [
+                {
+                  op: 'replace',
+                  path: `/workflows/${WORKFLOW_ID}/bpmnAwsS3Identifier`,
+                  value: 'v-new',
+                },
+              ])
+              .reply(204),
+        ],
+        std: [{ out: 'upload BPMN sidecar' }, { out: 'Applied 0 changes + 1 workflow BPMN' }],
+        assertNoStdError: false,
+      }));
+  });
+
   describe('when the confirmation is declined', () => {
     it('applies nothing and logs that it aborted', () =>
       testCli({

--- a/test/services/layout/workflow-sidecar.unit.test.ts
+++ b/test/services/layout/workflow-sidecar.unit.test.ts
@@ -6,6 +6,7 @@ import { LayoutApiError } from '../../../src/services/layout/errors';
 import {
   hasWorkflowBpmnOps,
   isSafeWorkflowId,
+  partitionMissingSidecars,
   planSidecarUploads,
   resolveRemoteWorkflow,
   selectStaleSidecars,
@@ -156,6 +157,35 @@ describe('resolveRemoteWorkflow', () => {
       resolveRemoteWorkflow([{ id: 'x', name: 'Y' }], { id: 'src-id', name: 'My workflow' }),
     ).toBeUndefined();
   });
+
+  it('resolves duplicate names to the LAST remote, exactly like the domain patch', () => {
+    expect.assertions(1);
+    // Two same-name workflows in the target: the diff engine's Map keeps the
+    // last one, so the sidecar upload must target that same workflow — not the
+    // first — or the BPMN and the metadata patch would land on different ones.
+    const remotes = [
+      { id: 'prod-1', name: 'My workflow' },
+      { id: 'prod-2', name: 'My workflow' },
+    ];
+
+    expect(resolveRemoteWorkflow(remotes, { id: 'src-id', name: 'My workflow' })).toBe(remotes[1]);
+  });
+});
+
+describe('partitionMissingSidecars', () => {
+  it('splits missing sidecars by whether the target env already has the workflow', () => {
+    expect.assertions(1);
+    const remotes = [{ id: 'prod-1', name: 'Existing' }];
+    const missing = [
+      { id: 'src-1', name: 'Existing' }, // name-matched: the target keeps its own BPMN
+      { id: 'src-2', name: 'Brand new' }, // added by this apply: created with NO BPMN
+    ];
+
+    expect(partitionMissingSidecars(missing, remotes)).toStrictEqual({
+      createdWithoutBpmn: [{ id: 'src-2', name: 'Brand new' }],
+      targetKeepsOwn: [{ id: 'src-1', name: 'Existing' }],
+    });
+  });
 });
 
 describe('planSidecarUploads', () => {
@@ -289,20 +319,22 @@ describe('planSidecarUploads', () => {
 });
 
 describe('selectStaleSidecars', () => {
+  const STALE_UUID = '01234567-89ab-cdef-0123-456789abcdef';
+
   it('selects only managed sidecars whose workflow no longer exists in the env', () => {
     expect.assertions(1);
-    const entries = ['kept.bpmn', 'stale.bpmn'];
+    const entries = ['42.bpmn', `${STALE_UUID}.bpmn`];
 
-    expect(selectStaleSidecars(entries, new Set(['kept']))).toStrictEqual(['stale.bpmn']);
+    expect(selectStaleSidecars(entries, new Set(['42']))).toStrictEqual([`${STALE_UUID}.bpmn`]);
   });
 
   it('preserves sidecars of workflows still in the env even when their download was skipped', () => {
     expect.assertions(1);
-    // "dead-ref" was skipped (404 on S3) but the workflow still exists: its
-    // sidecar may be the last copy of the BPMN — never prune it.
-    const keep = new Set(['saved', 'dead-ref']);
+    // The uuid workflow was skipped (404 on S3) but still exists: its sidecar
+    // may be the last copy of the BPMN — never prune it.
+    const keep = new Set(['42', STALE_UUID]);
 
-    expect(selectStaleSidecars(['saved.bpmn', 'dead-ref.bpmn'], keep)).toStrictEqual([]);
+    expect(selectStaleSidecars(['42.bpmn', `${STALE_UUID}.bpmn`], keep)).toStrictEqual([]);
   });
 
   it('never touches files that do not look like a managed sidecar', () => {
@@ -310,5 +342,14 @@ describe('selectStaleSidecars', () => {
     const entries = ['notes.txt', 'draft..v2.bpmn', '.bpmn', 'diagram.bpmn.bak'];
 
     expect(selectStaleSidecars(entries, new Set())).toStrictEqual([]);
+  });
+
+  it("preserves a user's own hand-named BPMN files (not server-id shaped)", () => {
+    expect.assertions(1);
+    // `review.bpmn` is traversal-safe but was never written by pull (sidecars
+    // are named after NUM_OR_UUID server ids) — pull must never delete it.
+    const entries = ['review.bpmn', 'my-draft.bpmn', '7.bpmn'];
+
+    expect(selectStaleSidecars(entries, new Set())).toStrictEqual(['7.bpmn']);
   });
 });

--- a/test/services/layout/workflow-sidecar.unit.test.ts
+++ b/test/services/layout/workflow-sidecar.unit.test.ts
@@ -1,0 +1,314 @@
+import type LayoutManager from '../../../src/services/layout/layout-manager';
+import type { LayoutScope } from '../../../src/services/layout/types';
+import type { SidecarFile } from '../../../src/services/layout/workflow-sidecar';
+
+import { LayoutApiError } from '../../../src/services/layout/errors';
+import {
+  hasWorkflowBpmnOps,
+  isSafeWorkflowId,
+  planSidecarUploads,
+  resolveRemoteWorkflow,
+  selectStaleSidecars,
+  sidecarPath,
+  stripWorkflowBpmnOps,
+} from '../../../src/services/layout/workflow-sidecar';
+
+const scope = {} as LayoutScope;
+
+const managerWith = (getWorkflowBpmn: jest.Mock) =>
+  ({ getWorkflowBpmn } as unknown as LayoutManager);
+
+const sidecar = (over: Partial<SidecarFile['workflow']> = {}): SidecarFile => ({
+  bpmn: '<bpmn:definitions />',
+  workflow: { collectionId: 'aml_alerts', id: 'src-id', name: 'My workflow', ...over },
+});
+
+describe('isSafeWorkflowId', () => {
+  it.each([
+    ['a path-traversal id', '../x'],
+    ['a slash-separated id', 'a/b'],
+    ['a backslash-separated id', 'a\\b'],
+    ['a dot-dot id', 'a..b'],
+    ['an empty string', ''],
+    ['a non-string id', 42],
+    ['an undefined id', undefined],
+  ])('rejects %s', (_label, id) => {
+    expect.assertions(1);
+
+    expect(isSafeWorkflowId(id)).toBe(false);
+  });
+
+  it.each([
+    ['a numeric id', '123'],
+    ['a uuid', 'a1b2c3d4-e5f6-4a1b-8c2d-1234567890ab'],
+  ])('accepts %s', (_label, id) => {
+    expect.assertions(1);
+
+    expect(isSafeWorkflowId(id)).toBe(true);
+  });
+});
+
+describe('sidecarPath', () => {
+  it('builds <dir>/<id>.bpmn for a safe id', () => {
+    expect.assertions(1);
+
+    expect(sidecarPath('/layout/workflows', 'wf1')).toBe('/layout/workflows/wf1.bpmn');
+  });
+
+  it('returns null for a traversal-unsafe id (never touches disk)', () => {
+    expect.assertions(1);
+
+    expect(sidecarPath('/layout/workflows', '../../etc/passwd')).toBeNull();
+  });
+});
+
+describe('stripWorkflowBpmnOps', () => {
+  it('drops replace ops targeting bpmnAwsS3Identifier', () => {
+    expect.assertions(1);
+    const ops = [
+      { op: 'replace', path: '/workflows/wf1/bpmnAwsS3Identifier', value: 'v1' },
+      { op: 'replace', path: '/workflows/wf1/name', value: 'Renamed' },
+    ];
+
+    expect(stripWorkflowBpmnOps(ops).map(op => op.path)).toStrictEqual(['/workflows/wf1/name']);
+  });
+
+  it('strips bpmnAwsS3Identifier from add values, keeping the other fields', () => {
+    expect.assertions(1);
+    const ops = [
+      {
+        op: 'add',
+        path: '/workflows/-',
+        value: { bpmnAwsS3Identifier: 'v1', id: 'wf1', name: 'W' },
+      },
+    ];
+
+    expect(stripWorkflowBpmnOps(ops)[0].value).toStrictEqual({ id: 'wf1', name: 'W' });
+  });
+
+  it('leaves non-workflow ops untouched', () => {
+    expect.assertions(1);
+    const ops = [
+      { op: 'replace', path: '/folders/12/name', value: 'Renamed' },
+      { op: 'remove', path: '/workflows/wf1' },
+    ];
+
+    expect(stripWorkflowBpmnOps(ops)).toStrictEqual(ops);
+  });
+});
+
+describe('hasWorkflowBpmnOps', () => {
+  it('detects a replace of the bpmn pointer', () => {
+    expect.assertions(1);
+
+    expect(
+      hasWorkflowBpmnOps([
+        { op: 'replace', path: '/workflows/wf1/bpmnAwsS3Identifier', value: 'v1' },
+      ]),
+    ).toBe(true);
+  });
+
+  it('detects an added workflow carrying a bpmn pointer', () => {
+    expect.assertions(1);
+
+    expect(
+      hasWorkflowBpmnOps([
+        { op: 'add', path: '/workflows/-', value: { bpmnAwsS3Identifier: 'v1', id: 'wf1' } },
+      ]),
+    ).toBe(true);
+  });
+
+  it('ignores plans that never write a bpmn pointer', () => {
+    expect.assertions(1);
+
+    expect(
+      hasWorkflowBpmnOps([
+        { op: 'replace', path: '/workflows/wf1/name', value: 'W' },
+        { op: 'add', path: '/workflows/-', value: { id: 'wf2', name: 'X' } },
+        { op: 'replace', path: '/folders/12/name', value: 'F' },
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe('resolveRemoteWorkflow', () => {
+  it('matches by id first', () => {
+    expect.assertions(1);
+    const remotes = [
+      { id: 'src-id', name: 'Other' },
+      { id: 'prod-id', name: 'My workflow' },
+    ];
+
+    expect(resolveRemoteWorkflow(remotes, { id: 'src-id', name: 'My workflow' })).toBe(remotes[0]);
+  });
+
+  it('falls back to name when no id matches (dev→prod promote)', () => {
+    expect.assertions(1);
+    const remotes = [{ id: 'prod-id', name: 'My workflow' }];
+
+    expect(resolveRemoteWorkflow(remotes, { id: 'src-id', name: 'My workflow' })).toBe(remotes[0]);
+  });
+
+  it('returns undefined when neither id nor name matches', () => {
+    expect.assertions(1);
+
+    expect(
+      resolveRemoteWorkflow([{ id: 'x', name: 'Y' }], { id: 'src-id', name: 'My workflow' }),
+    ).toBeUndefined();
+  });
+});
+
+describe('planSidecarUploads', () => {
+  it('skips the upload when the stored BPMN already matches, on an id match (idempotent)', async () => {
+    expect.assertions(2);
+    const plan = sidecar();
+    const getWorkflowBpmn = jest.fn().mockResolvedValue(plan.bpmn);
+
+    const uploads = await planSidecarUploads(
+      managerWith(getWorkflowBpmn),
+      scope,
+      [plan],
+      [{ bpmnAwsS3Identifier: 'v1', collectionId: 'aml_alerts', id: 'src-id' }],
+      7,
+    );
+
+    expect(uploads).toStrictEqual([]);
+    expect(getWorkflowBpmn).toHaveBeenCalledWith(scope, 'src-id', 'aml_alerts', 'v1', 7);
+  });
+
+  it('resolves a same-name workflow to the TARGET id and stays idempotent (promote)', async () => {
+    expect.assertions(2);
+    const plan = sidecar();
+    const getWorkflowBpmn = jest.fn().mockResolvedValue(plan.bpmn);
+
+    const uploads = await planSidecarUploads(
+      managerWith(getWorkflowBpmn),
+      scope,
+      [plan],
+      [
+        {
+          bpmnAwsS3Identifier: 'prod-v',
+          collectionId: 'aml_alerts',
+          id: 'prod-id',
+          name: 'My workflow',
+        },
+      ],
+      7,
+    );
+
+    // Idempotence must hold even when the ids differ: the stored bytes are
+    // fetched under the TARGET id and match, so nothing is re-uploaded.
+    expect(uploads).toStrictEqual([]);
+    expect(getWorkflowBpmn).toHaveBeenCalledWith(scope, 'prod-id', 'aml_alerts', 'prod-v', 7);
+  });
+
+  it('uploads a changed sidecar to the name-matched TARGET workflow, never the source id', async () => {
+    expect.assertions(1);
+    const plan = sidecar();
+    const getWorkflowBpmn = jest.fn().mockResolvedValue('<bpmn:definitions>old</bpmn:definitions>');
+
+    const uploads = await planSidecarUploads(
+      managerWith(getWorkflowBpmn),
+      scope,
+      [plan],
+      [
+        {
+          bpmnAwsS3Identifier: 'prod-v',
+          collectionId: 'prod_col',
+          id: 'prod-id',
+          name: 'My workflow',
+        },
+      ],
+      7,
+    );
+
+    expect(uploads[0].target).toStrictEqual({ collectionId: 'prod_col', id: 'prod-id' });
+  });
+
+  it('keeps an unmatched sidecar with a null target (workflow added by this apply)', async () => {
+    expect.assertions(2);
+    const getWorkflowBpmn = jest.fn();
+
+    const uploads = await planSidecarUploads(
+      managerWith(getWorkflowBpmn),
+      scope,
+      [sidecar()],
+      [],
+      7,
+    );
+
+    expect(uploads[0].target).toBeNull();
+    expect(getWorkflowBpmn).not.toHaveBeenCalled();
+  });
+
+  it('uploads without fetching when the target workflow has no stored BPMN yet', async () => {
+    expect.assertions(2);
+    const getWorkflowBpmn = jest.fn();
+
+    const uploads = await planSidecarUploads(
+      managerWith(getWorkflowBpmn),
+      scope,
+      [sidecar()],
+      [{ collectionId: 'aml_alerts', id: 'src-id' }],
+      7,
+    );
+
+    expect(uploads[0].target).toStrictEqual({ collectionId: 'aml_alerts', id: 'src-id' });
+    expect(getWorkflowBpmn).not.toHaveBeenCalled();
+  });
+
+  it('re-uploads when the stored BPMN cannot be read (rather than risk a stale skip)', async () => {
+    expect.assertions(1);
+    const getWorkflowBpmn = jest.fn().mockRejectedValue(new LayoutApiError(404, 'gone'));
+
+    const uploads = await planSidecarUploads(
+      managerWith(getWorkflowBpmn),
+      scope,
+      [sidecar()],
+      [{ bpmnAwsS3Identifier: 'v1', collectionId: 'aml_alerts', id: 'src-id' }],
+      7,
+    );
+
+    expect(uploads).toHaveLength(1);
+  });
+
+  it('surfaces auth failures instead of reframing them as "changed"', async () => {
+    expect.assertions(1);
+    const getWorkflowBpmn = jest.fn().mockRejectedValue(new LayoutApiError(403, 'forbidden'));
+
+    await expect(
+      planSidecarUploads(
+        managerWith(getWorkflowBpmn),
+        scope,
+        [sidecar()],
+        [{ bpmnAwsS3Identifier: 'v1', collectionId: 'aml_alerts', id: 'src-id' }],
+        7,
+      ),
+    ).rejects.toThrow('403');
+  });
+});
+
+describe('selectStaleSidecars', () => {
+  it('selects only managed sidecars whose workflow no longer exists in the env', () => {
+    expect.assertions(1);
+    const entries = ['kept.bpmn', 'stale.bpmn'];
+
+    expect(selectStaleSidecars(entries, new Set(['kept']))).toStrictEqual(['stale.bpmn']);
+  });
+
+  it('preserves sidecars of workflows still in the env even when their download was skipped', () => {
+    expect.assertions(1);
+    // "dead-ref" was skipped (404 on S3) but the workflow still exists: its
+    // sidecar may be the last copy of the BPMN — never prune it.
+    const keep = new Set(['saved', 'dead-ref']);
+
+    expect(selectStaleSidecars(['saved.bpmn', 'dead-ref.bpmn'], keep)).toStrictEqual([]);
+  });
+
+  it('never touches files that do not look like a managed sidecar', () => {
+    expect.assertions(1);
+    const entries = ['notes.txt', 'draft..v2.bpmn', '.bpmn', 'diagram.bpmn.bak'];
+
+    expect(selectStaleSidecars(entries, new Set())).toStrictEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Opt-in `--with-workflows` on both sides of the layout-as-code loop:

- `layout pull --with-workflows` → downloads each workflow's stored BPMN into sidecar files `workflows/<id>.bpmn` next to `forest-layout.json`.
- `layout apply --with-workflows` → re-uploads those sidecars to the **target** env and relinks `bpmnAwsS3Identifier`.

This is the "pull + apply back" round-trip: **back up** a project's workflows, or **promote** them dev → prod, with faithful BPMN transport.

## Behaviour

- **Precedence**: a workflow authored with `steps` in the file is compiled and wins; sidecars only cover file workflows *without* `steps` (including UI-authored ones — the CLI has no `steps` for those, so verbatim transport is the only faithful option).
- **Dead refs are skipped, not fatal**: a `bpmnAwsS3Identifier` that no longer resolves to an S3 version (e.g. baked by a demo seed but never uploaded to this bucket → `NoSuchVersion`) is skipped with a warning instead of aborting the whole pull.

## Tested

Live on a demo project: `pull → apply back → pull` yields fresh S3 version ids **and** byte-identical BPMN (faithful round-trip). Dead refs from the bundled demo were skipped cleanly (4 live workflows transported, 9 dead refs warned).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--with-workflows` flag to round-trip workflow BPMN sidecars in `layout pull` and `layout apply`
> - `layout pull --with-workflows` downloads each workflow's BPMN from S3 into `workflows/<id>.bpmn` sidecar files alongside the layout file, pruning stale sidecars for workflows no longer in the environment.
> - `layout apply --with-workflows` reads those sidecar files, uploads BPMN to the target environment, and strips non-portable `bpmnAwsS3Identifier` JSON patch ops so S3 pointers from the source env are never written directly.
> - Without `--with-workflows`, `layout apply` warns when it detects that applying would plant cross-environment S3 references.
> - New utilities in [`workflow-sidecar.ts`](https://github.com/ForestAdmin/toolbelt/pull/801/files#diff-cb2e3ee3186a5c71888642a9b83cd5e7332e80b5c6394436edf1a7430e9eebdd) handle id safety (path traversal guards), upload planning (skip identical bytes, resolve by id then name for promote scenarios), and stale sidecar selection.
> - Risk: sidecar uploads for workflows added in the same apply run require a re-fetch to resolve new workflow ids; if resolution fails the upload is skipped with a warning.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be38184.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

Part of [PRD-715 — Workflows in CLI](https://linear.app/forestadmin/issue/PRD-715/workflows-in-cli).