### PR TITLE
fix(roles): support colons in smart-action names in the roles CSV

### DIFF
--- a/src/services/roles-csv.js
+++ b/src/services/roles-csv.js
@@ -100,10 +100,22 @@ function collectSmartActionsForCollection(roles, envId, colName) {
 
 function collectColumns(collections, roles, envId) {
   return collections.reduce((cols, colName) => {
-    const crudCols = CRUD_SUFFIXES.map(s => `${colName}:${s}`);
+    const crudCols = CRUD_SUFFIXES.map(s => ({
+      header: `${colName}:${s}`,
+      collectionName: colName,
+      suffix: s,
+    }));
     const actions = collectSmartActionsForCollection(roles, envId, colName);
     const saCols = actions.reduce(
-      (acc, action) => [...acc, ...SMART_ACTION_SUFFIXES.map(s => `${colName}:${action}:${s}`)],
+      (acc, action) => [
+        ...acc,
+        ...SMART_ACTION_SUFFIXES.map(s => ({
+          header: `${colName}:${action}:${s}`,
+          collectionName: colName,
+          actionName: action,
+          suffix: s,
+        })),
+      ],
       [],
     );
     return [...cols, ...crudCols, ...saCols];
@@ -146,17 +158,13 @@ function getSmartActionValue(col, actionName, suffix) {
   return Boolean(sa[SA_FIELD_MAP[suffix]]);
 }
 
-function buildCellForColumn(colHeader, colByName) {
-  const parts = colHeader.split(':');
-  if (parts.length === 2) {
-    const [colName, suffix] = parts;
-    return String(getCrudValue(colByName[colName], suffix));
-  }
-  if (parts.length === 3) {
-    const [colName, actionName, suffix] = parts;
-    return String(getSmartActionValue(colByName[colName], actionName, suffix));
-  }
-  return 'false';
+// Reads the structured column descriptor built by collectColumns rather than
+// re-splitting its `header`: a smart-action name may itself contain a colon
+// (e.g. "SAML SSO #2: Edit SSO config"), which a split would mis-slice.
+function buildCellForColumn(column, colByName) {
+  const col = colByName[column.collectionName];
+  if (column.actionName === undefined) return String(getCrudValue(col, column.suffix));
+  return String(getSmartActionValue(col, column.actionName, column.suffix));
 }
 
 function buildRoleRow(role, columns, envId) {
@@ -182,7 +190,7 @@ function buildRoleRow(role, columns, envId) {
  */
 function formatWide(roles, envId) {
   const columns = buildColumns(roles, envId);
-  const header = ['role', 'enabled', ...columns].map(escapeCsv).join(',');
+  const header = ['role', 'enabled', ...columns.map(c => c.header)].map(escapeCsv).join(',');
   const rows = [header, ...roles.map(role => buildRoleRow(role, columns, envId))];
   return `${rows.join('\n')}\n`;
 }
@@ -238,12 +246,52 @@ function applyThreePartHeader(collectionMap, colName, actionName, suffix, rawVal
   return { ...collectionMap, [colName]: { ...col, smartActions: updatedSmartActions } };
 }
 
+/**
+ * Split a column header into its parts, keying off the trailing suffix instead of
+ * splitting on every colon: smart-action names routinely contain one (e.g.
+ * "Organisation:SAML SSO #2: Edit SSO config:trigger"), so a naive split
+ * over-slices them. The CRUD and smart-action suffix sets are disjoint, which
+ * makes the trailing segment enough to tell the two column shapes apart.
+ *
+ * A collection name containing a colon stays ambiguous in the smart-action case;
+ * we keep the export's convention that the collection is the first segment.
+ * @returns {{ collectionName: string, actionName?: string, suffix: string }|null}
+ */
+function parseHeader(header) {
+  const lastColon = header.lastIndexOf(':');
+  if (lastColon === -1) return null;
+  const suffix = header.slice(lastColon + 1);
+  const prefix = header.slice(0, lastColon);
+  if (!prefix) return null;
+
+  if (SMART_ACTION_SUFFIXES.includes(suffix)) {
+    const firstColon = prefix.indexOf(':');
+    if (firstColon === -1) return null;
+    return {
+      collectionName: prefix.slice(0, firstColon),
+      actionName: prefix.slice(firstColon + 1),
+      suffix,
+    };
+  }
+  // Not a smart-action suffix: the whole prefix is the collection name, colons
+  // included. Unknown suffixes fall through here and are rejected downstream
+  // with the more precise "Unknown permission column" message.
+  return { collectionName: prefix, suffix };
+}
+
 function applyHeader(collectionMap, header, rawValue) {
-  const parts = header.split(':');
-  if (parts.length === 2) return applyTwoPartHeader(collectionMap, parts[0], parts[1], rawValue);
-  if (parts.length === 3)
-    return applyThreePartHeader(collectionMap, parts[0], parts[1], parts[2], rawValue);
-  throw new Error(`Unrecognized CSV column "${header}".`);
+  const parsed = parseHeader(header);
+  if (!parsed) throw new Error(`Unrecognized CSV column "${header}".`);
+  if (parsed.actionName === undefined) {
+    return applyTwoPartHeader(collectionMap, parsed.collectionName, parsed.suffix, rawValue);
+  }
+  return applyThreePartHeader(
+    collectionMap,
+    parsed.collectionName,
+    parsed.actionName,
+    parsed.suffix,
+    rawValue,
+  );
 }
 
 function parseRow(headers, cells, envId) {

--- a/test/services/roles-csv.unit.test.js
+++ b/test/services/roles-csv.unit.test.js
@@ -74,6 +74,30 @@ describe('roles-csv formatWide', () => {
     expect(row.endsWith('true,false,true,false,true')).toBe(true);
   });
 
+  it('emits real cell values for a smart action whose name contains a colon', () => {
+    expect.assertions(2);
+    const collections = [
+      {
+        collectionName: 'Organisation',
+        smartActions: [
+          {
+            smartActionName: 'SAML SSO #2: Edit SSO config',
+            triggerEnabled: true,
+            approvalRequired: true,
+            userApprovalEnabled: false,
+            selfApprovalEnabled: false,
+          },
+        ],
+      },
+    ];
+    const csv = formatWide([role('R', [{ environmentId: 3, enabled: true, collections }])], 3);
+    const [header, row] = rows(csv);
+
+    expect(header).toContain('Organisation:SAML SSO #2: Edit SSO config:trigger');
+    // Regression: the colon in the action name used to make every cell read "false".
+    expect(row.endsWith('true,true,false,false,false')).toBe(true);
+  });
+
   it('hasConditions is false when no *Condition field is set', () => {
     expect.assertions(1);
     const collections = [
@@ -208,6 +232,36 @@ describe('roles-csv parseWide', () => {
 
     expect(parsed.enabled).toBe(true);
     expect(parsed.collections[0].browseEnabled).toBe(true);
+  });
+
+  it('round-trips a smart action whose name contains a colon (PRD-535 regression)', () => {
+    expect.assertions(2);
+    // Verbatim shape of the column `roles:export` produced for Spendesk, which
+    // `roles:apply` then rejected as an unrecognized column.
+    const csv = [
+      'role,enabled,Organisation:browse,Organisation:SAML SSO #2: Edit SSO config:trigger',
+      'Ops,true,true,true',
+    ].join('\n');
+    const [parsed] = parseWide(csv, '3');
+    const [collection] = parsed.collections;
+
+    expect(collection.browseEnabled).toBe(true);
+    expect(collection.smartActions).toStrictEqual([
+      {
+        smartActionName: 'SAML SSO #2: Edit SSO config',
+        triggerEnabled: true,
+        approvalRequired: false,
+        userApprovalEnabled: false,
+        selfApprovalEnabled: false,
+      },
+    ]);
+  });
+
+  it('keeps a colon in the collection name on a CRUD column', () => {
+    expect.assertions(1);
+    const csv = ['role,enabled,schema:orders:browse', 'Ops,true,true'].join('\n');
+
+    expect(parseWide(csv, '3')[0].collections[0].collectionName).toBe('schema:orders');
   });
 
   it('rejects an invalid boolean cell (write-safety: no silent coercion)', () => {


### PR DESCRIPTION
## Context

Reported by a customer (Spendesk) round-tripping the new roles commands: `forest roles:export` produced a CSV, and `forest roles:apply` on that same untouched file failed with

```
Error: Unrecognized CSV column "Organisation:SAML SSO #2: Edit SSO config:trigger".
```

The smart action exists and the export extracted it verbatim — the asymmetry was in the reader.

## Root cause

The export emits one column per smart action as `collection:action:suffix`. `applyHeader` read it back with a plain `split(':')` and only accepted 2 or 3 segments. A smart action whose own name contains a colon — here `SAML SSO #2: Edit SSO config` — yields 4 segments and falls through to the `Unrecognized CSV column` throw.

## The bug behind the bug

The export path was silently wrong too. `buildCellForColumn` re-split the header string it had just built; with 4 segments it missed both the 2- and 3-segment cases and hit the trailing `return 'false'`. **Every cell of such an action exported as `false`, regardless of the actual permissions.**

So had the parser not thrown, `roles:apply` would have silently revoked `trigger` on that action for every role. The error was acting as an accidental guard rail.

## Fix

- **Read path** — new `parseHeader()` keys off the *trailing* suffix instead of splitting on every colon. The CRUD (`browse/read/add/edit/delete/export`) and smart-action (`trigger/approvalRequired/userApproval/selfApproval/hasConditions`) suffix sets are disjoint, so the last segment is enough to tell the two column shapes apart; the action name is whatever sits between the collection and the suffix, colons included.
- **Write path** — `collectColumns` now returns structured descriptors (`{header, collectionName, actionName, suffix}`) instead of strings, so a header is never re-parsed to locate its value.

Side effect, for free: collection names containing a colon (schema-prefixed tables) now work on CRUD columns.

Known limitation, documented in a comment: a header where *both* the collection and the action contain a colon stays ambiguous, and keeps the export's convention that the collection is the first segment. Resolving it properly would mean passing the known collection list into `parseWide` (`roles:apply` has it via `fullRoles`) — out of scope here.

## Tests

3 new cases in `roles-csv.unit.test.js`: export cells for a colon-bearing action name, a verbatim round-trip of the Spendesk column, and a colon-bearing collection name on a CRUD column. Full `roles-csv` unit suite plus the 4 `roles:*` command suites pass (32 tests), lint clean.

Also verified end-to-end that export → apply on the Spendesk shape now yields **0 ops**, which was the customer's expectation.

## Note for support

The CSV the customer already exported is unusable as-is — the cells for that action read `false` while the real grants are likely `true`. They need to re-export with this fix rather than re-apply the file they have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix roles CSV parsing to support colons in smart-action names
> - Replaces naive `header.split(':')` logic in `collectColumns`, `buildCellForColumn`, and `applyHeader` with structured column descriptors and a `parseHeader` helper that uses the last colon to locate the trailing suffix.
> - Smart-action names containing colons are now correctly parsed by extracting `collectionName` from the first segment and `actionName` from the remainder, preserving internal colons.
> - Previously, smart actions with colons in their names would produce incorrect `false` cell values and could be misclassified or rejected during import.
> - Tests in [roles-csv.unit.test.js](https://github.com/ForestAdmin/toolbelt/pull/813/files#diff-0bc6d264f4b8f3c451b9301551fff5c8cec58650021b5527db779aa9b1e2825e) cover colon-containing smart-action round-trips and CRUD collection names with colons.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d73adad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->