### PR TITLE
feat(skills): add `forest skills:update` — refresh installed skills

### DIFF
--- a/src/commands/skills/update.ts
+++ b/src/commands/skills/update.ts
@@ -11,6 +11,8 @@ import {
   readManifest,
   removeStaleSkillFiles,
   skillDirEntries,
+  validateLocalMcp,
+  validateMarketplaceBundle,
   writeManifest,
 } from '../../services/skills/skills-manager';
 
@@ -42,9 +44,26 @@ export default class SkillsUpdateCommand extends AbstractCommand {
 
     const { agents } = SkillsUpdateCommand;
 
+    // Fail fast BEFORE any disk mutation: a broken local .mcp.json would otherwise only surface
+    // in installDocsMcp, at the very end, leaving a half-applied refresh behind (same as init).
+    validateLocalMcp();
+
+    // An update targets the requested ref (default main) — but never silently: an install pinned
+    // to a tag/SHA jumping refs must be visible, and the way back must be obvious.
+    if (manifest.ref && manifest.ref !== flags.ref) {
+      this.logger.warn(
+        `Skills were installed from "${manifest.ref}"; updating to "${flags.ref}". ` +
+          `Pass ${this.chalk.bold(`--ref ${manifest.ref}`)} to stay pinned.`,
+      );
+    }
+
     this.logger.info(`Refreshing Forest skills from ForestAdmin/ai-marketplace@${flags.ref}…`);
     const { root: srcRoot, cleanup } = await fetchMarketplace(flags.ref);
     try {
+      // Still before any write: the bundle must carry the docs MCP config, or the last step
+      // would fail with a raw ENOENT after skills/context files were already refreshed.
+      validateMarketplaceBundle(srcRoot, flags.ref);
+
       // The managed skill files previously installed — candidates for stale-pruning.
       const oldSkillFiles = skillDirEntries(manifest.files);
 

--- a/src/commands/skills/update.ts
+++ b/src/commands/skills/update.ts
@@ -1,0 +1,76 @@
+import { Flags } from '@oclif/core';
+
+import AbstractCommand from '../../abstract-command';
+import {
+  FOREST_BLOCK,
+  contextFileFor,
+  fetchMarketplace,
+  installDocsMcp,
+  installSkills,
+  mergeBlock,
+  readManifest,
+  removeStaleSkillFiles,
+  skillDirEntries,
+  writeManifest,
+} from '../../services/skills/skills-manager';
+
+export default class SkillsUpdateCommand extends AbstractCommand {
+  static override description =
+    'Refresh the Forest skills in this repo from ForestAdmin/ai-marketplace (anti-drift). ' +
+    'Overwrites the managed skill files and prunes ones dropped upstream (git shows the diff); ' +
+    'files you added yourself inside the skill dirs are left untouched.';
+
+  static override flags = {
+    ref: Flags.string({ description: 'Marketplace version (git ref).', default: 'main' }),
+  };
+
+  // Always refresh both agents (matches skills:init) — avoids the class of bug where refreshing
+  // one agent treats the other agent's files as stale and deletes them.
+  private static readonly agents = ['claude', 'codex'];
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(SkillsUpdateCommand);
+
+    const manifest = readManifest();
+    if (!manifest) {
+      this.logger.error('No Forest skills found in this repo.');
+      this.logger.log(`help: run ${this.chalk.bold('forest skills:init')} first.`);
+      this.exit(1);
+
+      return;
+    }
+
+    const { agents } = SkillsUpdateCommand;
+
+    this.logger.info(`Refreshing Forest skills from ForestAdmin/ai-marketplace@${flags.ref}…`);
+    const { root: srcRoot, cleanup } = await fetchMarketplace(flags.ref);
+    try {
+      // The managed skill files previously installed — candidates for stale-pruning.
+      const oldSkillFiles = skillDirEntries(manifest.files);
+
+      const skillFiles = agents.flatMap(agent => {
+        const written = installSkills(srcRoot, agent, true); // force: managed files are Forest-owned
+        const contextFile = contextFileFor(agent);
+        mergeBlock(contextFile, FOREST_BLOCK); // refreshes only the Forest block; user content untouched
+
+        return [...written, contextFile];
+      });
+
+      // Deletions: managed skill files removed upstream are removed locally.
+      const removed = removeStaleSkillFiles(oldSkillFiles, skillFiles);
+
+      const files = [...skillFiles, installDocsMcp(srcRoot)];
+
+      writeManifest({ ref: flags.ref, installedAt: new Date().toISOString(), agents, files });
+
+      this.logger.success(
+        `Forest skills refreshed for ${agents.join(', ')} (${files.length} files, ${
+          removed.length
+        } removed).`,
+        { lineColor: 'green' },
+      );
+    } finally {
+      cleanup();
+    }
+  }
+}

--- a/test/commands/skills/update.test.js
+++ b/test/commands/skills/update.test.js
@@ -1,0 +1,220 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const testCli = require('../test-cli-helper/test-cli');
+
+// Mock ONLY the network fetch: the command's real orchestration (validation, install, block
+// merge, stale-pruning, manifest rewrite) runs against a fake extracted bundle on disk.
+jest.mock('../../../src/services/skills/skills-manager', () => ({
+  ...jest.requireActual('../../../src/services/skills/skills-manager'),
+  fetchMarketplace: jest.fn(),
+}));
+
+const SkillsUpdateCommand = require('../../../src/commands/skills/update').default;
+const { SKILL_SOURCES, fetchMarketplace } = require('../../../src/services/skills/skills-manager');
+
+// Build a fake extracted marketplace holding every curated skill (derived from SKILL_SOURCES so
+// the fixture stays in sync with the real list) + forest-docs/.mcp.json.
+function makeFakeBundle() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skills-update-test-'));
+  const write = (p, c) => {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, c);
+  };
+  SKILL_SOURCES.forEach(({ plugin, skills }) =>
+    skills.forEach(skill =>
+      write(path.join(root, plugin, 'skills', skill, 'SKILL.md'), `# ${skill} skill (fresh)`),
+    ),
+  );
+  write(
+    path.join(root, 'forest-docs', '.mcp.json'),
+    JSON.stringify({
+      mcpServers: { 'forest-docs': { type: 'http', url: 'https://docs.forest.app/mcp' } },
+    }),
+  );
+  return root;
+}
+
+function mockMarketplaceFetch() {
+  fetchMarketplace.mockReset();
+  fetchMarketplace.mockImplementation(async () => {
+    const root = makeFakeBundle();
+    return { root, cleanup: () => fs.rmSync(root, { recursive: true, force: true }) };
+  });
+}
+
+// Run testCli but keep the temporary project directory so the resulting disk state can be
+// asserted; returns that directory — the caller must remove it afterwards.
+async function runCliKeepingProjectDir(options) {
+  const previousFlag = process.env.KEEP_TEMPORARY_FILES;
+  process.env.KEEP_TEMPORARY_FILES = '1';
+  try {
+    await testCli(options);
+  } finally {
+    if (previousFlag === undefined) delete process.env.KEEP_TEMPORARY_FILES;
+    else process.env.KEEP_TEMPORARY_FILES = previousFlag;
+  }
+  // testCli assigns the temporary project directory to each file lacking an explicit chdir.
+  return options.files[0].chdir;
+}
+
+const previousManifest = (ref, files) =>
+  JSON.stringify({ ref, installedAt: '2026-01-01T00:00:00.000Z', agents: ['claude'], files });
+
+describe('skills:update', () => {
+  describe('when no manifest exists', () => {
+    it('exits with an error and never reaches the marketplace', async () => {
+      expect.hasAssertions();
+      mockMarketplaceFetch();
+
+      await testCli({
+        commandClass: SkillsUpdateCommand,
+        exitCode: 1,
+        std: [
+          { err: 'No Forest skills found in this repo.' },
+          { out: 'help: run forest skills:init first.' },
+        ],
+      });
+
+      // Bailed out before the pipeline: nothing fetched, hence nothing written.
+      expect(fetchMarketplace).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the local .mcp.json is unparsable', () => {
+    it('fails fast before fetching or mutating anything', async () => {
+      expect.hasAssertions();
+      mockMarketplaceFetch();
+
+      await testCli({
+        commandClass: SkillsUpdateCommand,
+        files: [
+          {
+            name: '.forest/skills-manifest.json',
+            content: previousManifest('main', ['.claude/skills/layout/SKILL.md']),
+          },
+          { name: '.mcp.json', content: '{ not valid json' },
+        ],
+        exitMessage:
+          "Cannot parse existing .mcp.json; aborting before any changes so it isn't overwritten. " +
+          'Fix or remove it, then re-run.',
+      });
+
+      expect(fetchMarketplace).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when a manifest exists', () => {
+    it('refreshes managed files, prunes stale ones and rewrites the manifest', async () => {
+      expect.hasAssertions();
+      mockMarketplaceFetch();
+
+      const files = [
+        {
+          name: '.forest/skills-manifest.json',
+          content: previousManifest('main', [
+            '.claude/skills/layout/SKILL.md',
+            '.claude/skills/old-skill/SKILL.md', // left the upstream bundle since
+            'CLAUDE.md',
+            '.mcp.json',
+          ]),
+        },
+        { name: '.claude/skills/layout/SKILL.md', content: 'outdated content' },
+        { name: '.claude/skills/old-skill/SKILL.md', content: 'stale content' },
+      ];
+
+      const projectDir = await runCliKeepingProjectDir({
+        commandClass: SkillsUpdateCommand,
+        files,
+        std: [
+          { out: 'Refreshing Forest skills from ForestAdmin/ai-marketplace@main' },
+          { out: 'Forest skills refreshed for claude, codex' },
+        ],
+      });
+
+      try {
+        const at = p => path.join(projectDir, p);
+        // Managed file refreshed from the bundle.
+        expect(fs.readFileSync(at('.claude/skills/layout/SKILL.md'), 'utf8')).toBe(
+          '# layout skill (fresh)',
+        );
+        // Stale managed file (in the old manifest, gone upstream) pruned.
+        expect(fs.existsSync(at('.claude/skills/old-skill/SKILL.md'))).toBe(false);
+        // Freshly installed files NOT pruned (removeStaleSkillFiles argument order).
+        expect(fs.existsSync(at('.claude/skills/forest-code/SKILL.md'))).toBe(true);
+        expect(fs.existsSync(at('.agents/skills/layout/SKILL.md'))).toBe(true);
+        // Manifest rewritten with the effective ref and the refreshed file list.
+        const manifest = JSON.parse(fs.readFileSync(at('.forest/skills-manifest.json'), 'utf8'));
+        expect(manifest.ref).toBe('main');
+        expect(manifest.files).toContain(path.join('.claude/skills', 'forest-code', 'SKILL.md'));
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+
+    it('logs the ref transition when the manifest was pinned to another ref', async () => {
+      expect.hasAssertions();
+      mockMarketplaceFetch();
+
+      const files = [
+        {
+          name: '.forest/skills-manifest.json',
+          content: previousManifest('v2.1.0', ['.claude/skills/layout/SKILL.md']),
+        },
+        { name: '.claude/skills/layout/SKILL.md', content: 'outdated content' },
+      ];
+
+      const projectDir = await runCliKeepingProjectDir({
+        commandClass: SkillsUpdateCommand,
+        files,
+        std: [
+          { out: 'Skills were installed from "v2.1.0"; updating to "main".' },
+          { out: '--ref v2.1.0' }, // the way back to the pin is spelled out
+          { out: 'Forest skills refreshed' },
+        ],
+      });
+
+      try {
+        // The de-pin is applied (and recorded) — only the silence around it was the bug.
+        const manifest = JSON.parse(
+          fs.readFileSync(path.join(projectDir, '.forest/skills-manifest.json'), 'utf8'),
+        );
+        expect(manifest.ref).toBe('main');
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+
+    it('passes the requested --ref through to the fetch and the manifest', async () => {
+      expect.hasAssertions();
+      mockMarketplaceFetch();
+
+      const files = [
+        {
+          name: '.forest/skills-manifest.json',
+          content: previousManifest('v2.1.0', ['.claude/skills/layout/SKILL.md']),
+        },
+        { name: '.claude/skills/layout/SKILL.md', content: 'outdated content' },
+      ];
+
+      const projectDir = await runCliKeepingProjectDir({
+        commandClass: SkillsUpdateCommand,
+        commandArgs: ['--ref', 'v2.1.0'],
+        files,
+        // Staying on the pinned ref: no transition warning to emit.
+        std: [{ out: 'Refreshing Forest skills from ForestAdmin/ai-marketplace@v2.1.0' }],
+      });
+
+      try {
+        expect(fetchMarketplace).toHaveBeenCalledWith('v2.1.0');
+        const manifest = JSON.parse(
+          fs.readFileSync(path.join(projectDir, '.forest/skills-manifest.json'), 'utf8'),
+        );
+        expect(manifest.ref).toBe('v2.1.0');
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+  });
+});


### PR DESCRIPTION
> ⚠️ **Stacked on #804.** Review/merge that first.

## What

`forest skills:update` — refresh the skills installed by `skills:init`.

Reads `.forest/skills-manifest.json` (guiding error if missing → run `skills:init` first), re-fetches from the marketplace, overwrites the managed skill files, and **prunes** files that were managed before but are no longer produced (removed upstream → deleted from disk and the manifest). Refreshes the `CLAUDE.md`/`AGENTS.md` block + docs MCP, bumps the manifest. Files you added yourself inside the skill dirs are left untouched. The command is **unconditionally non-interactive** — it overwrites managed files; `git` shows you the diff.

**Flags:** `--ref` (git ref, default `main`).

Stale-file removal is a tested `removeStaleSkillFiles`: only files inside the skill dirs are pruned (blocks `..` traversal and symlinked-dir escape; cross-platform paths normalized).

## Tested

Unit tests (service, incl. `removeStaleSkillFiles`: removes what left the set, keeps current files, ignores ghosts, refuses traversal / symlinked-dir escape).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `forest skills:update` command to refresh installed Forest skills
> - Adds a new `skills:update` oclif command in [src/commands/skills/update.ts](https://github.com/ForestAdmin/toolbelt/pull/805/files#diff-cc7eb1dfa4612ab7637b28cadba9e830b9b1409bab901ad011efc7eecd9f2294) that re-fetches managed skills from `ForestAdmin/ai-marketplace` at a given git ref (default: `main`) and installs them for both Claude and Codex agents.
> - Merges the `FOREST_BLOCK` into each agent's context file while preserving user-authored content, prunes managed files removed upstream, and rewrites the local manifest with the new ref, timestamp, and file list.
> - Exits early with guidance if no manifest exists, fails fast on an invalid `.mcp.json`, and warns when the requested `--ref` differs from the manifest's recorded ref.
> - Test coverage in [test/commands/skills/update.test.js](https://github.com/ForestAdmin/toolbelt/pull/805/files#diff-7880364751dfe1aeecdad524a53edc1fcb87079cedf6efac4aeebf8765a0ccbd) covers missing manifest, invalid `.mcp.json`, stale file pruning, ref-mismatch warnings, and `--ref` passthrough.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9c415e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->