### PR TITLE
chore(security): patch 6 Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,8 @@
     "uuid": "^11.1.1",
     "inquirer/**/tmp": "^0.2.6",
     "brace-expansion": "^1.1.16 || ^2.1.2",
-    "fast-uri": "^3.1.4"
+    "fast-uri": "^3.1.4",
+    "undici": "^6.28.0",
+    "ip-address": "^10.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7551,10 +7551,10 @@ into-stream@^7.0.0:
     from2 "^2.3.0"
     p-is-promise "^3.0.0"
 
-ip-address@^10.0.1:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
-  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
+ip-address@^10.0.1, ip-address@^10.3.1:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.5.0.tgz#fcd6d7dfe9e68416b7cb71afe9bc960b3e38c13b"
+  integrity sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==
 
 ip-regex@5.0.0:
   version "5.0.0"
@@ -12471,10 +12471,10 @@ undici-types@~7.16.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
   integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
-undici@^6.23.0:
-  version "6.27.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.27.0.tgz#41f9e48f7c5a40d27376caaead8c9a9fc7bca9c4"
-  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
+undici@^6.23.0, undici@^6.28.0:
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
+  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
 
 unicode-emoji-modifier-base@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
> 👋 First-level support: see [Handling automated security PRs](https://forest.slite.com/app/docs/rmjdwFgmV2RzUp) for how to triage and merge this PR.

## Summary

6 fixed, 0 ignored, 2 deferred, 2 resolutions added, 0 resolutions removed. | label: :lock: security applied

## Fixed

| Done | Alert | Package | Ecosystem | From → To | Severity | What was bumped |
|---|---|---|---|---|---|---|
| - [ ] | [#241](https://github.com/ForestAdmin/toolbelt/security/dependabot/241) | ip-address | npm | 10.2.0 → 10.5.0 | medium | Added `ip-address: ^10.3.1` resolution (root) |
| - [ ] | [#242](https://github.com/ForestAdmin/toolbelt/security/dependabot/242) | ip-address | npm | 10.2.0 → 10.5.0 | medium | Same resolution as [#241](https://github.com/ForestAdmin/toolbelt/security/dependabot/241) |
| - [ ] | [#243](https://github.com/ForestAdmin/toolbelt/security/dependabot/243) | ip-address | npm | 10.2.0 → 10.5.0 | high | Same resolution as [#241](https://github.com/ForestAdmin/toolbelt/security/dependabot/241) |
| - [ ] | [#244](https://github.com/ForestAdmin/toolbelt/security/dependabot/244) | undici | npm | 6.27.0 → 6.28.0 | medium | Added `undici: ^6.28.0` resolution (root) |
| - [ ] | [#245](https://github.com/ForestAdmin/toolbelt/security/dependabot/245) | undici | npm | 6.27.0 → 6.28.0 | medium | Same resolution as [#244](https://github.com/ForestAdmin/toolbelt/security/dependabot/244) |
| - [ ] | [#246](https://github.com/ForestAdmin/toolbelt/security/dependabot/246) | undici | npm | 6.27.0 → 6.28.0 | medium | Same resolution as [#244](https://github.com/ForestAdmin/toolbelt/security/dependabot/244) |

## Ignored

None.

## Deferred

Skipped by the 7-day age gate (opened less than 7 days ago; today is 2026-08-13):

- [#248](https://github.com/ForestAdmin/toolbelt/security/dependabot/248) — js-yaml (runtime, transitive via `@oclif/core`), created 2026-08-11
- [#249](https://github.com/ForestAdmin/toolbelt/security/dependabot/249) — js-yaml (development, transitive via `eslint`/`semantic-release`), created 2026-08-11

## Resolutions added

| Alert(s) | Package + pinned range | Parent chain tried | Why the bump wasn't viable | package.json | Form |
|---|---|---|---|---|---|
| [#244](https://github.com/ForestAdmin/toolbelt/security/dependabot/244), [#245](https://github.com/ForestAdmin/toolbelt/security/dependabot/245), [#246](https://github.com/ForestAdmin/toolbelt/security/dependabot/246) | `undici: ^6.28.0` | `@semantic-release/npm@^13.1.1 > @actions/core > @actions/http-client@4.0.1 > undici@^6.23.0` | Latest `@semantic-release/npm` (13.1.5), `@actions/core` (3.0.1) and `@actions/http-client` (4.0.1) all still require `undici@^6.23.0`, which naturally resolves to 6.27.0. No ancestor bump pulls in the patched sub-dep. | root `package.json` | unconditional (single chain — scoped syntax `"@actions/http-client/undici"` is not honored by Yarn 1.x and resolved back to 6.27.0; unconditional matches the same blast radius since only one chain resolves undici) |
| [#241](https://github.com/ForestAdmin/toolbelt/security/dependabot/241), [#242](https://github.com/ForestAdmin/toolbelt/security/dependabot/242), [#243](https://github.com/ForestAdmin/toolbelt/security/dependabot/243) | `ip-address: ^10.3.1` | `mongodb > socks@2.8.7 > ip-address@^10.0.1` (also hoisted via `@forestadmin/datasource-sql`, `@npmcli/agent > socks-proxy-agent`) | Latest `socks` (2.8.9) requires `ip-address@^10.1.1`, which still naturally resolves to 10.2.0 (unpatched). No ancestor bump closes the gap. | root `package.json` | unconditional (all chains funnel through `socks`; scoped syntax `"socks/ip-address"` is not honored by Yarn 1.x) |

## Resolutions removed

None. All existing entries in `resolutions` still have live pins in the resolved dependency tree (verified with `yarn why`); none are stale. Redundancy hygiene was deferred to avoid the risk of quietly rolling back an earlier security pin without an integration-test signal.

## Risks

- **undici 6.27.0 → 6.28.0** (patch bump within 6.x): fixes three security advisories (cookie attribute injection, CRLF injection in blob body `type`, downstream response desync in retry interceptor). No API changes touching consumers per the upstream release notes; only `@actions/http-client` uses it here, and that path is exercised solely by `@semantic-release/npm` at release time — no runtime code path in the CLI touches undici.
- **ip-address 10.2.0 → 10.5.0** (minor bumps within 10.x): closes three SSRF/trust-boundary bypass advisories (leading-zero octal decoding, CIDR-suffix special-use classification, IPv4-mapped/NAT64 misclassification). `socks@2.8.7`'s declared range is `^10.0.1`, so 10.5.0 satisfies it; the release notes for 10.3.x–10.5.x are security fixes and internal refactors, no API surface touched by `socks`.
- No consumer code in this repo directly imports `undici` or `ip-address` — grep confirms; the pins only affect transitive resolution.

## Manual testing

Covered by CI.

## Validation

⏳ Awaiting CI


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Patch 6 Dependabot security alerts by pinning `undici` and `ip-address`
> Adds `undici` at `^6.28.0` and `ip-address` at `^10.3.1` as explicit dependencies in [package.json](https://github.com/ForestAdmin/toolbelt/pull/812/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to resolve vulnerable transitive versions flagged by Dependabot. The lockfile is updated to reflect the resolved versions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f4f388.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->