### PR TITLE
feat(skills): add `forest skills:init` — install Forest skills into a repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "spinnies": "0.5.1",
     "stdout-stderr": "0.1.13",
     "superagent": "^10.3.0",
+    "tar": "^7.5.9",
     "tedious": "18.6.1",
     "uuid": "^11.1.1",
     "validate-npm-package-name": "3.0.0"

--- a/src/commands/skills/init.ts
+++ b/src/commands/skills/init.ts
@@ -1,0 +1,68 @@
+import { Flags } from '@oclif/core';
+
+import AbstractCommand from '../../abstract-command';
+import {
+  AGENT_SKILL_DIRS,
+  FOREST_BLOCK,
+  contextFileFor,
+  fetchMarketplace,
+  installDocsMcp,
+  installSkills,
+  mergeBlock,
+  readManifest,
+  removeStaleSkillFiles,
+  skillDirEntries,
+  writeManifest,
+} from '../../services/skills/skills-manager';
+
+export default class SkillsInitCommand extends AbstractCommand {
+  static override description =
+    'Install the Forest skills into this repo so your coding agent (Claude Code / Codex) knows Forest — project-scoped, no marketplace add.';
+
+  static override flags = {
+    ref: Flags.string({ description: 'Marketplace version (git ref).', default: 'main' }),
+    force: Flags.boolean({ description: 'Overwrite existing skill files.', default: false }),
+  };
+
+  // Always set up both agents — the files for the one you don't use are inert, and this keeps
+  // the repo ready whichever coding agent a teammate opens it with.
+  private static readonly agents = ['claude', 'codex'];
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(SkillsInitCommand);
+    const { agents } = SkillsInitCommand;
+    const previous = readManifest(); // to prune Forest files that left the bundle on a re-install
+
+    this.logger.info(
+      `Fetching Forest skills from ${this.chalk.bold('ForestAdmin/ai-marketplace')}@${flags.ref}…`,
+    );
+    const { root: srcRoot, cleanup } = await fetchMarketplace(flags.ref);
+    try {
+      const skillFiles = agents.flatMap(agent => {
+        const written = installSkills(srcRoot, agent, flags.force);
+        const contextFile = contextFileFor(agent);
+        mergeBlock(contextFile, FOREST_BLOCK);
+        this.logger.success(`Forest skills installed for ${agent} → ${AGENT_SKILL_DIRS[agent]}`, {
+          lineColor: 'green',
+        });
+
+        return [...written, contextFile];
+      });
+
+      // Prune only Forest-managed skill files that were installed before and are no longer in the
+      // bundle (manifest-scoped) — user-added files in the skill dirs are left untouched.
+      if (previous) removeStaleSkillFiles(skillDirEntries(previous.files), skillFiles);
+
+      // Wire the Forest docs MCP (fetched from the marketplace's forest-docs plugin).
+      const files = [...skillFiles, installDocsMcp(srcRoot)];
+
+      writeManifest({ ref: flags.ref, installedAt: new Date().toISOString(), agents, files });
+
+      this.logger.info(
+        'Open this repo in Claude Code or Codex — it now knows Forest. Refresh later with `forest skills:update`.',
+      );
+    } finally {
+      cleanup();
+    }
+  }
+}

--- a/src/commands/skills/init.ts
+++ b/src/commands/skills/init.ts
@@ -39,7 +39,7 @@ export default class SkillsInitCommand extends AbstractCommand {
     const { root: srcRoot, cleanup } = await fetchMarketplace(flags.ref);
     try {
       const skillFiles = agents.flatMap(agent => {
-        const written = installSkills(srcRoot, agent, flags.force);
+        const written = installSkills(srcRoot, agent, flags.force, previous?.files ?? null);
         const contextFile = contextFileFor(agent);
         mergeBlock(contextFile, FOREST_BLOCK);
         this.logger.success(`Forest skills installed for ${agent} → ${AGENT_SKILL_DIRS[agent]}`, {

--- a/src/commands/skills/init.ts
+++ b/src/commands/skills/init.ts
@@ -12,6 +12,8 @@ import {
   readManifest,
   removeStaleSkillFiles,
   skillDirEntries,
+  validateLocalMcp,
+  validateMarketplaceBundle,
   writeManifest,
 } from '../../services/skills/skills-manager';
 
@@ -33,11 +35,19 @@ export default class SkillsInitCommand extends AbstractCommand {
     const { agents } = SkillsInitCommand;
     const previous = readManifest(); // to prune Forest files that left the bundle on a re-install
 
+    // Fail fast BEFORE any disk mutation: a broken local .mcp.json would otherwise only surface
+    // in installDocsMcp, at the very end, leaving a half-applied install behind.
+    validateLocalMcp();
+
     this.logger.info(
       `Fetching Forest skills from ${this.chalk.bold('ForestAdmin/ai-marketplace')}@${flags.ref}…`,
     );
     const { root: srcRoot, cleanup } = await fetchMarketplace(flags.ref);
     try {
+      // Still before any write: the bundle must carry the docs MCP config, or the last step
+      // would fail with a raw ENOENT after skills/context files were already applied.
+      validateMarketplaceBundle(srcRoot, flags.ref);
+
       const skillFiles = agents.flatMap(agent => {
         const written = installSkills(srcRoot, agent, flags.force, previous?.files ?? null);
         const contextFile = contextFileFor(agent);

--- a/src/services/skills/skills-manager.ts
+++ b/src/services/skills/skills-manager.ts
@@ -1,0 +1,297 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import superagent from 'superagent';
+import * as tar from 'tar';
+
+/**
+ * Shared logic for `skills:init` / `skills:update`: fetch the public
+ * ForestAdmin/ai-marketplace repo, copy the Forest skill bundles into a project
+ * (project-scoped, for Claude Code and Codex), merge a Forest block into
+ * CLAUDE.md/AGENTS.md, wire the Forest docs MCP, and track it in a manifest.
+ *
+ * The marketplace repo is PUBLIC → no auth needed for the fetch.
+ */
+
+export const MARKETPLACE_REPO = 'ForestAdmin/ai-marketplace';
+
+// Which dev-facing skills we distribute into a client's repo. Curated on purpose
+// (explicit control over what ships; internal/test-only skills like deploy-heroku
+// stay out). Source path in the repo = `<plugin>/skills/<name>`.
+export const SKILL_SOURCES: { plugin: string; skills: string[] }[] = [
+  {
+    plugin: 'forest',
+    skills: ['boot-standalone-agent', 'layout', 'management', 'onboard', 'workflows'],
+  },
+  { plugin: 'forest-code', skills: ['forest-code', 'forest-legacy'] },
+];
+
+// Per-agent project-scoped skill dir (both are auto-discovered; no marketplace needed).
+export const AGENT_SKILL_DIRS: Record<string, string> = {
+  claude: '.claude/skills',
+  codex: '.agents/skills',
+};
+
+export const MANIFEST_PATH = '.forest/skills-manifest.json';
+
+const BLOCK_BEGIN = '<!-- forest:begin -->';
+const BLOCK_END = '<!-- forest:end -->';
+
+// The Forest block merged into CLAUDE.md / AGENTS.md (project context for the agent).
+export const FOREST_BLOCK = [
+  'This project uses **Forest Admin**. Skills to build/customize it are installed in',
+  '`.claude/skills/` (Claude Code) and `.agents/skills/` (Codex) — e.g. `/forest-code`, `/forest:layout`.',
+  'Forest documentation is searchable via the `forest-docs` MCP server.',
+].join('\n');
+
+export type Manifest = { ref: string; installedAt: string; agents: string[]; files: string[] };
+
+export function contextFileFor(agent: string): string {
+  return agent === 'claude' ? 'CLAUDE.md' : 'AGENTS.md';
+}
+
+/**
+ * Download + extract the marketplace tarball at `ref`. Returns the extracted root dir and a
+ * `cleanup` the caller must run (in a finally) to delete the temp dir — otherwise every
+ * init/update leaks a full copy of the marketplace under the OS temp dir.
+ */
+export async function fetchMarketplace(
+  ref = 'main',
+): Promise<{ root: string; cleanup: () => void }> {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'forest-skills-'));
+  const cleanup = () => fs.rmSync(tmp, { recursive: true, force: true });
+  try {
+    // Generic archive path (not `refs/heads/…`) so `ref` accepts branches, tags, and SHAs alike.
+    const url = `https://codeload.github.com/${MARKETPLACE_REPO}/tar.gz/${ref}`;
+    let res;
+    try {
+      res = await superagent
+        .get(url)
+        .timeout({ response: 15000, deadline: 30000 }) // don't hang forever on a stalled connection
+        .responseType('blob');
+    } catch (err) {
+      if (err.status === 404) {
+        throw new Error(
+          `Forest marketplace ref "${ref}" not found in ${MARKETPLACE_REPO}. Check the --ref value.`,
+        );
+      }
+      if (err.timeout)
+        throw new Error(
+          'Timed out reaching the Forest marketplace — check your connection and retry.',
+        );
+      throw new Error(
+        `Could not fetch the Forest marketplace (${MARKETPLACE_REPO}): ${err.message}`,
+      );
+    }
+    const tgz = path.join(tmp, 'marketplace.tar.gz');
+    fs.writeFileSync(tgz, res.body as Buffer);
+    await tar.x({ file: tgz, cwd: tmp });
+    const root = fs.readdirSync(tmp).find(dir => dir.startsWith('ai-marketplace-'));
+    if (!root) throw new Error('Could not extract the marketplace tarball.');
+
+    return { root: path.join(tmp, root), cleanup };
+  } catch (error) {
+    cleanup(); // don't leak the temp dir when the fetch/extract fails
+    throw error;
+  }
+}
+
+/** True if `p` exists and is a symlink (never throws). */
+function isSymlink(p: string): boolean {
+  try {
+    return fs.lstatSync(p).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+/** Remove a symlink sitting at `p` so a following write/mkdir creates a real file/dir inside the
+ *  project rather than following the link to overwrite something outside it. No-op otherwise. */
+function replaceSymlink(p: string): void {
+  if (isSymlink(p)) fs.rmSync(p);
+}
+
+/** Recursively list the files under `dir` (dest paths), mirroring copyDir's return without copying. */
+function listFiles(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const p = path.join(dir, entry.name);
+
+    return entry.isDirectory() ? listFiles(p) : [p];
+  });
+}
+
+/** Recursively copy a directory, returning the list of files written. Never follows a symlink at
+ *  the destination — it's replaced — so a planted link can't redirect a write outside the project. */
+export function copyDir(src: string, dest: string): string[] {
+  // Refuse a source dir that is itself a symlink — a crafted marketplace could point a curated
+  // skill path at an absolute host dir and have readdirSync follow it, copying local files in.
+  if (isSymlink(src)) return [];
+  if (isSymlink(dest)) fs.rmSync(dest);
+  fs.mkdirSync(dest, { recursive: true });
+
+  return fs.readdirSync(src, { withFileTypes: true }).flatMap(entry => {
+    const from = path.join(src, entry.name);
+    const to = path.join(dest, entry.name);
+    // Never follow a symlink in the source bundle (a crafted marketplace could point one at an
+    // arbitrary file on the user's machine and have us copy its contents in).
+    if (entry.isSymbolicLink()) return [];
+    if (entry.isDirectory()) return copyDir(from, to);
+    if (isSymlink(to)) fs.rmSync(to);
+    fs.copyFileSync(from, to);
+
+    return [to];
+  });
+}
+
+/** Copy the skill bundles from the extracted repo into one agent's skills dir. */
+export function installSkills(srcRoot: string, agent: string, force: boolean): string[] {
+  const targetBase = AGENT_SKILL_DIRS[agent];
+
+  return SKILL_SOURCES.flatMap(({ plugin, skills }) =>
+    skills.flatMap(skill => {
+      const src = path.join(srcRoot, plugin, 'skills', skill);
+      const dest = path.join(targetBase, skill);
+      // Fail loud on a missing curated skill rather than reporting a misleading partial success.
+      if (!fs.existsSync(src)) {
+        throw new Error(
+          `Skill "${skill}" is missing from the marketplace (expected ${plugin}/skills/${skill}). ` +
+            'The curated SKILL_SOURCES list is out of sync with this marketplace ref.',
+        );
+      }
+      if (fs.existsSync(dest)) {
+        if (!fs.lstatSync(dest).isDirectory()) {
+          // A stray non-directory where a skill dir belongs → replace it wholesale.
+          fs.rmSync(dest, { recursive: true, force: true });
+        } else if (!force) {
+          // Installed and no --force: keep as-is, but report the *managed* files (derived from the
+          // source bundle, mapped to dest) so the manifest stays complete — NOT the actual dir
+          // contents, which may include user-added files we must never record as managed (they'd
+          // then be pruned on a later refresh).
+          return listFiles(src).map(f => path.join(dest, path.relative(src, f)));
+        }
+        // With --force on an existing dir we fall through and overlay the incoming bundle on top.
+        // We deliberately do NOT delete the dir, so user-added files survive; pruning of
+        // Forest-owned files that left the bundle is the command's job (removeStaleSkillFiles,
+        // manifest-scoped) — never a blind rm here.
+      }
+
+      return copyDir(src, dest);
+    }),
+  );
+}
+
+/** From a manifest file list, the entries that live under the skill dirs (normalized for Windows,
+ *  where manifest paths use backslashes). These are the candidates for stale-pruning on a refresh. */
+export function skillDirEntries(files: string[]): string[] {
+  const bases = Object.values(AGENT_SKILL_DIRS);
+
+  return files.filter(file => bases.some(dir => file.replace(/\\/g, '/').startsWith(dir)));
+}
+
+/** Guard a deletion candidate: it must resolve *inside* the skill dirs (blocks `..` traversal and
+ *  absolute paths) and its real location must stay there too (blocks a symlinked ancestor from
+ *  redirecting the delete outside the project). A crafted manifest entry must never widen rmSync. */
+function isWithinSkillDirs(file: string): boolean {
+  const skillBases = Object.values(AGENT_SKILL_DIRS).map(dir => path.resolve(dir));
+  const resolved = path.resolve(file);
+  // Textual containment: reject `..` traversal and absolute paths outside the skill dirs.
+  if (!skillBases.some(base => resolved.startsWith(base + path.sep))) return false;
+  // Real containment against the PROJECT root (not the skill dir's symlink target): a symlinked
+  // skill dir pointing outside the project must be rejected, never whitelisted via its target.
+  try {
+    const projectRoot = fs.realpathSync(process.cwd());
+    const realParent = fs.realpathSync(path.dirname(file));
+
+    return realParent === projectRoot || realParent.startsWith(projectRoot + path.sep);
+  } catch {
+    return false; // path doesn't resolve (already gone) → nothing to delete
+  }
+}
+
+/**
+ * Delete managed skill files that existed before but are no longer produced (removed upstream).
+ * Set-diff of previous vs current, deleting only paths that still exist *and* are safely contained
+ * within the skill dirs. Returns what it removed.
+ */
+export function removeStaleSkillFiles(previousFiles: string[], currentFiles: string[]): string[] {
+  // Compare on forward-slash-normalized paths so a manifest written on one OS (e.g. Unix `/`)
+  // matches files produced on another (Windows `\`) — otherwise every entry looks stale and a
+  // cross-platform refresh would wipe freshly-installed bundles. Delete via the original path.
+  const normalize = (p: string) => p.replace(/\\/g, '/');
+  const kept = new Set(currentFiles.map(normalize));
+  const stale = previousFiles.filter(
+    file => !kept.has(normalize(file)) && fs.existsSync(file) && isWithinSkillDirs(file),
+  );
+  stale.forEach(file => fs.rmSync(file));
+
+  return stale;
+}
+
+/** Merge a delimited Forest block into a context file (CLAUDE.md / AGENTS.md) without
+ *  clobbering the user's own content. Creates the file if absent. */
+export function mergeBlock(file: string, content: string): void {
+  replaceSymlink(file); // never write through a symlinked context file
+  const block = `${BLOCK_BEGIN}\n${content}\n${BLOCK_END}`;
+  if (!fs.existsSync(file)) {
+    fs.writeFileSync(file, `${block}\n`);
+
+    return;
+  }
+  const current = fs.readFileSync(file, 'utf8');
+  const re = new RegExp(`${BLOCK_BEGIN}[\\s\\S]*?${BLOCK_END}`);
+  const next = re.test(current) ? current.replace(re, block) : `${current.trimEnd()}\n\n${block}\n`;
+  fs.writeFileSync(file, next);
+}
+
+/**
+ * Wire the Forest docs MCP (Mintlify, https://docs.forest.app/mcp — static, read-only, NO secret)
+ * by reading the source of truth `forest-docs/.mcp.json` from the fetched marketplace and merging
+ * its `mcpServers` into the project's `.mcp.json` (preserving any existing servers the user has).
+ */
+export function installDocsMcp(srcRoot: string): string {
+  const incoming = JSON.parse(
+    fs.readFileSync(path.join(srcRoot, 'forest-docs', '.mcp.json'), 'utf8'),
+  );
+  const target = '.mcp.json';
+  replaceSymlink(target); // never read/write through a symlinked .mcp.json
+  let current: { mcpServers?: Record<string, unknown> } = { mcpServers: {} };
+  if (fs.existsSync(target)) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(target, 'utf8'));
+      // Valid JSON that isn't a plain object (null, array, scalar) → treat as empty, don't crash.
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        current = parsed as { mcpServers?: Record<string, unknown> };
+      }
+    } catch {
+      // Don't clobber a user-authored (but unparseable) config with an empty one.
+      throw new Error(
+        `Cannot parse existing ${target}; aborting so it isn't overwritten. Fix or remove it, then re-run.`,
+      );
+    }
+  }
+  current.mcpServers = { ...(current.mcpServers || {}), ...(incoming.mcpServers || {}) };
+  fs.writeFileSync(target, `${JSON.stringify(current, null, 2)}\n`);
+
+  return target;
+}
+
+export function readManifest(): Manifest | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+    // Validate the shape: a valid-but-malformed manifest ({}, [], null…) must read as "absent",
+    // otherwise callers dereference `previous.files` and crash.
+    if (parsed && typeof parsed === 'object' && Array.isArray(parsed.files)) return parsed;
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeManifest(manifest: Manifest): void {
+  const dir = path.dirname(MANIFEST_PATH);
+  replaceSymlink(dir); // don't let a symlinked .forest redirect the write outside the project
+  fs.mkdirSync(dir, { recursive: true });
+  replaceSymlink(MANIFEST_PATH);
+  fs.writeFileSync(MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`);
+}

--- a/src/services/skills/skills-manager.ts
+++ b/src/services/skills/skills-manager.ts
@@ -96,6 +96,10 @@ export async function fetchMarketplace(
   }
 }
 
+/** Forward-slash-normalize a path so entries written on one OS (Windows `\`) compare equal to
+ *  paths produced on another (Unix `/`). */
+const normalizePath = (p: string) => p.replace(/\\/g, '/');
+
 /** True if `p` exists and is a symlink (never throws). */
 function isSymlink(p: string): boolean {
   try {
@@ -143,9 +147,18 @@ export function copyDir(src: string, dest: string): string[] {
   });
 }
 
-/** Copy the skill bundles from the extracted repo into one agent's skills dir. */
-export function installSkills(srcRoot: string, agent: string, force: boolean): string[] {
+/** Copy the skill bundles from the extracted repo into one agent's skills dir.
+ *  `previousFiles` is the file list from the previous manifest (`null` on a first run): on the
+ *  no-force skip path it bounds what we may claim as managed — we never claim a file we did not
+ *  write ourselves on some run, or a later prune would delete user-authored content. */
+export function installSkills(
+  srcRoot: string,
+  agent: string,
+  force: boolean,
+  previousFiles: string[] | null,
+): string[] {
   const targetBase = AGENT_SKILL_DIRS[agent];
+  const previouslyManaged = new Set((previousFiles ?? []).map(normalizePath));
 
   return SKILL_SOURCES.flatMap(({ plugin, skills }) =>
     skills.flatMap(skill => {
@@ -163,11 +176,14 @@ export function installSkills(srcRoot: string, agent: string, force: boolean): s
           // A stray non-directory where a skill dir belongs → replace it wholesale.
           fs.rmSync(dest, { recursive: true, force: true });
         } else if (!force) {
-          // Installed and no --force: keep as-is, but report the *managed* files (derived from the
-          // source bundle, mapped to dest) so the manifest stays complete — NOT the actual dir
-          // contents, which may include user-added files we must never record as managed (they'd
-          // then be pruned on a later refresh).
-          return listFiles(src).map(f => path.join(dest, path.relative(src, f)));
+          // Installed and no --force: nothing is written here, so only carry over files that are
+          // BOTH in the incoming bundle (derived from source, mapped to dest — never the actual
+          // dir contents, which may include user-added files) AND in the previous manifest (proof
+          // a past run wrote them). A dir that pre-existed the first run was authored by the user:
+          // claiming its files would mark them managed and a later refresh would prune them.
+          return listFiles(src)
+            .map(f => path.join(dest, path.relative(src, f)))
+            .filter(f => previouslyManaged.has(normalizePath(f)));
         }
         // With --force on an existing dir we fall through and overlay the incoming bundle on top.
         // We deliberately do NOT delete the dir, so user-added files survive; pruning of
@@ -217,10 +233,9 @@ export function removeStaleSkillFiles(previousFiles: string[], currentFiles: str
   // Compare on forward-slash-normalized paths so a manifest written on one OS (e.g. Unix `/`)
   // matches files produced on another (Windows `\`) — otherwise every entry looks stale and a
   // cross-platform refresh would wipe freshly-installed bundles. Delete via the original path.
-  const normalize = (p: string) => p.replace(/\\/g, '/');
-  const kept = new Set(currentFiles.map(normalize));
+  const kept = new Set(currentFiles.map(normalizePath));
   const stale = previousFiles.filter(
-    file => !kept.has(normalize(file)) && fs.existsSync(file) && isWithinSkillDirs(file),
+    file => !kept.has(normalizePath(file)) && fs.existsSync(file) && isWithinSkillDirs(file),
   );
   stale.forEach(file => fs.rmSync(file));
 

--- a/src/services/skills/skills-manager.ts
+++ b/src/services/skills/skills-manager.ts
@@ -259,6 +259,41 @@ export function mergeBlock(file: string, content: string): void {
 }
 
 /**
+ * Fail-fast preflight for the local `.mcp.json`: run it BEFORE any disk mutation. `installDocsMcp`
+ * throws on an unparseable local config (on purpose, to protect user content), but it runs last —
+ * without this check the failure would surface after skills were installed and the context files
+ * merged, leaving a half-applied state with no manifest rewrite.
+ */
+export function validateLocalMcp(): void {
+  const target = '.mcp.json';
+  // A symlinked .mcp.json is replaced (never read) at install time, so its target's content is
+  // irrelevant here. Same for an absent file.
+  if (isSymlink(target) || !fs.existsSync(target)) return;
+  try {
+    JSON.parse(fs.readFileSync(target, 'utf8'));
+  } catch {
+    throw new Error(
+      `Cannot parse existing ${target}; aborting before any changes so it isn't overwritten. ` +
+        'Fix or remove it, then re-run.',
+    );
+  }
+}
+
+/**
+ * Fail-fast preflight for the fetched marketplace bundle: run it after the fetch but BEFORE any
+ * write. The docs MCP config is read last by `installDocsMcp`; a bundle missing it would otherwise
+ * die on a raw ENOENT after everything else was already applied.
+ */
+export function validateMarketplaceBundle(srcRoot: string, ref: string): void {
+  if (!fs.existsSync(path.join(srcRoot, 'forest-docs', '.mcp.json'))) {
+    throw new Error(
+      `The Forest marketplace at ref "${ref}" has no forest-docs/.mcp.json (docs MCP config). ` +
+        'Nothing was changed. Check the --ref value or try again with the default ref.',
+    );
+  }
+}
+
+/**
  * Wire the Forest docs MCP (Mintlify, https://docs.forest.app/mcp — static, read-only, NO secret)
  * by reading the source of truth `forest-docs/.mcp.json` from the fetched marketplace and merging
  * its `mcpServers` into the project's `.mcp.json` (preserving any existing servers the user has).

--- a/test/services/skills/skills-manager.unit.test.ts
+++ b/test/services/skills/skills-manager.unit.test.ts
@@ -12,6 +12,8 @@ import {
   readManifest,
   removeStaleSkillFiles,
   skillDirEntries,
+  validateLocalMcp,
+  validateMarketplaceBundle,
   writeManifest,
 } from '../../../src/services/skills/skills-manager';
 
@@ -428,6 +430,62 @@ describe('skills-manager', () => {
         installDocsMcp(root);
         const mcp = JSON.parse(fs.readFileSync('.mcp.json', 'utf8'));
         expect(mcp.mcpServers['forest-docs']).toBeDefined();
+      });
+    });
+  });
+
+  describe('validateLocalMcp', () => {
+    it('passes when no .mcp.json exists', () => {
+      expect.assertions(1);
+      withTempDir(() => {
+        expect(() => validateLocalMcp()).not.toThrow();
+      });
+    });
+
+    it('passes on a parsable .mcp.json', () => {
+      expect.assertions(1);
+      withTempDir(() => {
+        fs.writeFileSync('.mcp.json', JSON.stringify({ mcpServers: {} }));
+        expect(() => validateLocalMcp()).not.toThrow();
+      });
+    });
+
+    it('throws a clear error on an unparsable .mcp.json (fail fast, before any install)', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.writeFileSync('.mcp.json', '{ not valid json');
+        expect(() => validateLocalMcp()).toThrow(/Cannot parse existing \.mcp\.json/);
+        expect(fs.readFileSync('.mcp.json', 'utf8')).toBe('{ not valid json'); // left untouched
+      });
+    });
+
+    it('passes on a symlinked .mcp.json (replaced, never read, at install time)', () => {
+      expect.assertions(1);
+      withTempDir(() => {
+        fs.writeFileSync('outside.json', '{ not valid json');
+        fs.symlinkSync(path.resolve('outside.json'), '.mcp.json');
+        expect(() => validateLocalMcp()).not.toThrow();
+      });
+    });
+  });
+
+  describe('validateMarketplaceBundle', () => {
+    it('passes when the bundle carries forest-docs/.mcp.json', () => {
+      expect.assertions(1);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        expect(() => validateMarketplaceBundle(root, 'main')).not.toThrow();
+      });
+    });
+
+    it('throws a clear error naming the ref when forest-docs/.mcp.json is missing', () => {
+      expect.assertions(1);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        fs.rmSync(path.join(root, 'forest-docs'), { recursive: true, force: true });
+        expect(() => validateMarketplaceBundle(root, 'v1.2.3')).toThrow(
+          /ref "v1\.2\.3" has no forest-docs\/\.mcp\.json/,
+        );
       });
     });
   });

--- a/test/services/skills/skills-manager.unit.test.ts
+++ b/test/services/skills/skills-manager.unit.test.ts
@@ -1,0 +1,434 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  SKILL_SOURCES,
+  contextFileFor,
+  copyDir,
+  installDocsMcp,
+  installSkills,
+  mergeBlock,
+  readManifest,
+  removeStaleSkillFiles,
+  skillDirEntries,
+  writeManifest,
+} from '../../../src/services/skills/skills-manager';
+
+// Run `fn` inside a throwaway temp dir (cwd), restoring + cleaning up afterwards.
+// A helper (not a jest hook) — this repo forbids beforeEach/afterEach (jest/no-hooks).
+function withTempDir(run: (dir: string) => void): void {
+  const previousCwd = process.cwd();
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'skills-test-'));
+  process.chdir(tmp);
+  try {
+    run(tmp);
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+// Build a fake extracted marketplace holding every curated skill (derived from SKILL_SOURCES so
+// the fixture stays in sync with the real list) + forest-docs/.mcp.json.
+function fakeMarketplace(root: string): string {
+  const write = (p: string, c: string) => {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, c);
+  };
+  SKILL_SOURCES.forEach(({ plugin, skills }) =>
+    skills.forEach(skill =>
+      write(path.join(root, plugin, 'skills', skill, 'SKILL.md'), `# ${skill} skill`),
+    ),
+  );
+  write(path.join(root, 'forest', 'skills', 'layout', 'references', 'a.md'), 'ref a');
+  write(
+    path.join(root, 'forest-docs', '.mcp.json'),
+    JSON.stringify({
+      mcpServers: { 'forest-docs': { type: 'http', url: 'https://docs.forest.app/mcp' } },
+    }),
+  );
+
+  return root;
+}
+
+describe('skills-manager', () => {
+  describe('contextFileFor', () => {
+    it('maps claude to CLAUDE.md', () => {
+      expect.assertions(1);
+      expect(contextFileFor('claude')).toBe('CLAUDE.md');
+    });
+
+    it('maps any other agent to AGENTS.md', () => {
+      expect.assertions(1);
+      expect(contextFileFor('codex')).toBe('AGENTS.md');
+    });
+  });
+
+  describe('mergeBlock', () => {
+    it('creates the file with a delimited Forest block when absent', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        mergeBlock('CLAUDE.md', 'hello forest');
+        const content = fs.readFileSync('CLAUDE.md', 'utf8');
+        expect(content).toContain('<!-- forest:begin -->');
+        expect(content).toContain('hello forest');
+      });
+    });
+
+    it('preserves pre-existing user content and appends the block', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.writeFileSync('CLAUDE.md', '# My own notes\n');
+        mergeBlock('CLAUDE.md', 'forest block');
+        const content = fs.readFileSync('CLAUDE.md', 'utf8');
+        expect(content).toContain('# My own notes');
+        expect(content).toContain('forest block');
+      });
+    });
+
+    it('replaces only the Forest block on re-merge, keeping user content', () => {
+      expect.assertions(3);
+      withTempDir(() => {
+        fs.writeFileSync('CLAUDE.md', '# Notes\n');
+        mergeBlock('CLAUDE.md', 'version one');
+        mergeBlock('CLAUDE.md', 'version two');
+        const content = fs.readFileSync('CLAUDE.md', 'utf8');
+        expect(content).toContain('# Notes');
+        expect(content).toContain('version two');
+        expect(content).not.toContain('version one');
+      });
+    });
+  });
+
+  describe('installSkills', () => {
+    it('copies the curated skill bundles into the agent dir', () => {
+      expect.assertions(3);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        const written = installSkills(root, 'claude', false);
+        expect(fs.existsSync('.claude/skills/layout/SKILL.md')).toBe(true);
+        expect(fs.existsSync('.claude/skills/forest-code/SKILL.md')).toBe(true);
+        expect(written).toContain(path.join('.claude/skills', 'layout', 'references', 'a.md'));
+      });
+    });
+
+    it('throws when a curated skill is absent from the marketplace (no misleading partial install)', () => {
+      expect.assertions(1);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        const { plugin, skills } = SKILL_SOURCES[0];
+        fs.rmSync(path.join(root, plugin, 'skills', skills[0]), { recursive: true, force: true });
+        expect(() => installSkills(root, 'claude', false)).toThrow(/missing from the marketplace/);
+      });
+    });
+
+    it('skips an already-installed skill unless force is set', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        installSkills(root, 'claude', false);
+        fs.writeFileSync('.claude/skills/layout/SKILL.md', 'edited');
+        installSkills(root, 'claude', false); // no force → keep edit
+        expect(fs.readFileSync('.claude/skills/layout/SKILL.md', 'utf8')).toBe('edited');
+        installSkills(root, 'claude', true); // force → overwrite
+        expect(fs.readFileSync('.claude/skills/layout/SKILL.md', 'utf8')).toBe('# layout skill');
+      });
+    });
+
+    it('reports existing files on a no-force re-run so the manifest stays complete', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        const first = installSkills(root, 'claude', false);
+        const second = installSkills(root, 'claude', false); // skips copy, still lists the files
+        expect(second).toHaveLength(first.length);
+        expect(second).toContain(path.join('.claude/skills', 'layout', 'SKILL.md'));
+      });
+    });
+
+    it('overlays on force, preserving user-added files in the skill dir (no blind dir wipe)', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        installSkills(root, 'claude', false);
+        fs.writeFileSync('.claude/skills/layout/my-notes.md', 'mine');
+        installSkills(root, 'claude', true); // force → overlay, not a dir nuke
+        expect(fs.readFileSync('.claude/skills/layout/my-notes.md', 'utf8')).toBe('mine');
+        expect(fs.readFileSync('.claude/skills/layout/SKILL.md', 'utf8')).toBe('# layout skill');
+      });
+    });
+
+    it('replaces a stray non-directory sitting where a skill dir belongs', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        fs.mkdirSync('.claude/skills', { recursive: true });
+        fs.writeFileSync('.claude/skills/layout', 'stray file, not a dir');
+        installSkills(root, 'claude', false);
+        expect(fs.statSync('.claude/skills/layout').isDirectory()).toBe(true);
+        expect(fs.existsSync('.claude/skills/layout/SKILL.md')).toBe(true);
+      });
+    });
+
+    it('never reports user-added files as managed on a no-force re-run (so they are not pruned)', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        installSkills(root, 'claude', false);
+        fs.writeFileSync('.claude/skills/layout/my-notes.md', 'mine');
+        const reported = installSkills(root, 'claude', false);
+        expect(reported).not.toContain(path.join('.claude/skills', 'layout', 'my-notes.md'));
+        expect(reported).toContain(path.join('.claude/skills', 'layout', 'SKILL.md'));
+      });
+    });
+  });
+
+  describe('copyDir', () => {
+    it('replaces a destination symlink instead of following it (no writes outside the project)', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.mkdirSync('src-skill', { recursive: true });
+        fs.writeFileSync('src-skill/SKILL.md', 'new content');
+        fs.writeFileSync('outside.md', 'protected');
+        fs.mkdirSync('dest', { recursive: true });
+        fs.symlinkSync(path.resolve('outside.md'), 'dest/SKILL.md'); // planted link to a file outside
+        copyDir('src-skill', 'dest');
+        expect(fs.readFileSync('outside.md', 'utf8')).toBe('protected'); // link target untouched
+        expect(fs.readFileSync('dest/SKILL.md', 'utf8')).toBe('new content'); // real file written in place
+      });
+    });
+
+    it('skips a symlink in the SOURCE bundle (never copies through it)', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.mkdirSync('src-skill', { recursive: true });
+        fs.writeFileSync('src-skill/SKILL.md', 'real');
+        fs.writeFileSync('secret.txt', 'private'); // a file the crafted symlink would point at
+        fs.symlinkSync(path.resolve('secret.txt'), 'src-skill/leak');
+        const written = copyDir('src-skill', 'dest');
+        expect(fs.existsSync('dest/leak')).toBe(false); // symlink entry skipped, not followed
+        expect(written).toStrictEqual([path.join('dest', 'SKILL.md')]); // only the real file copied
+      });
+    });
+
+    it('refuses a SOURCE dir that is itself a symlink (crafted-marketplace escape)', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.mkdirSync('host-dir', { recursive: true });
+        fs.writeFileSync('host-dir/private.txt', 'local secret');
+        fs.symlinkSync(path.resolve('host-dir'), 'src-link'); // the skill dir IS a symlink
+        const written = copyDir('src-link', 'dest');
+        expect(written).toStrictEqual([]); // nothing copied
+        expect(fs.existsSync('dest/private.txt')).toBe(false); // host file not exfiltrated
+      });
+    });
+  });
+
+  describe('symlink-safe writes', () => {
+    it('mergeBlock replaces a symlinked context file instead of following it', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.writeFileSync('outside.md', 'protected');
+        fs.symlinkSync(path.resolve('outside.md'), 'CLAUDE.md');
+        mergeBlock('CLAUDE.md', 'forest');
+        expect(fs.readFileSync('outside.md', 'utf8')).toBe('protected');
+        expect(fs.lstatSync('CLAUDE.md').isSymbolicLink()).toBe(false);
+      });
+    });
+
+    it('installDocsMcp replaces a symlinked .mcp.json instead of overwriting its target', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        fs.writeFileSync('outside.json', 'protected');
+        fs.symlinkSync(path.resolve('outside.json'), '.mcp.json');
+        installDocsMcp(root);
+        expect(fs.readFileSync('outside.json', 'utf8')).toBe('protected');
+        expect(fs.lstatSync('.mcp.json').isSymbolicLink()).toBe(false);
+      });
+    });
+
+    it('writeManifest does not write through a symlinked .forest dir', () => {
+      expect.assertions(1);
+      withTempDir(() => {
+        fs.mkdirSync('outside-dir');
+        fs.symlinkSync(path.resolve('outside-dir'), '.forest');
+        writeManifest({ ref: 'main', installedAt: 'x', agents: ['claude'], files: [] });
+        expect(fs.existsSync('outside-dir/skills-manifest.json')).toBe(false);
+      });
+    });
+  });
+
+  describe('skillDirEntries', () => {
+    it('keeps only entries under the skill dirs (normalized), dropping context/mcp files', () => {
+      expect.assertions(1);
+      expect(
+        skillDirEntries([
+          '.claude/skills/layout/SKILL.md',
+          '.agents\\skills\\layout\\SKILL.md', // windows-style separators
+          'CLAUDE.md',
+          '.mcp.json',
+        ]),
+      ).toStrictEqual(['.claude/skills/layout/SKILL.md', '.agents\\skills\\layout\\SKILL.md']);
+    });
+  });
+
+  describe('removeStaleSkillFiles', () => {
+    it('removes a previously-installed file that is gone upstream', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.mkdirSync('.claude/skills/layout', { recursive: true });
+        fs.writeFileSync('.claude/skills/layout/stale.md', 'old');
+        const removed = removeStaleSkillFiles(
+          ['.claude/skills/layout/stale.md'],
+          ['.claude/skills/layout/fresh.md'],
+        );
+        expect(removed).toStrictEqual(['.claude/skills/layout/stale.md']);
+        expect(fs.existsSync('.claude/skills/layout/stale.md')).toBe(false);
+      });
+    });
+
+    it('keeps files still produced by the current run', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.mkdirSync('.claude/skills/layout', { recursive: true });
+        fs.writeFileSync('.claude/skills/layout/keep.md', 'x');
+        const removed = removeStaleSkillFiles(
+          ['.claude/skills/layout/keep.md'],
+          ['.claude/skills/layout/keep.md'],
+        );
+        expect(removed).toHaveLength(0);
+        expect(fs.existsSync('.claude/skills/layout/keep.md')).toBe(true);
+      });
+    });
+
+    it('ignores previous entries that no longer exist on disk', () => {
+      expect.assertions(1);
+      withTempDir(() => {
+        expect(removeStaleSkillFiles(['.claude/skills/layout/ghost.md'], [])).toHaveLength(0);
+      });
+    });
+
+    it('refuses to delete a path that escapes the skill dirs (`..` traversal)', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.writeFileSync('precious.txt', 'keep me');
+        const removed = removeStaleSkillFiles(['.claude/skills/../../precious.txt'], []);
+        expect(removed).toHaveLength(0);
+        expect(fs.existsSync('precious.txt')).toBe(true);
+      });
+    });
+
+    it('matches previous vs current across path separators (Unix manifest, Windows run)', () => {
+      expect.assertions(1);
+      withTempDir(() => {
+        fs.mkdirSync('.claude/skills/layout', { recursive: true });
+        fs.writeFileSync('.claude/skills/layout/SKILL.md', 'x');
+        // Backslash "previous" must be recognized as the same file as forward-slash "current".
+        const removed = removeStaleSkillFiles(
+          ['.claude\\skills\\layout\\SKILL.md'],
+          ['.claude/skills/layout/SKILL.md'],
+        );
+        expect(removed).toHaveLength(0);
+      });
+    });
+
+    it('refuses to delete through a skill dir symlinked outside the project', () => {
+      expect.assertions(2);
+      const external = fs.mkdtempSync(path.join(os.tmpdir(), 'ext-'));
+      try {
+        fs.mkdirSync(path.join(external, 'layout'));
+        fs.writeFileSync(path.join(external, 'layout', 'old.md'), 'external file');
+        withTempDir(() => {
+          fs.mkdirSync('.claude', { recursive: true });
+          fs.symlinkSync(external, '.claude/skills'); // skills dir → outside the project
+          const removed = removeStaleSkillFiles(['.claude/skills/layout/old.md'], []);
+          expect(removed).toHaveLength(0);
+          expect(fs.existsSync(path.join(external, 'layout', 'old.md'))).toBe(true);
+        });
+      } finally {
+        fs.rmSync(external, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('installDocsMcp', () => {
+    it('writes the forest-docs MCP server from the marketplace', () => {
+      expect.assertions(1);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        installDocsMcp(root);
+        const mcp = JSON.parse(fs.readFileSync('.mcp.json', 'utf8'));
+        expect(mcp.mcpServers['forest-docs'].url).toBe('https://docs.forest.app/mcp');
+      });
+    });
+
+    it('preserves an existing MCP server the user already had', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        fs.writeFileSync('.mcp.json', JSON.stringify({ mcpServers: { other: { url: 'x' } } }));
+        installDocsMcp(root);
+        const mcp = JSON.parse(fs.readFileSync('.mcp.json', 'utf8'));
+        expect(mcp.mcpServers.other).toBeDefined();
+        expect(mcp.mcpServers['forest-docs']).toBeDefined();
+      });
+    });
+
+    it('aborts on a malformed existing .mcp.json instead of clobbering it', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        fs.writeFileSync('.mcp.json', '{ not valid json');
+        expect(() => installDocsMcp(root)).toThrow(/Cannot parse existing/);
+        expect(fs.readFileSync('.mcp.json', 'utf8')).toBe('{ not valid json');
+      });
+    });
+
+    it('treats a valid-but-non-object .mcp.json (JSON null) as empty instead of crashing', () => {
+      expect.assertions(1);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        fs.writeFileSync('.mcp.json', 'null');
+        installDocsMcp(root);
+        const mcp = JSON.parse(fs.readFileSync('.mcp.json', 'utf8'));
+        expect(mcp.mcpServers['forest-docs']).toBeDefined();
+      });
+    });
+  });
+
+  describe('manifest', () => {
+    it('returns null when no manifest exists', () => {
+      expect.assertions(1);
+      withTempDir(() => {
+        expect(readManifest()).toBeNull();
+      });
+    });
+
+    it('returns null for a valid-but-malformed manifest (no files array)', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.mkdirSync('.forest', { recursive: true });
+        fs.writeFileSync('.forest/skills-manifest.json', '{}');
+        expect(readManifest()).toBeNull();
+        fs.writeFileSync('.forest/skills-manifest.json', '[]');
+        expect(readManifest()).toBeNull();
+      });
+    });
+
+    it('round-trips through write/read', () => {
+      expect.assertions(1);
+      withTempDir(() => {
+        const manifest = {
+          ref: 'main',
+          installedAt: '2026-01-01',
+          agents: ['claude'],
+          files: ['a'],
+        };
+        writeManifest(manifest);
+        expect(readManifest()).toStrictEqual(manifest);
+      });
+    });
+  });
+});

--- a/test/services/skills/skills-manager.unit.test.ts
+++ b/test/services/skills/skills-manager.unit.test.ts
@@ -106,7 +106,7 @@ describe('skills-manager', () => {
       expect.assertions(3);
       withTempDir(dir => {
         const root = fakeMarketplace(path.join(dir, 'src'));
-        const written = installSkills(root, 'claude', false);
+        const written = installSkills(root, 'claude', false, null);
         expect(fs.existsSync('.claude/skills/layout/SKILL.md')).toBe(true);
         expect(fs.existsSync('.claude/skills/forest-code/SKILL.md')).toBe(true);
         expect(written).toContain(path.join('.claude/skills', 'layout', 'references', 'a.md'));
@@ -119,7 +119,9 @@ describe('skills-manager', () => {
         const root = fakeMarketplace(path.join(dir, 'src'));
         const { plugin, skills } = SKILL_SOURCES[0];
         fs.rmSync(path.join(root, plugin, 'skills', skills[0]), { recursive: true, force: true });
-        expect(() => installSkills(root, 'claude', false)).toThrow(/missing from the marketplace/);
+        expect(() => installSkills(root, 'claude', false, null)).toThrow(
+          /missing from the marketplace/,
+        );
       });
     });
 
@@ -127,11 +129,11 @@ describe('skills-manager', () => {
       expect.assertions(2);
       withTempDir(dir => {
         const root = fakeMarketplace(path.join(dir, 'src'));
-        installSkills(root, 'claude', false);
+        const first = installSkills(root, 'claude', false, null);
         fs.writeFileSync('.claude/skills/layout/SKILL.md', 'edited');
-        installSkills(root, 'claude', false); // no force → keep edit
+        installSkills(root, 'claude', false, first); // no force → keep edit
         expect(fs.readFileSync('.claude/skills/layout/SKILL.md', 'utf8')).toBe('edited');
-        installSkills(root, 'claude', true); // force → overwrite
+        installSkills(root, 'claude', true, first); // force → overwrite
         expect(fs.readFileSync('.claude/skills/layout/SKILL.md', 'utf8')).toBe('# layout skill');
       });
     });
@@ -140,8 +142,8 @@ describe('skills-manager', () => {
       expect.assertions(2);
       withTempDir(dir => {
         const root = fakeMarketplace(path.join(dir, 'src'));
-        const first = installSkills(root, 'claude', false);
-        const second = installSkills(root, 'claude', false); // skips copy, still lists the files
+        const first = installSkills(root, 'claude', false, null);
+        const second = installSkills(root, 'claude', false, first); // skips copy, still lists them
         expect(second).toHaveLength(first.length);
         expect(second).toContain(path.join('.claude/skills', 'layout', 'SKILL.md'));
       });
@@ -151,9 +153,9 @@ describe('skills-manager', () => {
       expect.assertions(2);
       withTempDir(dir => {
         const root = fakeMarketplace(path.join(dir, 'src'));
-        installSkills(root, 'claude', false);
+        const first = installSkills(root, 'claude', false, null);
         fs.writeFileSync('.claude/skills/layout/my-notes.md', 'mine');
-        installSkills(root, 'claude', true); // force → overlay, not a dir nuke
+        installSkills(root, 'claude', true, first); // force → overlay, not a dir nuke
         expect(fs.readFileSync('.claude/skills/layout/my-notes.md', 'utf8')).toBe('mine');
         expect(fs.readFileSync('.claude/skills/layout/SKILL.md', 'utf8')).toBe('# layout skill');
       });
@@ -165,7 +167,7 @@ describe('skills-manager', () => {
         const root = fakeMarketplace(path.join(dir, 'src'));
         fs.mkdirSync('.claude/skills', { recursive: true });
         fs.writeFileSync('.claude/skills/layout', 'stray file, not a dir');
-        installSkills(root, 'claude', false);
+        installSkills(root, 'claude', false, null);
         expect(fs.statSync('.claude/skills/layout').isDirectory()).toBe(true);
         expect(fs.existsSync('.claude/skills/layout/SKILL.md')).toBe(true);
       });
@@ -175,10 +177,42 @@ describe('skills-manager', () => {
       expect.assertions(2);
       withTempDir(dir => {
         const root = fakeMarketplace(path.join(dir, 'src'));
-        installSkills(root, 'claude', false);
+        const first = installSkills(root, 'claude', false, null);
         fs.writeFileSync('.claude/skills/layout/my-notes.md', 'mine');
-        const reported = installSkills(root, 'claude', false);
+        const reported = installSkills(root, 'claude', false, first);
         expect(reported).not.toContain(path.join('.claude/skills', 'layout', 'my-notes.md'));
+        expect(reported).toContain(path.join('.claude/skills', 'layout', 'SKILL.md'));
+      });
+    });
+
+    it('claims nothing for a skill dir that pre-existed the first run (later prune spares it)', () => {
+      expect.assertions(3);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        // The user authored their own layout skill BEFORE ever running skills:init.
+        fs.mkdirSync('.claude/skills/layout', { recursive: true });
+        fs.writeFileSync('.claude/skills/layout/SKILL.md', 'user-authored');
+        // First run (no manifest), no --force: the dir is skipped, so nothing in it was written
+        // by us and nothing in it may be claimed as managed.
+        const written = installSkills(root, 'claude', false, null);
+        expect(written).not.toContain(path.join('.claude/skills', 'layout', 'SKILL.md'));
+        // Later refresh where `layout` left the upstream bundle: the prune (manifest-scoped) must
+        // not touch the user's file, since the manifest never claimed it.
+        const removed = removeStaleSkillFiles(skillDirEntries(written), []);
+        expect(removed).not.toContain(path.join('.claude/skills', 'layout', 'SKILL.md'));
+        expect(fs.readFileSync('.claude/skills/layout/SKILL.md', 'utf8')).toBe('user-authored');
+      });
+    });
+
+    it('matches previous manifest entries across path separators on the skip path', () => {
+      expect.assertions(1);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        installSkills(root, 'claude', false, null);
+        // A manifest written on Windows (backslashes) must still vouch for the same file here.
+        const reported = installSkills(root, 'claude', false, [
+          '.claude\\skills\\layout\\SKILL.md',
+        ]);
         expect(reported).toContain(path.join('.claude/skills', 'layout', 'SKILL.md'));
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11596,7 +11596,7 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11612,15 +11612,6 @@ string-width@^2.1.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -11686,7 +11677,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11706,13 +11697,6 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.2"
@@ -11859,6 +11843,17 @@ tar@^7.4.3, tar@^7.5.1:
   version "7.5.9"
   resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.9.tgz#817ac12a54bc4362c51340875b8985d7dc9724b8"
   integrity sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==
+  dependencies:
+    "@isaacs/fs-minipass" "^4.0.0"
+    chownr "^3.0.0"
+    minipass "^7.1.2"
+    minizlib "^3.1.0"
+    yallist "^5.0.0"
+
+tar@^7.5.9:
+  version "7.5.21"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.21.tgz#b3405af2eb493523ce4379f531e9ebda0601bc59"
+  integrity sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"
@@ -12661,7 +12656,7 @@ wordwrap@>=0.0.2, wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12674,15 +12669,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## What

`forest skills:init` — install Forest's agent skills into the current repo, **project-scoped** (`.claude/skills/` + `.agents/skills/`), so a client's coding agent (Claude Code or Codex) knows Forest with no marketplace add.

Fetches from `ForestAdmin/ai-marketplace` (tarball at `--ref`, default `main`), copies the curated dev-facing skills for **both** agents, merges a delimited Forest block into `CLAUDE.md` / `AGENTS.md` (preserving user content), wires the Forest docs MCP into `.mcp.json`, and records the ref + file list in `.forest/skills-manifest.json`.

**Flags:** `--ref` (git ref, default `main`), `--force` (overwrite existing skill files). Both agents are always set up — the unused one's files are inert.

The distributed set is a curated list in `SKILL_SOURCES` (explicit control over what ships; internal/test-only skills stay out).

## Tested

- Unit tests (service): context-file resolution, block merge preserving user content, install into both agent dirs, docs-MCP merge (incl. malformed/non-object `.mcp.json`), manifest round-trip, missing-source fail-loud, and symlink-safe writes on **both** the destination and the source bundle.
- Network path hardened: `fetchMarketplace` has a timeout and maps a bad `--ref` (404) to a clear message.
- Live e2e against `ai-marketplace@main`: skills installed across `.claude/` + `.agents/`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `forest skills:init` command to install Forest skills into agent repos
> - Adds a new `forest skills:init` CLI command in [init.ts](https://github.com/ForestAdmin/toolbelt/pull/804/files#diff-4e3bfaec772f4772fd7080241cac46e0348fb2eb84f15d4b1e355599b006d0d5) that downloads a tar.gz bundle from `ForestAdmin/ai-marketplace` at a given git ref and installs curated skills for Claude Code (`.claude/skills`) and Codex (`.agents/skills`).
> - Merges a Forest context block into `CLAUDE.md`/`AGENTS.md` and wires the `forest-docs` MCP server into `.mcp.json`, preserving existing user-defined servers.
> - Tracks installed files in `.forest/skills-manifest.json` to prune stale managed files on re-runs without deleting user-added content.
> - [skills-manager.ts](https://github.com/ForestAdmin/toolbelt/pull/804/files#diff-4b76cc1bbafb57a12af6006e3b6710e37203b9ee482fe6c5cf990509ce591d4b) implements all underlying utilities including marketplace fetch, recursive directory copy, symlink-safe writes, stale file pruning, and preflight validation of local `.mcp.json` and the bundle.
> - Risk: adds `tar` as a new runtime dependency; command aborts early if the local `.mcp.json` is malformed or the bundle is missing `forest-docs/.mcp.json`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aea7046.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->