### PR TITLE
feat(skills): install the Forest plugin on Claude Code / Codex, copy the skills for the rest

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "spinnies": "0.5.1",
     "stdout-stderr": "0.1.13",
     "superagent": "^10.3.0",
+    "tar": "^7.5.9",
     "tedious": "18.6.1",
     "uuid": "^11.1.1",
     "validate-npm-package-name": "3.0.0"

--- a/src/commands/skills/init.ts
+++ b/src/commands/skills/init.ts
@@ -94,7 +94,10 @@ export default class SkillsInitCommand extends AbstractCommand {
       {
         type: 'checkbox',
         name: 'chosen',
-        message: 'Which coding agent(s) do you use?',
+        // The hint lives in the message, not in inquirer's own one — that one is appended to the
+        // first render only and vanishes on the first keypress, right when it is needed most.
+        // Arrow keys move without selecting, so "press space" is the one thing users must know.
+        message: 'Which coding agent(s) do you use? (space to select, enter to confirm)',
         choices: ALL_AGENTS.map(agent => ({
           name: AGENT_LABELS[agent],
           value: agent,

--- a/src/commands/skills/init.ts
+++ b/src/commands/skills/init.ts
@@ -1,0 +1,68 @@
+import { Flags } from '@oclif/core';
+
+import AbstractCommand from '../../abstract-command';
+import {
+  AGENT_SKILL_DIRS,
+  FOREST_BLOCK,
+  contextFileFor,
+  fetchMarketplace,
+  installDocsMcp,
+  installSkills,
+  mergeBlock,
+  readManifest,
+  removeStaleSkillFiles,
+  skillDirEntries,
+  writeManifest,
+} from '../../services/skills/skills-manager';
+
+export default class SkillsInitCommand extends AbstractCommand {
+  static override description =
+    'Install the Forest skills into this repo so your coding agent (Claude Code / Codex) knows Forest — project-scoped, no marketplace add.';
+
+  static override flags = {
+    ref: Flags.string({ description: 'Marketplace version (git ref).', default: 'main' }),
+    force: Flags.boolean({ description: 'Overwrite existing skill files.', default: false }),
+  };
+
+  // Always set up both agents — the files for the one you don't use are inert, and this keeps
+  // the repo ready whichever coding agent a teammate opens it with.
+  private static readonly agents = ['claude', 'codex'];
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(SkillsInitCommand);
+    const { agents } = SkillsInitCommand;
+    const previous = readManifest(); // to prune Forest files that left the bundle on a re-install
+
+    this.logger.info(
+      `Fetching Forest skills from ${this.chalk.bold('ForestAdmin/ai-marketplace')}@${flags.ref}…`,
+    );
+    const { root: srcRoot, cleanup } = await fetchMarketplace(flags.ref);
+    try {
+      const skillFiles = agents.flatMap(agent => {
+        const written = installSkills(srcRoot, agent, flags.force);
+        const contextFile = contextFileFor(agent);
+        mergeBlock(contextFile, FOREST_BLOCK);
+        this.logger.success(`Forest skills installed for ${agent} → ${AGENT_SKILL_DIRS[agent]}`, {
+          lineColor: 'green',
+        });
+
+        return [...written, contextFile];
+      });
+
+      // Prune only Forest-managed skill files that were installed before and are no longer in the
+      // bundle (manifest-scoped) — user-added files in the skill dirs are left untouched.
+      if (previous) removeStaleSkillFiles(skillDirEntries(previous.files), skillFiles);
+
+      // Wire the Forest docs MCP (fetched from the marketplace's forest-docs plugin).
+      const files = [...skillFiles, installDocsMcp(srcRoot)];
+
+      writeManifest({ ref: flags.ref, installedAt: new Date().toISOString(), agents, files });
+
+      this.logger.info(
+        'Open this repo in Claude Code or Codex — it now knows Forest. Refresh later with `forest skills:update`.',
+      );
+    } finally {
+      cleanup();
+    }
+  }
+}

--- a/src/commands/skills/init.ts
+++ b/src/commands/skills/init.ts
@@ -39,7 +39,7 @@ export default class SkillsInitCommand extends AbstractCommand {
     const { root: srcRoot, cleanup } = await fetchMarketplace(flags.ref);
     try {
       const skillFiles = agents.flatMap(agent => {
-        const written = installSkills(srcRoot, agent, flags.force);
+        const written = installSkills(srcRoot, agent, flags.force, previous?.files ?? null);
         const contextFile = contextFileFor(agent);
         mergeBlock(contextFile, FOREST_BLOCK);
         this.logger.success(`Forest skills installed for ${agent} → ${AGENT_SKILL_DIRS[agent]}`, {

--- a/src/commands/skills/init.ts
+++ b/src/commands/skills/init.ts
@@ -8,7 +8,7 @@ import {
   ALL_AGENTS,
   MARKETPLACE_REPO,
   SKILLS_DIR,
-  contextFileFor,
+  contextFileGroups,
   detectAgents,
   fetchMarketplace,
   forestBlock,
@@ -55,15 +55,20 @@ export default class SkillsInitCommand extends AbstractCommand {
 
     const files = copyAgents.length ? await this.copySkills(flags.ref, flags.force) : [];
 
-    // Context files: tell the agent this repo is a Forest project, whichever route it came by.
-    const contextFiles = [...new Set(agents.map(contextFileFor))];
-    agents.forEach(agent => mergeBlock(contextFileFor(agent), forestBlock(agent)));
+    // Only what actually got set up: a plugin agent whose CLI is missing was skipped, so claiming
+    // it in the manifest would have `skills:update` refresh a plugin that was never installed, and
+    // its context file would tell the agent about a plugin it does not have.
+    const installed = [...pluginOk, ...copyAgents];
+    const groups = contextFileGroups(installed);
+    // One merged block per FILE, not per agent: AGENTS.md serves Codex, Cursor and OpenCode alike,
+    // and a second merge would replace the first instead of adding to it.
+    groups.forEach((groupAgents, file) => mergeBlock(file, forestBlock(groupAgents)));
 
     writeManifest({
       ref: flags.ref,
       installedAt: new Date().toISOString(),
-      agents,
-      files: [...files, ...contextFiles],
+      agents: installed,
+      files: [...files, ...groups.keys()],
     });
 
     this.logNextSteps(pluginOk, copyAgents);

--- a/src/commands/skills/init.ts
+++ b/src/commands/skills/init.ts
@@ -12,6 +12,8 @@ import {
   readManifest,
   removeStaleSkillFiles,
   skillDirEntries,
+  validateLocalMcp,
+  validateMarketplaceBundle,
   writeManifest,
 } from '../../services/skills/skills-manager';
 
@@ -33,11 +35,19 @@ export default class SkillsInitCommand extends AbstractCommand {
     const { agents } = SkillsInitCommand;
     const previous = readManifest(); // to prune Forest files that left the bundle on a re-install
 
+    // Fail fast BEFORE any disk mutation: a broken local .mcp.json would otherwise only surface
+    // in installDocsMcp, at the very end, leaving a half-applied install behind.
+    validateLocalMcp();
+
     this.logger.info(
       `Fetching Forest skills from ${this.chalk.bold('ForestAdmin/ai-marketplace')}@${flags.ref}…`,
     );
     const { root: srcRoot, cleanup } = await fetchMarketplace(flags.ref);
     try {
+      // Still before any write: the bundle must carry the docs MCP config, or the last step
+      // would fail with a raw ENOENT after skills/context files were already applied.
+      validateMarketplaceBundle(srcRoot, flags.ref);
+
       const skillFiles = agents.flatMap(agent => {
         const written = installSkills(srcRoot, agent, flags.force, previous?.files ?? null);
         const contextFile = contextFileFor(agent);

--- a/src/commands/skills/init.ts
+++ b/src/commands/skills/init.ts
@@ -1,78 +1,187 @@
+import type { Agent, PluginAgent } from '../../services/skills/skills-manager';
+
 import { Flags } from '@oclif/core';
 
 import AbstractCommand from '../../abstract-command';
 import {
-  AGENT_SKILL_DIRS,
-  FOREST_BLOCK,
+  AGENT_LABELS,
+  ALL_AGENTS,
+  MARKETPLACE_REPO,
+  SKILLS_DIR,
   contextFileFor,
+  detectAgents,
   fetchMarketplace,
-  installDocsMcp,
+  forestBlock,
+  hasPluginCli,
+  installPlugins,
   installSkills,
+  isPluginAgent,
   mergeBlock,
   readManifest,
   removeStaleSkillFiles,
   skillDirEntries,
-  validateLocalMcp,
-  validateMarketplaceBundle,
   writeManifest,
 } from '../../services/skills/skills-manager';
 
 export default class SkillsInitCommand extends AbstractCommand {
   static override description =
-    'Install the Forest skills into this repo so your coding agent (Claude Code / Codex) knows Forest — project-scoped, no marketplace add.';
+    'Give your coding agent the Forest skills: installs the Forest plugin (Claude Code, Codex) or copies the skills into the repo (Cursor, OpenCode, …).';
 
   static override flags = {
+    agent: Flags.string({
+      description: `Coding agent(s) to set up: ${ALL_AGENTS.join(
+        ', ',
+      )}. Repeatable. Skips the prompt — required in non-interactive runs.`,
+      multiple: true,
+      options: [...ALL_AGENTS],
+    }),
     ref: Flags.string({ description: 'Marketplace version (git ref).', default: 'main' }),
-    force: Flags.boolean({ description: 'Overwrite existing skill files.', default: false }),
+    force: Flags.boolean({
+      description: 'Overwrite skill files already installed by a previous run (copy route only).',
+      default: false,
+    }),
   };
-
-  // Always set up both agents — the files for the one you don't use are inert, and this keeps
-  // the repo ready whichever coding agent a teammate opens it with.
-  private static readonly agents = ['claude', 'codex'];
 
   async run(): Promise<void> {
     const { flags } = await this.parse(SkillsInitCommand);
-    const { agents } = SkillsInitCommand;
+    const agents = await this.resolveAgents(flags.agent as Agent[] | undefined);
+
+    const pluginAgents = agents.filter(isPluginAgent);
+    const copyAgents = agents.filter(agent => !isPluginAgent(agent));
+
+    // Plugin route first: it touches nothing in the repo beyond `.claude/settings.json`, so a
+    // failure here leaves the working tree as it was.
+    const pluginOk = pluginAgents.filter(agent => this.installPluginFor(agent, flags.ref));
+
+    const files = copyAgents.length ? await this.copySkills(flags.ref, flags.force) : [];
+
+    // Context files: tell the agent this repo is a Forest project, whichever route it came by.
+    const contextFiles = [...new Set(agents.map(contextFileFor))];
+    agents.forEach(agent => mergeBlock(contextFileFor(agent), forestBlock(agent)));
+
+    writeManifest({
+      ref: flags.ref,
+      installedAt: new Date().toISOString(),
+      agents,
+      files: [...files, ...contextFiles],
+    });
+
+    this.logNextSteps(pluginOk, copyAgents);
+  }
+
+  /** Explicit `--agent` wins; otherwise detect, and only ask when there's a terminal to ask in. */
+  private async resolveAgents(fromFlag?: Agent[]): Promise<Agent[]> {
+    if (fromFlag?.length) return [...new Set(fromFlag)];
+
+    const detected = detectAgents();
+    const { inquirer, process: proc } = this.context;
+    const interactive = proc?.stdout?.isTTY ?? process.stdout.isTTY;
+
+    if (!interactive) {
+      if (!detected.length) {
+        throw new Error(
+          `No coding agent detected and no --agent given. Re-run with --agent <${ALL_AGENTS.join(
+            '|',
+          )}>.`,
+        );
+      }
+      this.logger.info(`Detected ${detected.map(a => AGENT_LABELS[a]).join(', ')}.`);
+
+      return detected;
+    }
+
+    const { chosen } = await inquirer.prompt([
+      {
+        type: 'checkbox',
+        name: 'chosen',
+        message: 'Which coding agent(s) do you use?',
+        choices: ALL_AGENTS.map(agent => ({
+          name: AGENT_LABELS[agent],
+          value: agent,
+          checked: detected.includes(agent),
+        })),
+        validate: (picked: string[]) => picked.length > 0 || 'Pick at least one agent.',
+      },
+    ]);
+
+    return chosen;
+  }
+
+  /** Drive the agent's own plugin CLI. Returns false (and warns) when it can't be used. */
+  private installPluginFor(agent: PluginAgent, ref: string): boolean {
+    if (!hasPluginCli(agent)) {
+      this.logger.warn(
+        `${AGENT_LABELS[agent]} selected but its CLI isn't on your PATH — skipping. ` +
+          `Install it, then re-run \`forest skills:init --agent ${agent}\`.`,
+      );
+
+      return false;
+    }
+
+    const { installed, failed } = installPlugins(agent, ref);
+    if (installed.length) {
+      this.logger.success(
+        `${AGENT_LABELS[agent]}: installed the Forest plugin${
+          installed.length > 1 ? 's' : ''
+        } (${installed.join(', ')}).`,
+        { lineColor: 'green' },
+      );
+    }
+    if (failed.length) {
+      this.logger.warn(
+        `${AGENT_LABELS[agent]}: could not install ${failed.join(', ')}. ` +
+          `Retry by hand with \`${agent} plugin install <name>@forest-admin-ai\`.`,
+      );
+    }
+
+    return installed.length > 0;
+  }
+
+  /** Copy the curated skills into `.agents/skills/` for the agents that only read SKILL.md files. */
+  private async copySkills(ref: string, force: boolean): Promise<string[]> {
     const previous = readManifest(); // to prune Forest files that left the bundle on a re-install
 
-    // Fail fast BEFORE any disk mutation: a broken local .mcp.json would otherwise only surface
-    // in installDocsMcp, at the very end, leaving a half-applied install behind.
-    validateLocalMcp();
-
-    this.logger.info(
-      `Fetching Forest skills from ${this.chalk.bold('ForestAdmin/ai-marketplace')}@${flags.ref}…`,
-    );
-    const { root: srcRoot, cleanup } = await fetchMarketplace(flags.ref);
+    this.logger.info(`Fetching Forest skills from ${this.chalk.bold(MARKETPLACE_REPO)}@${ref}…`);
+    const { root: srcRoot, cleanup } = await fetchMarketplace(ref);
     try {
-      // Still before any write: the bundle must carry the docs MCP config, or the last step
-      // would fail with a raw ENOENT after skills/context files were already applied.
-      validateMarketplaceBundle(srcRoot, flags.ref);
-
-      const skillFiles = agents.flatMap(agent => {
-        const written = installSkills(srcRoot, agent, flags.force, previous?.files ?? null);
-        const contextFile = contextFileFor(agent);
-        mergeBlock(contextFile, FOREST_BLOCK);
-        this.logger.success(`Forest skills installed for ${agent} → ${AGENT_SKILL_DIRS[agent]}`, {
-          lineColor: 'green',
-        });
-
-        return [...written, contextFile];
-      });
+      const { written, skipped } = installSkills(srcRoot, force, previous?.files ?? null);
 
       // Prune only Forest-managed skill files that were installed before and are no longer in the
       // bundle (manifest-scoped) — user-added files in the skill dirs are left untouched.
-      if (previous) removeStaleSkillFiles(skillDirEntries(previous.files), skillFiles);
+      if (previous) removeStaleSkillFiles(skillDirEntries(previous.files), written);
 
-      // Wire the Forest docs MCP (fetched from the marketplace's forest-docs plugin).
-      const files = [...skillFiles, installDocsMcp(srcRoot)];
+      this.logger.success(`Forest skills copied to ${SKILLS_DIR}/`, { lineColor: 'green' });
+      if (skipped.length) {
+        this.logger.warn(
+          `Kept your own version of ${skipped.length} file(s) we've never written: ${skipped.join(
+            ', ',
+          )}. Delete them and re-run to take the Forest version.`,
+        );
+      }
 
-      writeManifest({ ref: flags.ref, installedAt: new Date().toISOString(), agents, files });
-
-      this.logger.info(
-        'Open this repo in Claude Code or Codex — it now knows Forest. Refresh later with `forest skills:update`.',
-      );
+      return written;
     } finally {
       cleanup();
+    }
+  }
+
+  private logNextSteps(pluginAgents: PluginAgent[], copyAgents: Agent[]): void {
+    if (pluginAgents.length) {
+      this.logger.info(
+        `Restart ${pluginAgents
+          .map(a => AGENT_LABELS[a])
+          .join(' / ')} to load the plugin — then try \`/forest:start\`.`,
+      );
+    }
+    if (pluginAgents.includes('claude')) {
+      this.logger.info(
+        'Commit `.claude/settings.json` so your teammates get the same plugin (they run `claude plugin install forest@forest-admin-ai` once).',
+      );
+    }
+    if (copyAgents.length) {
+      this.logger.info(
+        `Commit \`${SKILLS_DIR}/\` so your teammates get the skills at clone. Refresh later with \`forest skills:update\`.`,
+      );
     }
   }
 }

--- a/src/commands/skills/update.ts
+++ b/src/commands/skills/update.ts
@@ -11,6 +11,8 @@ import {
   readManifest,
   removeStaleSkillFiles,
   skillDirEntries,
+  validateLocalMcp,
+  validateMarketplaceBundle,
   writeManifest,
 } from '../../services/skills/skills-manager';
 
@@ -42,9 +44,26 @@ export default class SkillsUpdateCommand extends AbstractCommand {
 
     const { agents } = SkillsUpdateCommand;
 
+    // Fail fast BEFORE any disk mutation: a broken local .mcp.json would otherwise only surface
+    // in installDocsMcp, at the very end, leaving a half-applied refresh behind (same as init).
+    validateLocalMcp();
+
+    // An update targets the requested ref (default main) — but never silently: an install pinned
+    // to a tag/SHA jumping refs must be visible, and the way back must be obvious.
+    if (manifest.ref && manifest.ref !== flags.ref) {
+      this.logger.warn(
+        `Skills were installed from "${manifest.ref}"; updating to "${flags.ref}". ` +
+          `Pass ${this.chalk.bold(`--ref ${manifest.ref}`)} to stay pinned.`,
+      );
+    }
+
     this.logger.info(`Refreshing Forest skills from ForestAdmin/ai-marketplace@${flags.ref}…`);
     const { root: srcRoot, cleanup } = await fetchMarketplace(flags.ref);
     try {
+      // Still before any write: the bundle must carry the docs MCP config, or the last step
+      // would fail with a raw ENOENT after skills/context files were already refreshed.
+      validateMarketplaceBundle(srcRoot, flags.ref);
+
       // The managed skill files previously installed — candidates for stale-pruning.
       const oldSkillFiles = skillDirEntries(manifest.files);
 

--- a/src/commands/skills/update.ts
+++ b/src/commands/skills/update.ts
@@ -1,0 +1,76 @@
+import { Flags } from '@oclif/core';
+
+import AbstractCommand from '../../abstract-command';
+import {
+  FOREST_BLOCK,
+  contextFileFor,
+  fetchMarketplace,
+  installDocsMcp,
+  installSkills,
+  mergeBlock,
+  readManifest,
+  removeStaleSkillFiles,
+  skillDirEntries,
+  writeManifest,
+} from '../../services/skills/skills-manager';
+
+export default class SkillsUpdateCommand extends AbstractCommand {
+  static override description =
+    'Refresh the Forest skills in this repo from ForestAdmin/ai-marketplace (anti-drift). ' +
+    'Overwrites the managed skill files and prunes ones dropped upstream (git shows the diff); ' +
+    'files you added yourself inside the skill dirs are left untouched.';
+
+  static override flags = {
+    ref: Flags.string({ description: 'Marketplace version (git ref).', default: 'main' }),
+  };
+
+  // Always refresh both agents (matches skills:init) — avoids the class of bug where refreshing
+  // one agent treats the other agent's files as stale and deletes them.
+  private static readonly agents = ['claude', 'codex'];
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(SkillsUpdateCommand);
+
+    const manifest = readManifest();
+    if (!manifest) {
+      this.logger.error('No Forest skills found in this repo.');
+      this.logger.log(`help: run ${this.chalk.bold('forest skills:init')} first.`);
+      this.exit(1);
+
+      return;
+    }
+
+    const { agents } = SkillsUpdateCommand;
+
+    this.logger.info(`Refreshing Forest skills from ForestAdmin/ai-marketplace@${flags.ref}…`);
+    const { root: srcRoot, cleanup } = await fetchMarketplace(flags.ref);
+    try {
+      // The managed skill files previously installed — candidates for stale-pruning.
+      const oldSkillFiles = skillDirEntries(manifest.files);
+
+      const skillFiles = agents.flatMap(agent => {
+        const written = installSkills(srcRoot, agent, true); // force: managed files are Forest-owned
+        const contextFile = contextFileFor(agent);
+        mergeBlock(contextFile, FOREST_BLOCK); // refreshes only the Forest block; user content untouched
+
+        return [...written, contextFile];
+      });
+
+      // Deletions: managed skill files removed upstream are removed locally.
+      const removed = removeStaleSkillFiles(oldSkillFiles, skillFiles);
+
+      const files = [...skillFiles, installDocsMcp(srcRoot)];
+
+      writeManifest({ ref: flags.ref, installedAt: new Date().toISOString(), agents, files });
+
+      this.logger.success(
+        `Forest skills refreshed for ${agents.join(', ')} (${files.length} files, ${
+          removed.length
+        } removed).`,
+        { lineColor: 'green' },
+      );
+    } finally {
+      cleanup();
+    }
+  }
+}

--- a/src/commands/skills/update.ts
+++ b/src/commands/skills/update.ts
@@ -1,34 +1,36 @@
+import type { Agent, PluginAgent } from '../../services/skills/skills-manager';
+
 import { Flags } from '@oclif/core';
 
 import AbstractCommand from '../../abstract-command';
 import {
-  FOREST_BLOCK,
+  AGENT_LABELS,
+  MARKETPLACE_REPO,
+  SKILLS_DIR,
   contextFileFor,
   fetchMarketplace,
-  installDocsMcp,
+  forestBlock,
+  hasPluginCli,
   installSkills,
+  isPluginAgent,
   mergeBlock,
   readManifest,
   removeStaleSkillFiles,
   skillDirEntries,
-  validateLocalMcp,
-  validateMarketplaceBundle,
+  upgradePlugins,
   writeManifest,
 } from '../../services/skills/skills-manager';
 
 export default class SkillsUpdateCommand extends AbstractCommand {
   static override description =
-    'Refresh the Forest skills in this repo from ForestAdmin/ai-marketplace (anti-drift). ' +
-    'Overwrites the managed skill files and prunes ones dropped upstream (git shows the diff); ' +
-    'files you added yourself inside the skill dirs are left untouched.';
+    'Refresh what `forest skills:init` installed (anti-drift): re-installs the Forest plugin for ' +
+    'Claude Code / Codex, and re-copies the skills for the other agents — overwriting the managed ' +
+    'files and pruning what was dropped upstream (git shows the diff). Files you wrote yourself are ' +
+    'left untouched.';
 
   static override flags = {
     ref: Flags.string({ description: 'Marketplace version (git ref).', default: 'main' }),
   };
-
-  // Always refresh both agents (matches skills:init) — avoids the class of bug where refreshing
-  // one agent treats the other agent's files as stale and deletes them.
-  private static readonly agents = ['claude', 'codex'];
 
   async run(): Promise<void> {
     const { flags } = await this.parse(SkillsUpdateCommand);
@@ -42,12 +44,6 @@ export default class SkillsUpdateCommand extends AbstractCommand {
       return;
     }
 
-    const { agents } = SkillsUpdateCommand;
-
-    // Fail fast BEFORE any disk mutation: a broken local .mcp.json would otherwise only surface
-    // in installDocsMcp, at the very end, leaving a half-applied refresh behind (same as init).
-    validateLocalMcp();
-
     // An update targets the requested ref (default main) — but never silently: an install pinned
     // to a tag/SHA jumping refs must be visible, and the way back must be obvious.
     if (manifest.ref && manifest.ref !== flags.ref) {
@@ -57,37 +53,75 @@ export default class SkillsUpdateCommand extends AbstractCommand {
       );
     }
 
-    this.logger.info(`Refreshing Forest skills from ForestAdmin/ai-marketplace@${flags.ref}…`);
-    const { root: srcRoot, cleanup } = await fetchMarketplace(flags.ref);
+    // Refresh exactly the agents the install targeted: refreshing one agent must never treat
+    // another's files as stale. An older manifest without `agents` is treated as copy-only.
+    const agents = (manifest.agents ?? []) as Agent[];
+    const pluginAgents = agents.filter(isPluginAgent);
+    const copyAgents = agents.filter(agent => !isPluginAgent(agent));
+
+    pluginAgents.forEach(agent => this.upgradePluginFor(agent, flags.ref));
+
+    const files = copyAgents.length ? await this.refreshSkills(manifest.files, flags.ref) : [];
+
+    const contextFiles = [...new Set(agents.map(contextFileFor))];
+    agents.forEach(agent => mergeBlock(contextFileFor(agent), forestBlock(agent)));
+
+    writeManifest({
+      ref: flags.ref,
+      installedAt: new Date().toISOString(),
+      agents,
+      files: [...files, ...contextFiles],
+    });
+  }
+
+  private upgradePluginFor(agent: PluginAgent, ref: string): void {
+    if (!hasPluginCli(agent)) {
+      this.logger.warn(
+        `${AGENT_LABELS[agent]}: CLI not on your PATH — skipping its plugin refresh.`,
+      );
+
+      return;
+    }
+    const { installed, failed } = upgradePlugins(agent, ref);
+    if (installed.length) {
+      this.logger.success(
+        `${AGENT_LABELS[agent]}: Forest plugins refreshed (${installed.join(', ')}).`,
+        {
+          lineColor: 'green',
+        },
+      );
+    }
+    if (failed.length) {
+      this.logger.warn(`${AGENT_LABELS[agent]}: could not refresh ${failed.join(', ')}.`);
+    }
+  }
+
+  private async refreshSkills(previousFiles: string[], ref: string): Promise<string[]> {
+    this.logger.info(`Refreshing Forest skills from ${MARKETPLACE_REPO}@${ref}…`);
+    const { root: srcRoot, cleanup } = await fetchMarketplace(ref);
     try {
-      // Still before any write: the bundle must carry the docs MCP config, or the last step
-      // would fail with a raw ENOENT after skills/context files were already refreshed.
-      validateMarketplaceBundle(srcRoot, flags.ref);
-
       // The managed skill files previously installed — candidates for stale-pruning.
-      const oldSkillFiles = skillDirEntries(manifest.files);
-
-      const skillFiles = agents.flatMap(agent => {
-        const written = installSkills(srcRoot, agent, true); // force: managed files are Forest-owned
-        const contextFile = contextFileFor(agent);
-        mergeBlock(contextFile, FOREST_BLOCK); // refreshes only the Forest block; user content untouched
-
-        return [...written, contextFile];
-      });
+      const oldSkillFiles = skillDirEntries(previousFiles);
+      // force: managed files are Forest-owned. `previousFiles` still bounds what may be
+      // overwritten, so a same-named file the user wrote is preserved, not silently replaced.
+      const { written, skipped } = installSkills(srcRoot, true, previousFiles);
 
       // Deletions: managed skill files removed upstream are removed locally.
-      const removed = removeStaleSkillFiles(oldSkillFiles, skillFiles);
-
-      const files = [...skillFiles, installDocsMcp(srcRoot)];
-
-      writeManifest({ ref: flags.ref, installedAt: new Date().toISOString(), agents, files });
+      const removed = removeStaleSkillFiles(oldSkillFiles, written);
 
       this.logger.success(
-        `Forest skills refreshed for ${agents.join(', ')} (${files.length} files, ${
-          removed.length
-        } removed).`,
+        `Forest skills refreshed in ${SKILLS_DIR}/ (${written.length} files, ${removed.length} removed).`,
         { lineColor: 'green' },
       );
+      if (skipped.length) {
+        this.logger.warn(
+          `Kept your own version of ${skipped.length} file(s) we've never written: ${skipped.join(
+            ', ',
+          )}.`,
+        );
+      }
+
+      return written;
     } finally {
       cleanup();
     }

--- a/src/commands/skills/update.ts
+++ b/src/commands/skills/update.ts
@@ -7,7 +7,7 @@ import {
   AGENT_LABELS,
   MARKETPLACE_REPO,
   SKILLS_DIR,
-  contextFileFor,
+  contextFileGroups,
   fetchMarketplace,
   forestBlock,
   hasPluginCli,
@@ -54,8 +54,10 @@ export default class SkillsUpdateCommand extends AbstractCommand {
     }
 
     // Refresh exactly the agents the install targeted: refreshing one agent must never treat
-    // another's files as stale. An older manifest without `agents` is treated as copy-only.
-    const agents = (manifest.agents ?? []) as Agent[];
+    // another's files as stale. A manifest with no `agents` predates that field; it can only have
+    // come from a copy-route install, so treat it as one — reading it as "no agents" would refresh
+    // nothing AND rewrite the manifest without its files, orphaning every skill on disk.
+    const agents = (manifest.agents?.length ? manifest.agents : ['other']) as Agent[];
     const pluginAgents = agents.filter(isPluginAgent);
     const copyAgents = agents.filter(agent => !isPluginAgent(agent));
 
@@ -63,14 +65,15 @@ export default class SkillsUpdateCommand extends AbstractCommand {
 
     const files = copyAgents.length ? await this.refreshSkills(manifest.files, flags.ref) : [];
 
-    const contextFiles = [...new Set(agents.map(contextFileFor))];
-    agents.forEach(agent => mergeBlock(contextFileFor(agent), forestBlock(agent)));
+    // One merged block per FILE, not per agent — AGENTS.md serves Codex, Cursor and OpenCode.
+    const groups = contextFileGroups(agents);
+    groups.forEach((groupAgents, file) => mergeBlock(file, forestBlock(groupAgents)));
 
     writeManifest({
       ref: flags.ref,
       installedAt: new Date().toISOString(),
       agents,
-      files: [...files, ...contextFiles],
+      files: [...files, ...groups.keys()],
     });
   }
 

--- a/src/services/skills/skills-manager.ts
+++ b/src/services/skills/skills-manager.ts
@@ -14,8 +14,9 @@ import * as tar from 'tar';
  *   (`claude plugin …` / `codex plugin …`). They fetch, version, auto-update and wire the
  *   Forest docs MCP themselves, and the user gets the plugin's slash commands too. Nothing
  *   is copied into the repo.
- * - Agents that only discover `SKILL.md` files (Cursor, OpenCode, …) → we copy the curated
- *   skills into `.agents/skills/`, the cross-agent convention they all read.
+ * - Agents that only discover `SKILL.md` files (Cursor, OpenCode, …) → we copy the same
+ *   plugins' skills into `.agents/skills/`, the cross-agent convention they all read, so both
+ *   routes deliver the same set.
  *
  * The marketplace repo is PUBLIC → no auth needed for the fetch, and both plugin CLIs read
  * the same `.claude-plugin/marketplace.json` (verified against codex-cli 0.147.0), so one
@@ -25,16 +26,21 @@ import * as tar from 'tar';
 export const MARKETPLACE_REPO = 'ForestAdmin/ai-marketplace';
 export const MARKETPLACE_NAME = 'forest-admin-ai';
 
-// Which dev-facing skills we distribute into a client's repo on the COPY route. Curated on
-// purpose (explicit control over what ships; internal/test-only skills like deploy-heroku stay
-// out). Source path in the repo = `<plugin>/skills/<name>`.
-export const SKILL_SOURCES: { plugin: string; skills: string[] }[] = [
-  {
-    plugin: 'forest',
-    skills: ['boot-standalone-agent', 'layout', 'management', 'onboard', 'workflows'],
-  },
-  { plugin: 'forest-code', skills: ['forest-code', 'forest-legacy'] },
-];
+/**
+ * Which plugins the COPY route takes its skills from — ALL of their skills, discovered from the
+ * bundle rather than listed here.
+ *
+ * There used to be a hand-picked list of skill names. It made the two routes disagree: the plugin
+ * route installs whole plugins, so a name left out here still shipped there. Worse, the skills
+ * cross-reference each other — `onboard` hands the production step to `deploy-heroku`, which the
+ * list excluded — so copy-route users got an `onboard` skill pointing at something that was not
+ * installed. What ships is decided in the marketplace, by what a plugin contains; a second,
+ * divergent definition here can only drift.
+ *
+ * `forest-docs` is absent because it carries no skills (it is an MCP config, which only the plugin
+ * route can wire), and `forest-mcp` because it is data access, not developer help.
+ */
+export const SKILL_PLUGINS = ['forest', 'forest-code'];
 
 // Which plugins we install on the PLUGIN route. These three are what "knowing Forest" means:
 // how to build a back-office (`forest`), how to write agent code (`forest-code`), and how to look
@@ -176,6 +182,17 @@ function listFiles(dir: string): string[] {
   });
 }
 
+/** The skill directories a plugin ships: every subdirectory holding a SKILL.md. A symlinked entry
+ *  is ignored — copyDir would refuse it anyway, and it must not fabricate a dest dir. */
+function listSkillDirs(skillsRoot: string): string[] {
+  return fs
+    .readdirSync(skillsRoot, { withFileTypes: true })
+    .filter(
+      entry => entry.isDirectory() && fs.existsSync(path.join(skillsRoot, entry.name, 'SKILL.md')),
+    )
+    .map(entry => entry.name);
+}
+
 /** What a copy produced: files we wrote, and files we refused to overwrite because the user
  *  wrote them (same path as a bundle file, but never managed by us). */
 export type CopyResult = { written: string[]; skipped: string[] };
@@ -242,17 +259,20 @@ export function installSkills(
   const isManaged = (file: string) => previouslyManaged.has(normalizePath(file));
 
   return mergeCopy(
-    SKILL_SOURCES.flatMap(({ plugin, skills }) =>
-      skills.map(skill => {
-        const src = path.join(srcRoot, plugin, 'skills', skill);
+    SKILL_PLUGINS.flatMap(plugin => {
+      const skillsRoot = path.join(srcRoot, plugin, 'skills');
+      // Fail loud on a plugin that carries no skills at all rather than reporting a misleading
+      // partial success — at that point the marketplace layout has changed under us.
+      if (!fs.existsSync(skillsRoot)) {
+        throw new Error(
+          `Plugin "${plugin}" has no skills/ directory in the marketplace (expected ${plugin}/skills). ` +
+            'The marketplace layout changed — check the --ref value.',
+        );
+      }
+
+      return listSkillDirs(skillsRoot).map(skill => {
+        const src = path.join(skillsRoot, skill);
         const dest = path.join(SKILLS_DIR, skill);
-        // Fail loud on a missing curated skill rather than reporting a misleading partial success.
-        if (!fs.existsSync(src)) {
-          throw new Error(
-            `Skill "${skill}" is missing from the marketplace (expected ${plugin}/skills/${skill}). ` +
-              'The curated SKILL_SOURCES list is out of sync with this marketplace ref.',
-          );
-        }
         if (fs.existsSync(dest)) {
           if (!fs.lstatSync(dest).isDirectory()) {
             // A stray non-directory where a skill dir belongs → replace it wholesale.
@@ -278,8 +298,8 @@ export function installSkills(
         }
 
         return copyDir(src, dest, file => !previousFiles || isManaged(file));
-      }),
-    ),
+      });
+    }),
   );
 }
 

--- a/src/services/skills/skills-manager.ts
+++ b/src/services/skills/skills-manager.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -5,19 +6,28 @@ import superagent from 'superagent';
 import * as tar from 'tar';
 
 /**
- * Shared logic for `skills:init` / `skills:update`: fetch the public
- * ForestAdmin/ai-marketplace repo, copy the Forest skill bundles into a project
- * (project-scoped, for Claude Code and Codex), merge a Forest block into
- * CLAUDE.md/AGENTS.md, wire the Forest docs MCP, and track it in a manifest.
+ * Shared logic for `skills:init` / `skills:update`.
  *
- * The marketplace repo is PUBLIC → no auth needed for the fetch.
+ * Two distribution routes, because coding agents split in two families:
+ *
+ * - Agents with a native plugin system (Claude Code, Codex) → we drive THEIR CLI
+ *   (`claude plugin …` / `codex plugin …`). They fetch, version, auto-update and wire the
+ *   Forest docs MCP themselves, and the user gets the plugin's slash commands too. Nothing
+ *   is copied into the repo.
+ * - Agents that only discover `SKILL.md` files (Cursor, OpenCode, …) → we copy the curated
+ *   skills into `.agents/skills/`, the cross-agent convention they all read.
+ *
+ * The marketplace repo is PUBLIC → no auth needed for the fetch, and both plugin CLIs read
+ * the same `.claude-plugin/marketplace.json` (verified against codex-cli 0.147.0), so one
+ * catalog serves every agent.
  */
 
 export const MARKETPLACE_REPO = 'ForestAdmin/ai-marketplace';
+export const MARKETPLACE_NAME = 'forest-admin-ai';
 
-// Which dev-facing skills we distribute into a client's repo. Curated on purpose
-// (explicit control over what ships; internal/test-only skills like deploy-heroku
-// stay out). Source path in the repo = `<plugin>/skills/<name>`.
+// Which dev-facing skills we distribute into a client's repo on the COPY route. Curated on
+// purpose (explicit control over what ships; internal/test-only skills like deploy-heroku stay
+// out). Source path in the repo = `<plugin>/skills/<name>`.
 export const SKILL_SOURCES: { plugin: string; skills: string[] }[] = [
   {
     plugin: 'forest',
@@ -26,34 +36,73 @@ export const SKILL_SOURCES: { plugin: string; skills: string[] }[] = [
   { plugin: 'forest-code', skills: ['forest-code', 'forest-legacy'] },
 ];
 
-// Per-agent project-scoped skill dir (both are auto-discovered; no marketplace needed).
-export const AGENT_SKILL_DIRS: Record<string, string> = {
-  claude: '.claude/skills',
-  codex: '.agents/skills',
+// Which plugins we install on the PLUGIN route. `forest-mcp` is deliberately out: it needs the
+// user's Forest credentials at install time (authPolicy ON_INSTALL), so it is an opt-in.
+export const FOREST_PLUGINS = ['forest', 'forest-code', 'forest-docs'];
+
+/**
+ * The single skills dir on the copy route. `.agents/skills/` is the cross-agent convention:
+ * Cursor and OpenCode both read it (alongside their own `.cursor/`, `.opencode/`), and so does
+ * Codex. Claude Code is the one agent that does NOT read it — it reads `.claude/skills/` — but
+ * it is served by the plugin route, so a second copy would only duplicate its skills.
+ */
+export const SKILLS_DIR = '.agents/skills';
+
+/** Agents served by driving their own plugin CLI. */
+export const PLUGIN_AGENTS = ['claude', 'codex'] as const;
+/** Agents served by copying SKILL.md files into SKILLS_DIR. */
+export const COPY_AGENTS = ['cursor', 'opencode', 'other'] as const;
+export const ALL_AGENTS = [...PLUGIN_AGENTS, ...COPY_AGENTS] as const;
+
+export type PluginAgent = (typeof PLUGIN_AGENTS)[number];
+export type Agent = (typeof ALL_AGENTS)[number];
+
+export const AGENT_LABELS: Record<Agent, string> = {
+  claude: 'Claude Code',
+  codex: 'Codex',
+  cursor: 'Cursor',
+  opencode: 'OpenCode',
+  other: 'Other (any SKILL.md-compatible agent)',
 };
+
+export const isPluginAgent = (agent: string): agent is PluginAgent =>
+  (PLUGIN_AGENTS as readonly string[]).includes(agent);
 
 export const MANIFEST_PATH = '.forest/skills-manifest.json';
 
 const BLOCK_BEGIN = '<!-- forest:begin -->';
 const BLOCK_END = '<!-- forest:end -->';
 
-// The Forest block merged into CLAUDE.md / AGENTS.md (project context for the agent).
-export const FOREST_BLOCK = [
-  'This project uses **Forest Admin**. Skills to build/customize it are installed in',
-  '`.claude/skills/` (Claude Code) and `.agents/skills/` (Codex) — e.g. `/forest-code`, `/forest:layout`.',
-  'Forest documentation is searchable via the `forest-docs` MCP server.',
-].join('\n');
-
-export type Manifest = { ref: string; installedAt: string; agents: string[]; files: string[] };
-
-export function contextFileFor(agent: string): string {
+/** Context files, per agent. AGENTS.md is the cross-agent standard (Codex, Cursor, OpenCode). */
+export function contextFileFor(agent: Agent): string {
   return agent === 'claude' ? 'CLAUDE.md' : 'AGENTS.md';
 }
+
+/** The Forest block merged into CLAUDE.md / AGENTS.md, worded for the route actually applied. */
+export function forestBlock(agent: Agent): string {
+  const where = isPluginAgent(agent)
+    ? 'available through the `forest` plugin — e.g. `/forest:start`, `/forest:layout`, `/forest-code`'
+    : `installed in \`${SKILLS_DIR}/\` — e.g. \`layout\`, \`onboard\`, \`forest-code\``;
+
+  return [
+    `This project uses **Forest Admin**. Skills to build and customize it are ${where}.`,
+    'Forest documentation is searchable via the `forest-docs` MCP server.',
+  ].join('\n');
+}
+
+export type Manifest = {
+  ref: string;
+  installedAt: string;
+  agents: string[];
+  files: string[];
+};
 
 /**
  * Download + extract the marketplace tarball at `ref`. Returns the extracted root dir and a
  * `cleanup` the caller must run (in a finally) to delete the temp dir — otherwise every
  * init/update leaks a full copy of the marketplace under the OS temp dir.
+ *
+ * Only the copy route needs this: the plugin CLIs do their own fetching.
  */
 export async function fetchMarketplace(
   ref = 'main',
@@ -124,96 +173,129 @@ function listFiles(dir: string): string[] {
   });
 }
 
-/** Recursively copy a directory, returning the list of files written. Never follows a symlink at
- *  the destination — it's replaced — so a planted link can't redirect a write outside the project. */
-export function copyDir(src: string, dest: string): string[] {
+/** What a copy produced: files we wrote, and files we refused to overwrite because the user
+ *  wrote them (same path as a bundle file, but never managed by us). */
+export type CopyResult = { written: string[]; skipped: string[] };
+
+const emptyCopy = (): CopyResult => ({ written: [], skipped: [] });
+
+const mergeCopy = (results: CopyResult[]): CopyResult => ({
+  written: results.flatMap(r => r.written),
+  skipped: results.flatMap(r => r.skipped),
+});
+
+/**
+ * Recursively copy a directory. Never follows a symlink at the destination — it's replaced — so a
+ * planted link can't redirect a write outside the project.
+ *
+ * `isManaged` decides whether an EXISTING destination file may be overwritten. A file that is on
+ * disk but was never written by us is user-authored content that happens to share a bundle path:
+ * we leave it alone and report it, rather than silently destroying it.
+ */
+export function copyDir(
+  src: string,
+  dest: string,
+  isManaged: (file: string) => boolean = () => true,
+): CopyResult {
   // Refuse a source dir that is itself a symlink — a crafted marketplace could point a curated
   // skill path at an absolute host dir and have readdirSync follow it, copying local files in.
-  if (isSymlink(src)) return [];
+  if (isSymlink(src)) return emptyCopy();
   if (isSymlink(dest)) fs.rmSync(dest);
   fs.mkdirSync(dest, { recursive: true });
 
-  return fs.readdirSync(src, { withFileTypes: true }).flatMap(entry => {
-    const from = path.join(src, entry.name);
-    const to = path.join(dest, entry.name);
-    // Never follow a symlink in the source bundle (a crafted marketplace could point one at an
-    // arbitrary file on the user's machine and have us copy its contents in).
-    if (entry.isSymbolicLink()) return [];
-    if (entry.isDirectory()) return copyDir(from, to);
-    if (isSymlink(to)) fs.rmSync(to);
-    fs.copyFileSync(from, to);
+  return mergeCopy(
+    fs.readdirSync(src, { withFileTypes: true }).map(entry => {
+      const from = path.join(src, entry.name);
+      const to = path.join(dest, entry.name);
+      // Never follow a symlink in the source bundle (a crafted marketplace could point one at an
+      // arbitrary file on the user's machine and have us copy its contents in).
+      if (entry.isSymbolicLink()) return emptyCopy();
+      if (entry.isDirectory()) return copyDir(from, to, isManaged);
+      // Existing file we never wrote → the user's. Don't clobber it.
+      if (fs.existsSync(to) && !isSymlink(to) && !isManaged(to))
+        return { written: [], skipped: [to] };
+      if (isSymlink(to)) fs.rmSync(to);
+      fs.copyFileSync(from, to);
 
-    return [to];
-  });
-}
-
-/** Copy the skill bundles from the extracted repo into one agent's skills dir.
- *  `previousFiles` is the file list from the previous manifest (`null` on a first run): on the
- *  no-force skip path it bounds what we may claim as managed — we never claim a file we did not
- *  write ourselves on some run, or a later prune would delete user-authored content. */
-export function installSkills(
-  srcRoot: string,
-  agent: string,
-  force: boolean,
-  previousFiles: string[] | null,
-): string[] {
-  const targetBase = AGENT_SKILL_DIRS[agent];
-  const previouslyManaged = new Set((previousFiles ?? []).map(normalizePath));
-
-  return SKILL_SOURCES.flatMap(({ plugin, skills }) =>
-    skills.flatMap(skill => {
-      const src = path.join(srcRoot, plugin, 'skills', skill);
-      const dest = path.join(targetBase, skill);
-      // Fail loud on a missing curated skill rather than reporting a misleading partial success.
-      if (!fs.existsSync(src)) {
-        throw new Error(
-          `Skill "${skill}" is missing from the marketplace (expected ${plugin}/skills/${skill}). ` +
-            'The curated SKILL_SOURCES list is out of sync with this marketplace ref.',
-        );
-      }
-      if (fs.existsSync(dest)) {
-        if (!fs.lstatSync(dest).isDirectory()) {
-          // A stray non-directory where a skill dir belongs → replace it wholesale.
-          fs.rmSync(dest, { recursive: true, force: true });
-        } else if (!force) {
-          // Installed and no --force: nothing is written here, so only carry over files that are
-          // BOTH in the incoming bundle (derived from source, mapped to dest — never the actual
-          // dir contents, which may include user-added files) AND in the previous manifest (proof
-          // a past run wrote them). A dir that pre-existed the first run was authored by the user:
-          // claiming its files would mark them managed and a later refresh would prune them.
-          return listFiles(src)
-            .map(f => path.join(dest, path.relative(src, f)))
-            .filter(f => previouslyManaged.has(normalizePath(f)));
-        }
-        // With --force on an existing dir we fall through and overlay the incoming bundle on top.
-        // We deliberately do NOT delete the dir, so user-added files survive; pruning of
-        // Forest-owned files that left the bundle is the command's job (removeStaleSkillFiles,
-        // manifest-scoped) — never a blind rm here.
-      }
-
-      return copyDir(src, dest);
+      return { written: [to], skipped: [] };
     }),
   );
 }
 
-/** From a manifest file list, the entries that live under the skill dirs (normalized for Windows,
- *  where manifest paths use backslashes). These are the candidates for stale-pruning on a refresh. */
-export function skillDirEntries(files: string[]): string[] {
-  const bases = Object.values(AGENT_SKILL_DIRS);
+/**
+ * Copy the curated skill bundles from the extracted repo into `SKILLS_DIR`.
+ *
+ * `previousFiles` is the file list from the previous manifest (`null` on a first run). It bounds
+ * what we may claim as managed AND what we may overwrite: a file we never wrote is the user's,
+ * both on the skip path (claiming it would let a later prune delete it) and on the force path
+ * (overwriting it would destroy it outright).
+ */
+export function installSkills(
+  srcRoot: string,
+  force: boolean,
+  previousFiles: string[] | null,
+): CopyResult {
+  const previouslyManaged = new Set((previousFiles ?? []).map(normalizePath));
+  const isManaged = (file: string) => previouslyManaged.has(normalizePath(file));
 
-  return files.filter(file => bases.some(dir => file.replace(/\\/g, '/').startsWith(dir)));
+  return mergeCopy(
+    SKILL_SOURCES.flatMap(({ plugin, skills }) =>
+      skills.map(skill => {
+        const src = path.join(srcRoot, plugin, 'skills', skill);
+        const dest = path.join(SKILLS_DIR, skill);
+        // Fail loud on a missing curated skill rather than reporting a misleading partial success.
+        if (!fs.existsSync(src)) {
+          throw new Error(
+            `Skill "${skill}" is missing from the marketplace (expected ${plugin}/skills/${skill}). ` +
+              'The curated SKILL_SOURCES list is out of sync with this marketplace ref.',
+          );
+        }
+        if (fs.existsSync(dest)) {
+          if (!fs.lstatSync(dest).isDirectory()) {
+            // A stray non-directory where a skill dir belongs → replace it wholesale.
+            fs.rmSync(dest, { recursive: true, force: true });
+          } else if (!force) {
+            // Installed and no --force: nothing is written here, so only carry over files that are
+            // BOTH in the incoming bundle (derived from source, mapped to dest — never the actual
+            // dir contents, which may include user-added files) AND in the previous manifest (proof
+            // a past run wrote them). A dir that pre-existed the first run was authored by the user:
+            // claiming its files would mark them managed and a later refresh would prune them.
+            return {
+              written: listFiles(src)
+                .map(f => path.join(dest, path.relative(src, f)))
+                .filter(isManaged),
+              skipped: [],
+            };
+          }
+          // With --force on an existing dir we fall through and overlay the incoming bundle on top.
+          // We deliberately do NOT delete the dir, so user-added files survive; pruning of
+          // Forest-owned files that left the bundle is the command's job (removeStaleSkillFiles,
+          // manifest-scoped) — never a blind rm here. `isManaged` still shields user-authored
+          // files that collide with a bundle path.
+        }
+
+        return copyDir(src, dest, file => !previousFiles || isManaged(file));
+      }),
+    ),
+  );
 }
 
-/** Guard a deletion candidate: it must resolve *inside* the skill dirs (blocks `..` traversal and
+/** From a manifest file list, the entries that live under the skills dir (normalized for Windows,
+ *  where manifest paths use backslashes). These are the candidates for stale-pruning on a refresh. */
+export function skillDirEntries(files: string[]): string[] {
+  return files.filter(file => normalizePath(file).startsWith(SKILLS_DIR));
+}
+
+/** Guard a deletion candidate: it must resolve *inside* the skills dir (blocks `..` traversal and
  *  absolute paths) and its real location must stay there too (blocks a symlinked ancestor from
  *  redirecting the delete outside the project). A crafted manifest entry must never widen rmSync. */
 function isWithinSkillDirs(file: string): boolean {
-  const skillBases = Object.values(AGENT_SKILL_DIRS).map(dir => path.resolve(dir));
+  const base = path.resolve(SKILLS_DIR);
   const resolved = path.resolve(file);
-  // Textual containment: reject `..` traversal and absolute paths outside the skill dirs.
-  if (!skillBases.some(base => resolved.startsWith(base + path.sep))) return false;
+  // Textual containment: reject `..` traversal and absolute paths outside the skills dir.
+  if (!resolved.startsWith(base + path.sep)) return false;
   // Real containment against the PROJECT root (not the skill dir's symlink target): a symlinked
-  // skill dir pointing outside the project must be rejected, never whitelisted via its target.
+  // skills dir pointing outside the project must be rejected, never whitelisted via its target.
   try {
     const projectRoot = fs.realpathSync(process.cwd());
     const realParent = fs.realpathSync(path.dirname(file));
@@ -227,7 +309,7 @@ function isWithinSkillDirs(file: string): boolean {
 /**
  * Delete managed skill files that existed before but are no longer produced (removed upstream).
  * Set-diff of previous vs current, deleting only paths that still exist *and* are safely contained
- * within the skill dirs. Returns what it removed.
+ * within the skills dir. Returns what it removed.
  */
 export function removeStaleSkillFiles(previousFiles: string[], currentFiles: string[]): string[] {
   // Compare on forward-slash-normalized paths so a manifest written on one OS (e.g. Unix `/`)
@@ -258,71 +340,109 @@ export function mergeBlock(file: string, content: string): void {
   fs.writeFileSync(file, next);
 }
 
-/**
- * Fail-fast preflight for the local `.mcp.json`: run it BEFORE any disk mutation. `installDocsMcp`
- * throws on an unparseable local config (on purpose, to protect user content), but it runs last —
- * without this check the failure would surface after skills were installed and the context files
- * merged, leaving a half-applied state with no manifest rewrite.
- */
-export function validateLocalMcp(): void {
-  const target = '.mcp.json';
-  // A symlinked .mcp.json is replaced (never read) at install time, so its target's content is
-  // irrelevant here. Same for an absent file.
-  if (isSymlink(target) || !fs.existsSync(target)) return;
-  try {
-    JSON.parse(fs.readFileSync(target, 'utf8'));
-  } catch {
-    throw new Error(
-      `Cannot parse existing ${target}; aborting before any changes so it isn't overwritten. ` +
-        'Fix or remove it, then re-run.',
-    );
-  }
+// ---------------------------------------------------------------------------------------------
+// Plugin route: drive the agent's own CLI
+// ---------------------------------------------------------------------------------------------
+
+const PLUGIN_BINS: Record<PluginAgent, string> = { claude: 'claude', codex: 'codex' };
+
+/** Run an agent CLI and return its outcome. Never throws on a non-zero exit — callers decide. */
+function runCli(bin: string, args: string[]): { ok: boolean; output: string } {
+  const res = spawnSync(bin, args, { encoding: 'utf8' });
+  const output = `${res.stdout ?? ''}${res.stderr ?? ''}`.trim();
+  if (res.error) return { ok: false, output: res.error.message };
+
+  return { ok: res.status === 0, output };
+}
+
+/** True if the agent's CLI is installed and runnable. */
+export function hasPluginCli(agent: PluginAgent): boolean {
+  return runCli(PLUGIN_BINS[agent], ['--version']).ok;
 }
 
 /**
- * Fail-fast preflight for the fetched marketplace bundle: run it after the fetch but BEFORE any
- * write. The docs MCP config is read last by `installDocsMcp`; a bundle missing it would otherwise
- * die on a raw ENOENT after everything else was already applied.
+ * Marketplace source for an agent CLI. Both read the same `.claude-plugin/marketplace.json`.
+ * A non-default ref is passed the way each CLI accepts it: Codex has `--ref`, Claude Code takes
+ * it appended to a full git URL (`....git#ref`) since the `owner/repo` shorthand has no ref form.
  */
-export function validateMarketplaceBundle(srcRoot: string, ref: string): void {
-  if (!fs.existsSync(path.join(srcRoot, 'forest-docs', '.mcp.json'))) {
-    throw new Error(
-      `The Forest marketplace at ref "${ref}" has no forest-docs/.mcp.json (docs MCP config). ` +
-        'Nothing was changed. Check the --ref value or try again with the default ref.',
-    );
+function marketplaceAddArgs(agent: PluginAgent, ref: string): string[] {
+  if (agent === 'codex') {
+    return [
+      'plugin',
+      'marketplace',
+      'add',
+      MARKETPLACE_REPO,
+      ...(ref === 'main' ? [] : ['--ref', ref]),
+    ];
   }
+  const source =
+    ref === 'main' ? MARKETPLACE_REPO : `https://github.com/${MARKETPLACE_REPO}.git#${ref}`;
+
+  return ['plugin', 'marketplace', 'add', source, '--scope', 'project'];
 }
 
 /**
- * Wire the Forest docs MCP (Mintlify, https://docs.forest.app/mcp — static, read-only, NO secret)
- * by reading the source of truth `forest-docs/.mcp.json` from the fetched marketplace and merging
- * its `mcpServers` into the project's `.mcp.json` (preserving any existing servers the user has).
+ * `install` on Claude Code (project scope → the plugin is declared in `.claude/settings.json`,
+ * which the team commits), `add` on Codex (user scope only — its CLI has no project scope).
  */
-export function installDocsMcp(srcRoot: string): string {
-  const incoming = JSON.parse(
-    fs.readFileSync(path.join(srcRoot, 'forest-docs', '.mcp.json'), 'utf8'),
-  );
-  const target = '.mcp.json';
-  replaceSymlink(target); // never read/write through a symlinked .mcp.json
-  let current: { mcpServers?: Record<string, unknown> } = { mcpServers: {} };
-  if (fs.existsSync(target)) {
-    try {
-      const parsed = JSON.parse(fs.readFileSync(target, 'utf8'));
-      // Valid JSON that isn't a plain object (null, array, scalar) → treat as empty, don't crash.
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        current = parsed as { mcpServers?: Record<string, unknown> };
-      }
-    } catch {
-      // Don't clobber a user-authored (but unparseable) config with an empty one.
-      throw new Error(
-        `Cannot parse existing ${target}; aborting so it isn't overwritten. Fix or remove it, then re-run.`,
-      );
-    }
-  }
-  current.mcpServers = { ...(current.mcpServers || {}), ...(incoming.mcpServers || {}) };
-  fs.writeFileSync(target, `${JSON.stringify(current, null, 2)}\n`);
+function pluginInstallArgs(agent: PluginAgent, plugin: string): string[] {
+  return agent === 'codex'
+    ? ['plugin', 'add', `${plugin}@${MARKETPLACE_NAME}`, '--json']
+    : ['plugin', 'install', `${plugin}@${MARKETPLACE_NAME}`, '--scope', 'project'];
+}
 
-  return target;
+export type PluginInstallResult = { agent: PluginAgent; installed: string[]; failed: string[] };
+
+/**
+ * Register the Forest marketplace with the agent's CLI and install the Forest plugins.
+ * Throws when the marketplace cannot be added at all (nothing else can work); a single plugin
+ * that fails to install is reported, not fatal — the others are still worth having.
+ */
+export function installPlugins(agent: PluginAgent, ref = 'main'): PluginInstallResult {
+  const bin = PLUGIN_BINS[agent];
+  const added = runCli(bin, marketplaceAddArgs(agent, ref));
+  if (!added.ok) {
+    throw new Error(
+      `\`${bin} plugin marketplace add\` failed: ${added.output || 'unknown error'}. ` +
+        'Nothing was changed for this agent.',
+    );
+  }
+
+  const installed: string[] = [];
+  const failed: string[] = [];
+  FOREST_PLUGINS.forEach(plugin => {
+    if (runCli(bin, pluginInstallArgs(agent, plugin)).ok) installed.push(plugin);
+    else failed.push(plugin);
+  });
+
+  return { agent, installed, failed };
+}
+
+/** Refresh already-installed plugins (the plugin-route equivalent of re-copying files). */
+export function upgradePlugins(agent: PluginAgent, ref = 'main'): PluginInstallResult {
+  // Both CLIs are idempotent on add/install, and re-running them is the one path that works the
+  // same whether the plugin is present, stale, or was removed by hand.
+  return installPlugins(agent, ref);
+}
+
+// ---------------------------------------------------------------------------------------------
+// Agent detection
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * Best-effort guess of which agents this repo/machine uses, so the prompt comes pre-checked and
+ * `--agent` stays optional in scripted runs. A missing signal is not an error: the user can
+ * always tick a box or pass the flag.
+ */
+export function detectAgents(): Agent[] {
+  const detected: Agent[] = [];
+  if (fs.existsSync('.claude') || fs.existsSync('CLAUDE.md') || hasPluginCli('claude'))
+    detected.push('claude');
+  if (fs.existsSync('.codex') || hasPluginCli('codex')) detected.push('codex');
+  if (fs.existsSync('.cursor')) detected.push('cursor');
+  if (fs.existsSync('.opencode') || fs.existsSync('opencode.json')) detected.push('opencode');
+
+  return detected;
 }
 
 export function readManifest(): Manifest | null {

--- a/src/services/skills/skills-manager.ts
+++ b/src/services/skills/skills-manager.ts
@@ -429,20 +429,33 @@ export function upgradePlugins(agent: PluginAgent, ref = 'main'): PluginInstallR
 // Agent detection
 // ---------------------------------------------------------------------------------------------
 
+/** Marks an agent leaves in a repo it is actually used on. */
+const REPO_SIGNALS: Record<Agent, string[]> = {
+  claude: ['.claude', 'CLAUDE.md'],
+  codex: ['.codex'],
+  cursor: ['.cursor', '.cursorrules'],
+  opencode: ['.opencode', 'opencode.json'],
+  other: [],
+};
+
 /**
- * Best-effort guess of which agents this repo/machine uses, so the prompt comes pre-checked and
- * `--agent` stays optional in scripted runs. A missing signal is not an error: the user can
- * always tick a box or pass the flag.
+ * Best-effort guess of which agents THIS REPO uses, so the prompt comes pre-checked and `--agent`
+ * stays optional in scripted runs. A missing signal is not an error: the user can always tick a
+ * box or pass the flag.
+ *
+ * Repo signals win over an installed binary, and deliberately so: a developer who has every agent
+ * CLI on their machine would otherwise get all of them pre-checked in every repo, and confirming
+ * the prompt would install plugins they never asked for. The PATH is consulted only when the repo
+ * says nothing at all — the fresh-project case (`npx create-forest`), where "what you have
+ * installed" is the only signal there is.
  */
 export function detectAgents(): Agent[] {
-  const detected: Agent[] = [];
-  if (fs.existsSync('.claude') || fs.existsSync('CLAUDE.md') || hasPluginCli('claude'))
-    detected.push('claude');
-  if (fs.existsSync('.codex') || hasPluginCli('codex')) detected.push('codex');
-  if (fs.existsSync('.cursor')) detected.push('cursor');
-  if (fs.existsSync('.opencode') || fs.existsSync('opencode.json')) detected.push('opencode');
+  const fromRepo = (ALL_AGENTS as readonly Agent[]).filter(agent =>
+    REPO_SIGNALS[agent].some(mark => fs.existsSync(mark)),
+  );
+  if (fromRepo.length) return fromRepo;
 
-  return detected;
+  return (PLUGIN_AGENTS as readonly PluginAgent[]).filter(hasPluginCli);
 }
 
 export function readManifest(): Manifest | null {

--- a/src/services/skills/skills-manager.ts
+++ b/src/services/skills/skills-manager.ts
@@ -1,0 +1,297 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import superagent from 'superagent';
+import * as tar from 'tar';
+
+/**
+ * Shared logic for `skills:init` / `skills:update`: fetch the public
+ * ForestAdmin/ai-marketplace repo, copy the Forest skill bundles into a project
+ * (project-scoped, for Claude Code and Codex), merge a Forest block into
+ * CLAUDE.md/AGENTS.md, wire the Forest docs MCP, and track it in a manifest.
+ *
+ * The marketplace repo is PUBLIC → no auth needed for the fetch.
+ */
+
+export const MARKETPLACE_REPO = 'ForestAdmin/ai-marketplace';
+
+// Which dev-facing skills we distribute into a client's repo. Curated on purpose
+// (explicit control over what ships; internal/test-only skills like deploy-heroku
+// stay out). Source path in the repo = `<plugin>/skills/<name>`.
+export const SKILL_SOURCES: { plugin: string; skills: string[] }[] = [
+  {
+    plugin: 'forest',
+    skills: ['boot-standalone-agent', 'layout', 'management', 'onboard', 'workflows'],
+  },
+  { plugin: 'forest-code', skills: ['forest-code', 'forest-legacy'] },
+];
+
+// Per-agent project-scoped skill dir (both are auto-discovered; no marketplace needed).
+export const AGENT_SKILL_DIRS: Record<string, string> = {
+  claude: '.claude/skills',
+  codex: '.agents/skills',
+};
+
+export const MANIFEST_PATH = '.forest/skills-manifest.json';
+
+const BLOCK_BEGIN = '<!-- forest:begin -->';
+const BLOCK_END = '<!-- forest:end -->';
+
+// The Forest block merged into CLAUDE.md / AGENTS.md (project context for the agent).
+export const FOREST_BLOCK = [
+  'This project uses **Forest Admin**. Skills to build/customize it are installed in',
+  '`.claude/skills/` (Claude Code) and `.agents/skills/` (Codex) — e.g. `/forest-code`, `/forest:layout`.',
+  'Forest documentation is searchable via the `forest-docs` MCP server.',
+].join('\n');
+
+export type Manifest = { ref: string; installedAt: string; agents: string[]; files: string[] };
+
+export function contextFileFor(agent: string): string {
+  return agent === 'claude' ? 'CLAUDE.md' : 'AGENTS.md';
+}
+
+/**
+ * Download + extract the marketplace tarball at `ref`. Returns the extracted root dir and a
+ * `cleanup` the caller must run (in a finally) to delete the temp dir — otherwise every
+ * init/update leaks a full copy of the marketplace under the OS temp dir.
+ */
+export async function fetchMarketplace(
+  ref = 'main',
+): Promise<{ root: string; cleanup: () => void }> {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'forest-skills-'));
+  const cleanup = () => fs.rmSync(tmp, { recursive: true, force: true });
+  try {
+    // Generic archive path (not `refs/heads/…`) so `ref` accepts branches, tags, and SHAs alike.
+    const url = `https://codeload.github.com/${MARKETPLACE_REPO}/tar.gz/${ref}`;
+    let res;
+    try {
+      res = await superagent
+        .get(url)
+        .timeout({ response: 15000, deadline: 30000 }) // don't hang forever on a stalled connection
+        .responseType('blob');
+    } catch (err) {
+      if (err.status === 404) {
+        throw new Error(
+          `Forest marketplace ref "${ref}" not found in ${MARKETPLACE_REPO}. Check the --ref value.`,
+        );
+      }
+      if (err.timeout)
+        throw new Error(
+          'Timed out reaching the Forest marketplace — check your connection and retry.',
+        );
+      throw new Error(
+        `Could not fetch the Forest marketplace (${MARKETPLACE_REPO}): ${err.message}`,
+      );
+    }
+    const tgz = path.join(tmp, 'marketplace.tar.gz');
+    fs.writeFileSync(tgz, res.body as Buffer);
+    await tar.x({ file: tgz, cwd: tmp });
+    const root = fs.readdirSync(tmp).find(dir => dir.startsWith('ai-marketplace-'));
+    if (!root) throw new Error('Could not extract the marketplace tarball.');
+
+    return { root: path.join(tmp, root), cleanup };
+  } catch (error) {
+    cleanup(); // don't leak the temp dir when the fetch/extract fails
+    throw error;
+  }
+}
+
+/** True if `p` exists and is a symlink (never throws). */
+function isSymlink(p: string): boolean {
+  try {
+    return fs.lstatSync(p).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+/** Remove a symlink sitting at `p` so a following write/mkdir creates a real file/dir inside the
+ *  project rather than following the link to overwrite something outside it. No-op otherwise. */
+function replaceSymlink(p: string): void {
+  if (isSymlink(p)) fs.rmSync(p);
+}
+
+/** Recursively list the files under `dir` (dest paths), mirroring copyDir's return without copying. */
+function listFiles(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const p = path.join(dir, entry.name);
+
+    return entry.isDirectory() ? listFiles(p) : [p];
+  });
+}
+
+/** Recursively copy a directory, returning the list of files written. Never follows a symlink at
+ *  the destination — it's replaced — so a planted link can't redirect a write outside the project. */
+export function copyDir(src: string, dest: string): string[] {
+  // Refuse a source dir that is itself a symlink — a crafted marketplace could point a curated
+  // skill path at an absolute host dir and have readdirSync follow it, copying local files in.
+  if (isSymlink(src)) return [];
+  if (isSymlink(dest)) fs.rmSync(dest);
+  fs.mkdirSync(dest, { recursive: true });
+
+  return fs.readdirSync(src, { withFileTypes: true }).flatMap(entry => {
+    const from = path.join(src, entry.name);
+    const to = path.join(dest, entry.name);
+    // Never follow a symlink in the source bundle (a crafted marketplace could point one at an
+    // arbitrary file on the user's machine and have us copy its contents in).
+    if (entry.isSymbolicLink()) return [];
+    if (entry.isDirectory()) return copyDir(from, to);
+    if (isSymlink(to)) fs.rmSync(to);
+    fs.copyFileSync(from, to);
+
+    return [to];
+  });
+}
+
+/** Copy the skill bundles from the extracted repo into one agent's skills dir. */
+export function installSkills(srcRoot: string, agent: string, force: boolean): string[] {
+  const targetBase = AGENT_SKILL_DIRS[agent];
+
+  return SKILL_SOURCES.flatMap(({ plugin, skills }) =>
+    skills.flatMap(skill => {
+      const src = path.join(srcRoot, plugin, 'skills', skill);
+      const dest = path.join(targetBase, skill);
+      // Fail loud on a missing curated skill rather than reporting a misleading partial success.
+      if (!fs.existsSync(src)) {
+        throw new Error(
+          `Skill "${skill}" is missing from the marketplace (expected ${plugin}/skills/${skill}). ` +
+            'The curated SKILL_SOURCES list is out of sync with this marketplace ref.',
+        );
+      }
+      if (fs.existsSync(dest)) {
+        if (!fs.lstatSync(dest).isDirectory()) {
+          // A stray non-directory where a skill dir belongs → replace it wholesale.
+          fs.rmSync(dest, { recursive: true, force: true });
+        } else if (!force) {
+          // Installed and no --force: keep as-is, but report the *managed* files (derived from the
+          // source bundle, mapped to dest) so the manifest stays complete — NOT the actual dir
+          // contents, which may include user-added files we must never record as managed (they'd
+          // then be pruned on a later refresh).
+          return listFiles(src).map(f => path.join(dest, path.relative(src, f)));
+        }
+        // With --force on an existing dir we fall through and overlay the incoming bundle on top.
+        // We deliberately do NOT delete the dir, so user-added files survive; pruning of
+        // Forest-owned files that left the bundle is the command's job (removeStaleSkillFiles,
+        // manifest-scoped) — never a blind rm here.
+      }
+
+      return copyDir(src, dest);
+    }),
+  );
+}
+
+/** From a manifest file list, the entries that live under the skill dirs (normalized for Windows,
+ *  where manifest paths use backslashes). These are the candidates for stale-pruning on a refresh. */
+export function skillDirEntries(files: string[]): string[] {
+  const bases = Object.values(AGENT_SKILL_DIRS);
+
+  return files.filter(file => bases.some(dir => file.replace(/\\/g, '/').startsWith(dir)));
+}
+
+/** Guard a deletion candidate: it must resolve *inside* the skill dirs (blocks `..` traversal and
+ *  absolute paths) and its real location must stay there too (blocks a symlinked ancestor from
+ *  redirecting the delete outside the project). A crafted manifest entry must never widen rmSync. */
+function isWithinSkillDirs(file: string): boolean {
+  const skillBases = Object.values(AGENT_SKILL_DIRS).map(dir => path.resolve(dir));
+  const resolved = path.resolve(file);
+  // Textual containment: reject `..` traversal and absolute paths outside the skill dirs.
+  if (!skillBases.some(base => resolved.startsWith(base + path.sep))) return false;
+  // Real containment against the PROJECT root (not the skill dir's symlink target): a symlinked
+  // skill dir pointing outside the project must be rejected, never whitelisted via its target.
+  try {
+    const projectRoot = fs.realpathSync(process.cwd());
+    const realParent = fs.realpathSync(path.dirname(file));
+
+    return realParent === projectRoot || realParent.startsWith(projectRoot + path.sep);
+  } catch {
+    return false; // path doesn't resolve (already gone) → nothing to delete
+  }
+}
+
+/**
+ * Delete managed skill files that existed before but are no longer produced (removed upstream).
+ * Set-diff of previous vs current, deleting only paths that still exist *and* are safely contained
+ * within the skill dirs. Returns what it removed.
+ */
+export function removeStaleSkillFiles(previousFiles: string[], currentFiles: string[]): string[] {
+  // Compare on forward-slash-normalized paths so a manifest written on one OS (e.g. Unix `/`)
+  // matches files produced on another (Windows `\`) — otherwise every entry looks stale and a
+  // cross-platform refresh would wipe freshly-installed bundles. Delete via the original path.
+  const normalize = (p: string) => p.replace(/\\/g, '/');
+  const kept = new Set(currentFiles.map(normalize));
+  const stale = previousFiles.filter(
+    file => !kept.has(normalize(file)) && fs.existsSync(file) && isWithinSkillDirs(file),
+  );
+  stale.forEach(file => fs.rmSync(file));
+
+  return stale;
+}
+
+/** Merge a delimited Forest block into a context file (CLAUDE.md / AGENTS.md) without
+ *  clobbering the user's own content. Creates the file if absent. */
+export function mergeBlock(file: string, content: string): void {
+  replaceSymlink(file); // never write through a symlinked context file
+  const block = `${BLOCK_BEGIN}\n${content}\n${BLOCK_END}`;
+  if (!fs.existsSync(file)) {
+    fs.writeFileSync(file, `${block}\n`);
+
+    return;
+  }
+  const current = fs.readFileSync(file, 'utf8');
+  const re = new RegExp(`${BLOCK_BEGIN}[\\s\\S]*?${BLOCK_END}`);
+  const next = re.test(current) ? current.replace(re, block) : `${current.trimEnd()}\n\n${block}\n`;
+  fs.writeFileSync(file, next);
+}
+
+/**
+ * Wire the Forest docs MCP (Mintlify, https://docs.forest.app/mcp — static, read-only, NO secret)
+ * by reading the source of truth `forest-docs/.mcp.json` from the fetched marketplace and merging
+ * its `mcpServers` into the project's `.mcp.json` (preserving any existing servers the user has).
+ */
+export function installDocsMcp(srcRoot: string): string {
+  const incoming = JSON.parse(
+    fs.readFileSync(path.join(srcRoot, 'forest-docs', '.mcp.json'), 'utf8'),
+  );
+  const target = '.mcp.json';
+  replaceSymlink(target); // never read/write through a symlinked .mcp.json
+  let current: { mcpServers?: Record<string, unknown> } = { mcpServers: {} };
+  if (fs.existsSync(target)) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(target, 'utf8'));
+      // Valid JSON that isn't a plain object (null, array, scalar) → treat as empty, don't crash.
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        current = parsed as { mcpServers?: Record<string, unknown> };
+      }
+    } catch {
+      // Don't clobber a user-authored (but unparseable) config with an empty one.
+      throw new Error(
+        `Cannot parse existing ${target}; aborting so it isn't overwritten. Fix or remove it, then re-run.`,
+      );
+    }
+  }
+  current.mcpServers = { ...(current.mcpServers || {}), ...(incoming.mcpServers || {}) };
+  fs.writeFileSync(target, `${JSON.stringify(current, null, 2)}\n`);
+
+  return target;
+}
+
+export function readManifest(): Manifest | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+    // Validate the shape: a valid-but-malformed manifest ({}, [], null…) must read as "absent",
+    // otherwise callers dereference `previous.files` and crash.
+    if (parsed && typeof parsed === 'object' && Array.isArray(parsed.files)) return parsed;
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeManifest(manifest: Manifest): void {
+  const dir = path.dirname(MANIFEST_PATH);
+  replaceSymlink(dir); // don't let a symlinked .forest redirect the write outside the project
+  fs.mkdirSync(dir, { recursive: true });
+  replaceSymlink(MANIFEST_PATH);
+  fs.writeFileSync(MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`);
+}

--- a/src/services/skills/skills-manager.ts
+++ b/src/services/skills/skills-manager.ts
@@ -121,7 +121,8 @@ export function contextFileGroups(agents: Agent[]): Map<string, Agent[]> {
 export type Manifest = {
   ref: string;
   installedAt: string;
-  agents: string[];
+  /** Absent on manifests written before the field existed — those are copy-route installs. */
+  agents?: string[];
   files: string[];
 };
 
@@ -192,6 +193,27 @@ function replaceSymlink(p: string): void {
   if (isSymlink(p)) fs.rmSync(p);
 }
 
+/**
+ * Refuse to write anywhere below a symlinked ancestor. Checking the destination itself is not
+ * enough: `mkdirSync(..., { recursive: true })` happily follows a symlinked `.agents` or
+ * `.agents/skills`, and every file then lands outside the project. Walks relative segments only,
+ * so it stops at `.` and never judges the absolute path the project happens to live under.
+ */
+function assertNoSymlinkedAncestor(target: string): void {
+  for (
+    let parent = path.dirname(target);
+    parent !== path.dirname(parent);
+    parent = path.dirname(parent)
+  ) {
+    if (isSymlink(parent)) {
+      throw new Error(
+        `Refusing to write through the symlinked directory "${parent}" — it points outside the ` +
+          'files this command manages. Replace it with a real directory, then re-run.',
+      );
+    }
+  }
+}
+
 /** Recursively list the files under `dir` (dest paths), mirroring copyDir's return without copying. */
 function listFiles(dir: string): string[] {
   return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
@@ -204,6 +226,11 @@ function listFiles(dir: string): string[] {
 /** The skill directories a plugin ships: every subdirectory holding a SKILL.md. A symlinked entry
  *  is ignored — copyDir would refuse it anyway, and it must not fabricate a dest dir. */
 function listSkillDirs(skillsRoot: string): string[] {
+  // The ancestor, not just the entries: `copyDir` checks whether a SKILL dir is a symlink, but a
+  // crafted marketplace can symlink `<plugin>/skills` itself at an arbitrary local directory and
+  // have every real child underneath copied in. Refuse the whole root.
+  if (isSymlink(skillsRoot)) return [];
+
   return fs
     .readdirSync(skillsRoot, { withFileTypes: true })
     .filter(
@@ -321,6 +348,10 @@ export function installSkills(
   const previouslyManaged = new Set((previousFiles ?? []).map(normalizePath));
   const isManaged = (file: string) => previouslyManaged.has(normalizePath(file));
 
+  // Before ANY write: a symlinked `.agents` or `.agents/skills` would send every copy outside the
+  // project. Checked once here so the run aborts whole rather than half-applied.
+  assertNoSymlinkedAncestor(path.join(SKILLS_DIR, 'x'));
+
   const result = mergeCopy(
     FOREST_PLUGINS.flatMap(plugin => {
       const skillsRoot = path.join(srcRoot, plugin, 'skills');
@@ -356,13 +387,18 @@ function isWithinSkillDirs(file: string): boolean {
   const resolved = path.resolve(file);
   // Textual containment: reject `..` traversal and absolute paths outside the skills dir.
   if (!resolved.startsWith(base + path.sep)) return false;
-  // Real containment against the PROJECT root (not the skill dir's symlink target): a symlinked
-  // skills dir pointing outside the project must be rejected, never whitelisted via its target.
+  // Real containment against the real skills dir — NOT merely the project root. A skill
+  // subdirectory symlinked at, say, `src/` keeps its target inside the project, so a project-root
+  // check would happily authorise deleting `src/index.ts` through it. The skills dir itself must
+  // also resolve inside the project, or a link pointing outside would whitelist everything below.
   try {
     const projectRoot = fs.realpathSync(process.cwd());
+    const realSkillsDir = fs.realpathSync(SKILLS_DIR);
     const realParent = fs.realpathSync(path.dirname(file));
+    const isUnder = (child: string, root: string) =>
+      child === root || child.startsWith(root + path.sep);
 
-    return realParent === projectRoot || realParent.startsWith(projectRoot + path.sep);
+    return isUnder(realSkillsDir, projectRoot) && isUnder(realParent, realSkillsDir);
   } catch {
     return false; // path doesn't resolve (already gone) → nothing to delete
   }
@@ -374,13 +410,14 @@ function isWithinSkillDirs(file: string): boolean {
  * within the skills dir. Returns what it removed.
  */
 export function removeStaleSkillFiles(previousFiles: string[], currentFiles: string[]): string[] {
-  // Compare on forward-slash-normalized paths so a manifest written on one OS (e.g. Unix `/`)
-  // matches files produced on another (Windows `\`) — otherwise every entry looks stale and a
-  // cross-platform refresh would wipe freshly-installed bundles. Delete via the original path.
+  // Work on forward-slash-normalized paths throughout, not just for the comparison: a manifest
+  // written on Windows carries `.agents\skills\…`, which `existsSync` and `rmSync` do not resolve
+  // on Unix, so a normalized-comparison-only version silently pruned nothing. Node accepts forward
+  // slashes on Windows too, so the normalized form is safe to act on everywhere.
   const kept = new Set(currentFiles.map(normalizePath));
-  const stale = previousFiles.filter(
-    file => !kept.has(normalizePath(file)) && fs.existsSync(file) && isWithinSkillDirs(file),
-  );
+  const stale = previousFiles
+    .map(normalizePath)
+    .filter(file => !kept.has(file) && fs.existsSync(file) && isWithinSkillDirs(file));
   stale.forEach(file => fs.rmSync(file));
 
   return stale;
@@ -525,9 +562,12 @@ export function readManifest(): Manifest | null {
     const parsed = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
     // Validate the shape: a valid-but-malformed manifest ({}, [], null…) must read as "absent",
     // otherwise callers dereference `previous.files` and crash.
-    if (parsed && typeof parsed === 'object' && Array.isArray(parsed.files)) return parsed;
+    if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.files)) return null;
 
-    return null;
+    // `agents` is normalized rather than required: a manifest predating the field is a legitimate
+    // copy-route install that callers handle, but anything that is not an array (`{}`, a string)
+    // must not reach their `.filter` — it would throw instead of degrading.
+    return { ...parsed, agents: Array.isArray(parsed.agents) ? parsed.agents : undefined };
   } catch {
     return null;
   }

--- a/src/services/skills/skills-manager.ts
+++ b/src/services/skills/skills-manager.ts
@@ -96,6 +96,10 @@ export async function fetchMarketplace(
   }
 }
 
+/** Forward-slash-normalize a path so entries written on one OS (Windows `\`) compare equal to
+ *  paths produced on another (Unix `/`). */
+const normalizePath = (p: string) => p.replace(/\\/g, '/');
+
 /** True if `p` exists and is a symlink (never throws). */
 function isSymlink(p: string): boolean {
   try {
@@ -143,9 +147,18 @@ export function copyDir(src: string, dest: string): string[] {
   });
 }
 
-/** Copy the skill bundles from the extracted repo into one agent's skills dir. */
-export function installSkills(srcRoot: string, agent: string, force: boolean): string[] {
+/** Copy the skill bundles from the extracted repo into one agent's skills dir.
+ *  `previousFiles` is the file list from the previous manifest (`null` on a first run): on the
+ *  no-force skip path it bounds what we may claim as managed — we never claim a file we did not
+ *  write ourselves on some run, or a later prune would delete user-authored content. */
+export function installSkills(
+  srcRoot: string,
+  agent: string,
+  force: boolean,
+  previousFiles: string[] | null,
+): string[] {
   const targetBase = AGENT_SKILL_DIRS[agent];
+  const previouslyManaged = new Set((previousFiles ?? []).map(normalizePath));
 
   return SKILL_SOURCES.flatMap(({ plugin, skills }) =>
     skills.flatMap(skill => {
@@ -163,11 +176,14 @@ export function installSkills(srcRoot: string, agent: string, force: boolean): s
           // A stray non-directory where a skill dir belongs → replace it wholesale.
           fs.rmSync(dest, { recursive: true, force: true });
         } else if (!force) {
-          // Installed and no --force: keep as-is, but report the *managed* files (derived from the
-          // source bundle, mapped to dest) so the manifest stays complete — NOT the actual dir
-          // contents, which may include user-added files we must never record as managed (they'd
-          // then be pruned on a later refresh).
-          return listFiles(src).map(f => path.join(dest, path.relative(src, f)));
+          // Installed and no --force: nothing is written here, so only carry over files that are
+          // BOTH in the incoming bundle (derived from source, mapped to dest — never the actual
+          // dir contents, which may include user-added files) AND in the previous manifest (proof
+          // a past run wrote them). A dir that pre-existed the first run was authored by the user:
+          // claiming its files would mark them managed and a later refresh would prune them.
+          return listFiles(src)
+            .map(f => path.join(dest, path.relative(src, f)))
+            .filter(f => previouslyManaged.has(normalizePath(f)));
         }
         // With --force on an existing dir we fall through and overlay the incoming bundle on top.
         // We deliberately do NOT delete the dir, so user-added files survive; pruning of
@@ -217,10 +233,9 @@ export function removeStaleSkillFiles(previousFiles: string[], currentFiles: str
   // Compare on forward-slash-normalized paths so a manifest written on one OS (e.g. Unix `/`)
   // matches files produced on another (Windows `\`) — otherwise every entry looks stale and a
   // cross-platform refresh would wipe freshly-installed bundles. Delete via the original path.
-  const normalize = (p: string) => p.replace(/\\/g, '/');
-  const kept = new Set(currentFiles.map(normalize));
+  const kept = new Set(currentFiles.map(normalizePath));
   const stale = previousFiles.filter(
-    file => !kept.has(normalize(file)) && fs.existsSync(file) && isWithinSkillDirs(file),
+    file => !kept.has(normalizePath(file)) && fs.existsSync(file) && isWithinSkillDirs(file),
   );
   stale.forEach(file => fs.rmSync(file));
 

--- a/src/services/skills/skills-manager.ts
+++ b/src/services/skills/skills-manager.ts
@@ -83,16 +83,39 @@ export function contextFileFor(agent: Agent): string {
   return agent === 'claude' ? 'CLAUDE.md' : 'AGENTS.md';
 }
 
-/** The Forest block merged into CLAUDE.md / AGENTS.md, worded for the route actually applied. */
-export function forestBlock(agent: Agent): string {
-  const where = isPluginAgent(agent)
-    ? 'available through the `forest` plugin — e.g. `/forest:start`, `/forest:layout`, `/forest-code`'
-    : `installed in \`${SKILLS_DIR}/\` — e.g. \`layout\`, \`onboard\`, \`forest-code\``;
+/**
+ * The Forest block merged into a context file, describing every route that feeds THAT file.
+ *
+ * Takes the agents rather than one agent because a single file often serves both routes: AGENTS.md
+ * is Codex's (plugin) and Cursor's and OpenCode's (copy). Writing one block per agent would have
+ * the second merge replace the first — same delimiters — leaving the file describing only whichever
+ * route ran last.
+ */
+export function forestBlock(agents: Agent[]): string {
+  const where: string[] = [];
+  if (agents.some(isPluginAgent))
+    where.push(
+      'available through the `forest` plugin — e.g. `/forest:start`, `/forest:layout`, `/forest-code`',
+    );
+  if (agents.some(agent => !isPluginAgent(agent)))
+    where.push(`installed in \`${SKILLS_DIR}/\` — e.g. \`layout\`, \`onboard\`, \`forest-code\``);
 
   return [
-    `This project uses **Forest Admin**. Skills to build and customize it are ${where}.`,
+    `This project uses **Forest Admin**. Skills to build and customize it are ${where.join(
+      ', and ',
+    )}.`,
     'Forest documentation is searchable via the `forest-docs` MCP server.',
   ].join('\n');
+}
+
+/** Group agents by the context file they write to, so each file gets exactly one merged block. */
+export function contextFileGroups(agents: Agent[]): Map<string, Agent[]> {
+  return agents.reduce((groups, agent) => {
+    const file = contextFileFor(agent);
+    groups.set(file, [...(groups.get(file) ?? []), agent]);
+
+    return groups;
+  }, new Map<string, Agent[]>());
 }
 
 export type Manifest = {
@@ -238,6 +261,45 @@ export function copyDir(
   );
 }
 
+/** Install one skill directory. Split out of `installSkills` so each function stays readable. */
+function installSkill(
+  src: string,
+  dest: string,
+  force: boolean,
+  isManaged: (file: string) => boolean,
+): CopyResult {
+  if (fs.existsSync(dest)) {
+    if (!fs.lstatSync(dest).isDirectory()) {
+      // Something that is not a directory sits where a skill dir belongs. We did not put it there
+      // — a skill is always a directory — so it is the user's, and removing it to make room would
+      // destroy content no manifest ever claimed. Report it and move on.
+      return { written: [], skipped: [dest] };
+    }
+    if (!force) {
+      // Installed and no --force: nothing is written here, so only carry over files that are BOTH
+      // in the incoming bundle (derived from source, mapped to dest — never the actual dir
+      // contents, which may include user-added files) AND in the previous manifest (proof a past
+      // run wrote them). A dir that pre-existed the first run was authored by the user: claiming
+      // its files would mark them managed and a later refresh would prune them.
+      return {
+        written: listFiles(src)
+          .map(f => path.join(dest, path.relative(src, f)))
+          .filter(isManaged),
+        skipped: [],
+      };
+    }
+    // With --force on an existing dir we fall through and overlay the incoming bundle on top. We
+    // deliberately do NOT delete the dir, so user-added files survive; pruning of Forest-owned
+    // files that left the bundle is the command's job (removeStaleSkillFiles, manifest-scoped).
+  }
+
+  // `isManaged` is the only licence to overwrite, --force included: the flag re-writes what a
+  // previous run wrote, it does not claim the right to destroy files we never wrote. With no
+  // previous manifest nothing is managed, so a forced re-install over a directory the user authored
+  // overwrites none of it. New files are unaffected — the guard only sees paths already on disk.
+  return copyDir(src, dest, isManaged);
+}
+
 /**
  * Copy the skills of every shipped plugin from the extracted repo into `SKILLS_DIR`.
  *
@@ -264,35 +326,9 @@ export function installSkills(
       const skillsRoot = path.join(srcRoot, plugin, 'skills');
       if (!fs.existsSync(skillsRoot)) return [];
 
-      return listSkillDirs(skillsRoot).map(skill => {
-        const src = path.join(skillsRoot, skill);
-        const dest = path.join(SKILLS_DIR, skill);
-        if (fs.existsSync(dest)) {
-          if (!fs.lstatSync(dest).isDirectory()) {
-            // A stray non-directory where a skill dir belongs → replace it wholesale.
-            fs.rmSync(dest, { recursive: true, force: true });
-          } else if (!force) {
-            // Installed and no --force: nothing is written here, so only carry over files that are
-            // BOTH in the incoming bundle (derived from source, mapped to dest — never the actual
-            // dir contents, which may include user-added files) AND in the previous manifest (proof
-            // a past run wrote them). A dir that pre-existed the first run was authored by the user:
-            // claiming its files would mark them managed and a later refresh would prune them.
-            return {
-              written: listFiles(src)
-                .map(f => path.join(dest, path.relative(src, f)))
-                .filter(isManaged),
-              skipped: [],
-            };
-          }
-          // With --force on an existing dir we fall through and overlay the incoming bundle on top.
-          // We deliberately do NOT delete the dir, so user-added files survive; pruning of
-          // Forest-owned files that left the bundle is the command's job (removeStaleSkillFiles,
-          // manifest-scoped) — never a blind rm here. `isManaged` still shields user-authored
-          // files that collide with a bundle path.
-        }
-
-        return copyDir(src, dest, file => !previousFiles || isManaged(file));
-      });
+      return listSkillDirs(skillsRoot).map(skill =>
+        installSkill(path.join(skillsRoot, skill), path.join(SKILLS_DIR, skill), force, isManaged),
+      );
     }),
   );
 

--- a/src/services/skills/skills-manager.ts
+++ b/src/services/skills/skills-manager.ts
@@ -27,26 +27,22 @@ export const MARKETPLACE_REPO = 'ForestAdmin/ai-marketplace';
 export const MARKETPLACE_NAME = 'forest-admin-ai';
 
 /**
- * Which plugins the COPY route takes its skills from — ALL of their skills, discovered from the
- * bundle rather than listed here.
+ * The Forest plugins this command ships — the ONLY thing it decides, and it decides it once for
+ * both routes. These three are what "knowing Forest" means: how to build a back-office (`forest`),
+ * how to write agent code (`forest-code`), and how to look things up (`forest-docs`).
  *
- * There used to be a hand-picked list of skill names. It made the two routes disagree: the plugin
- * route installs whole plugins, so a name left out here still shipped there. Worse, the skills
- * cross-reference each other — `onboard` hands the production step to `deploy-heroku`, which the
- * list excluded — so copy-route users got an `onboard` skill pointing at something that was not
- * installed. What ships is decided in the marketplace, by what a plugin contains; a second,
- * divergent definition here can only drift.
+ * `forest-mcp` is not one of them: it is a data-access server for querying a live project's
+ * records, not help for the developer, so it has no place in a command whose job is to teach the
+ * agent Forest. Anyone who wants it installs it themselves.
  *
- * `forest-docs` is absent because it carries no skills (it is an MCP config, which only the plugin
- * route can wire), and `forest-mcp` because it is data access, not developer help.
+ * Nothing below the plugin is filtered. There used to be a hand-picked list of skill NAMES, and it
+ * did real damage: the plugin route installs whole plugins, so a name left out still shipped
+ * there, and the skills cross-reference each other — `onboard` hands the production step to
+ * `deploy-heroku`, which the list excluded — leaving copy-route users with an `onboard` skill
+ * pointing at something never installed. A plugin is the unit of distribution and is coherent only
+ * as a whole; what it contains is the marketplace's call, not ours. Choosing plugins is a product
+ * decision, choosing their contents is drift waiting to happen.
  */
-export const SKILL_PLUGINS = ['forest', 'forest-code'];
-
-// Which plugins we install on the PLUGIN route. These three are what "knowing Forest" means:
-// how to build a back-office (`forest`), how to write agent code (`forest-code`), and how to look
-// things up (`forest-docs`). `forest-mcp` is not one of them — it is a data-access server for
-// querying a live project's records, not help for the developer, so it has no place in a command
-// whose job is to teach the agent Forest. Anyone who wants it installs it themselves.
 export const FOREST_PLUGINS = ['forest', 'forest-code', 'forest-docs'];
 
 /**
@@ -243,7 +239,12 @@ export function copyDir(
 }
 
 /**
- * Copy the curated skill bundles from the extracted repo into `SKILLS_DIR`.
+ * Copy the skills of every shipped plugin from the extracted repo into `SKILLS_DIR`.
+ *
+ * The same `FOREST_PLUGINS` the plugin route installs — one list, so the two routes cannot drift.
+ * A plugin with no `skills/` is simply skipped rather than rejected: `forest-docs` legitimately
+ * carries only an MCP config, which this route cannot wire anyway. What must not pass silently is
+ * copying NOTHING, so that is what the guard checks — a marketplace whose layout moved under us.
  *
  * `previousFiles` is the file list from the previous manifest (`null` on a first run). It bounds
  * what we may claim as managed AND what we may overwrite: a file we never wrote is the user's,
@@ -258,17 +259,10 @@ export function installSkills(
   const previouslyManaged = new Set((previousFiles ?? []).map(normalizePath));
   const isManaged = (file: string) => previouslyManaged.has(normalizePath(file));
 
-  return mergeCopy(
-    SKILL_PLUGINS.flatMap(plugin => {
+  const result = mergeCopy(
+    FOREST_PLUGINS.flatMap(plugin => {
       const skillsRoot = path.join(srcRoot, plugin, 'skills');
-      // Fail loud on a plugin that carries no skills at all rather than reporting a misleading
-      // partial success — at that point the marketplace layout has changed under us.
-      if (!fs.existsSync(skillsRoot)) {
-        throw new Error(
-          `Plugin "${plugin}" has no skills/ directory in the marketplace (expected ${plugin}/skills). ` +
-            'The marketplace layout changed — check the --ref value.',
-        );
-      }
+      if (!fs.existsSync(skillsRoot)) return [];
 
       return listSkillDirs(skillsRoot).map(skill => {
         const src = path.join(skillsRoot, skill);
@@ -301,6 +295,15 @@ export function installSkills(
       });
     }),
   );
+
+  if (!result.written.length && !result.skipped.length) {
+    throw new Error(
+      `No skills found in the marketplace for ${FOREST_PLUGINS.join(', ')} (expected ` +
+        '`<plugin>/skills/<name>/SKILL.md`). The marketplace layout changed — check the --ref value.',
+    );
+  }
+
+  return result;
 }
 
 /** From a manifest file list, the entries that live under the skills dir (normalized for Windows,

--- a/src/services/skills/skills-manager.ts
+++ b/src/services/skills/skills-manager.ts
@@ -259,6 +259,41 @@ export function mergeBlock(file: string, content: string): void {
 }
 
 /**
+ * Fail-fast preflight for the local `.mcp.json`: run it BEFORE any disk mutation. `installDocsMcp`
+ * throws on an unparseable local config (on purpose, to protect user content), but it runs last —
+ * without this check the failure would surface after skills were installed and the context files
+ * merged, leaving a half-applied state with no manifest rewrite.
+ */
+export function validateLocalMcp(): void {
+  const target = '.mcp.json';
+  // A symlinked .mcp.json is replaced (never read) at install time, so its target's content is
+  // irrelevant here. Same for an absent file.
+  if (isSymlink(target) || !fs.existsSync(target)) return;
+  try {
+    JSON.parse(fs.readFileSync(target, 'utf8'));
+  } catch {
+    throw new Error(
+      `Cannot parse existing ${target}; aborting before any changes so it isn't overwritten. ` +
+        'Fix or remove it, then re-run.',
+    );
+  }
+}
+
+/**
+ * Fail-fast preflight for the fetched marketplace bundle: run it after the fetch but BEFORE any
+ * write. The docs MCP config is read last by `installDocsMcp`; a bundle missing it would otherwise
+ * die on a raw ENOENT after everything else was already applied.
+ */
+export function validateMarketplaceBundle(srcRoot: string, ref: string): void {
+  if (!fs.existsSync(path.join(srcRoot, 'forest-docs', '.mcp.json'))) {
+    throw new Error(
+      `The Forest marketplace at ref "${ref}" has no forest-docs/.mcp.json (docs MCP config). ` +
+        'Nothing was changed. Check the --ref value or try again with the default ref.',
+    );
+  }
+}
+
+/**
  * Wire the Forest docs MCP (Mintlify, https://docs.forest.app/mcp — static, read-only, NO secret)
  * by reading the source of truth `forest-docs/.mcp.json` from the fetched marketplace and merging
  * its `mcpServers` into the project's `.mcp.json` (preserving any existing servers the user has).

--- a/src/services/skills/skills-manager.ts
+++ b/src/services/skills/skills-manager.ts
@@ -36,8 +36,11 @@ export const SKILL_SOURCES: { plugin: string; skills: string[] }[] = [
   { plugin: 'forest-code', skills: ['forest-code', 'forest-legacy'] },
 ];
 
-// Which plugins we install on the PLUGIN route. `forest-mcp` is deliberately out: it needs the
-// user's Forest credentials at install time (authPolicy ON_INSTALL), so it is an opt-in.
+// Which plugins we install on the PLUGIN route. These three are what "knowing Forest" means:
+// how to build a back-office (`forest`), how to write agent code (`forest-code`), and how to look
+// things up (`forest-docs`). `forest-mcp` is not one of them — it is a data-access server for
+// querying a live project's records, not help for the developer, so it has no place in a command
+// whose job is to teach the agent Forest. Anyone who wants it installs it themselves.
 export const FOREST_PLUGINS = ['forest', 'forest-code', 'forest-docs'];
 
 /**

--- a/test/commands/skills/init.test.js
+++ b/test/commands/skills/init.test.js
@@ -124,6 +124,30 @@ describe('skills:init', () => {
       expect(installPlugins).not.toHaveBeenCalled();
     });
 
+    it('does not claim a skipped agent in the manifest or its context file', async () => {
+      expect.hasAssertions();
+      mockPipeline({ cliPresent: false });
+
+      const projectDir = await runCliKeepingProjectDir({
+        commandClass: SkillsInitCommand,
+        commandArgs: ['--agent', 'claude', '--agent', 'cursor'],
+        files: [{ name: 'placeholder', content: 'x' }],
+        std: [{ out: "Claude Code selected but its CLI isn't on your PATH" }],
+      });
+
+      try {
+        const at = p => path.join(projectDir, p);
+        // Nothing was installed for Claude Code, so nothing may say it was.
+        const manifest = JSON.parse(fs.readFileSync(at('.forest/skills-manifest.json'), 'utf8'));
+        expect(manifest.agents).toStrictEqual(['cursor']);
+        expect(fs.existsSync(at('CLAUDE.md'))).toBe(false);
+        // The agent that did get set up is unaffected.
+        expect(fs.existsSync(at(skill('layout', 'SKILL.md')))).toBe(true);
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+
     it('reports a plugin that failed to install without failing the whole run', async () => {
       expect.hasAssertions();
       mockPipeline({ failed: ['forest-docs'] });
@@ -218,6 +242,30 @@ describe('skills:init', () => {
         expect(fs.readFileSync(at('AGENTS.md'), 'utf8')).toContain(SKILLS_DIR);
         const manifest = JSON.parse(fs.readFileSync(at('.forest/skills-manifest.json'), 'utf8'));
         expect(manifest.agents).toStrictEqual(['claude', 'cursor']);
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('when one context file serves both routes (--agent codex --agent cursor)', () => {
+    it('writes a single AGENTS.md block covering the plugin AND the copied skills', async () => {
+      expect.hasAssertions();
+      mockPipeline();
+
+      const projectDir = await runCliKeepingProjectDir({
+        commandClass: SkillsInitCommand,
+        commandArgs: ['--agent', 'codex', '--agent', 'cursor'],
+        files: [{ name: 'placeholder', content: 'x' }],
+        std: [{ out: 'Forest skills copied to .agents/skills/' }],
+      });
+
+      try {
+        const agentsMd = fs.readFileSync(path.join(projectDir, 'AGENTS.md'), 'utf8');
+        // Both routes described — the second merge used to replace the first.
+        expect(agentsMd).toContain('`forest` plugin');
+        expect(agentsMd).toContain(SKILLS_DIR);
+        expect(agentsMd.match(/<!-- forest:begin -->/g)).toHaveLength(1);
       } finally {
         fs.rmSync(projectDir, { recursive: true, force: true });
       }

--- a/test/commands/skills/init.test.js
+++ b/test/commands/skills/init.test.js
@@ -16,11 +16,24 @@ jest.mock('../../../src/services/skills/skills-manager', () => ({
 const SkillsInitCommand = require('../../../src/commands/skills/init').default;
 const {
   SKILLS_DIR,
-  SKILL_SOURCES,
   fetchMarketplace,
   hasPluginCli,
   installPlugins,
 } = require('../../../src/services/skills/skills-manager');
+
+// Build a fake extracted marketplace: each plugin ships its skills as SKILL.md dirs, exactly as
+// the real bundle does — including deploy-heroku, which the old curated list dropped.
+const BUNDLE_SKILLS = {
+  forest: [
+    'boot-standalone-agent',
+    'deploy-heroku',
+    'layout',
+    'management',
+    'onboard',
+    'workflows',
+  ],
+  'forest-code': ['forest-code', 'forest-legacy'],
+};
 
 function makeFakeBundle() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skills-init-test-'));
@@ -28,7 +41,7 @@ function makeFakeBundle() {
     fs.mkdirSync(path.dirname(p), { recursive: true });
     fs.writeFileSync(p, c);
   };
-  SKILL_SOURCES.forEach(({ plugin, skills }) =>
+  Object.entries(BUNDLE_SKILLS).forEach(([plugin, skills]) =>
     skills.forEach(skill =>
       write(path.join(root, plugin, 'skills', skill, 'SKILL.md'), `# ${skill} skill`),
     ),
@@ -129,7 +142,7 @@ describe('skills:init', () => {
   });
 
   describe('with a copy-route agent (--agent cursor)', () => {
-    it('copies the curated skills into the cross-agent dir and records them', async () => {
+    it('copies the skills into the cross-agent dir and records them', async () => {
       expect.hasAssertions();
       mockPipeline();
 

--- a/test/commands/skills/init.test.js
+++ b/test/commands/skills/init.test.js
@@ -1,0 +1,238 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const testCli = require('../test-cli-helper/test-cli');
+
+// Mock ONLY the network fetch and the agent-CLI calls: the command's real orchestration
+// (route split, install, block merge, manifest write) runs for real against a fake bundle.
+jest.mock('../../../src/services/skills/skills-manager', () => ({
+  ...jest.requireActual('../../../src/services/skills/skills-manager'),
+  fetchMarketplace: jest.fn(),
+  hasPluginCli: jest.fn(),
+  installPlugins: jest.fn(),
+}));
+
+const SkillsInitCommand = require('../../../src/commands/skills/init').default;
+const {
+  SKILLS_DIR,
+  SKILL_SOURCES,
+  fetchMarketplace,
+  hasPluginCli,
+  installPlugins,
+} = require('../../../src/services/skills/skills-manager');
+
+function makeFakeBundle() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skills-init-test-'));
+  const write = (p, c) => {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, c);
+  };
+  SKILL_SOURCES.forEach(({ plugin, skills }) =>
+    skills.forEach(skill =>
+      write(path.join(root, plugin, 'skills', skill, 'SKILL.md'), `# ${skill} skill`),
+    ),
+  );
+  return root;
+}
+
+function mockPipeline({ cliPresent = true, failed = [] } = {}) {
+  fetchMarketplace.mockReset();
+  fetchMarketplace.mockImplementation(async () => {
+    const root = makeFakeBundle();
+    return { root, cleanup: () => fs.rmSync(root, { recursive: true, force: true }) };
+  });
+  hasPluginCli.mockReset();
+  hasPluginCli.mockReturnValue(cliPresent);
+  installPlugins.mockReset();
+  installPlugins.mockImplementation(agent => ({
+    agent,
+    installed: failed.length ? ['forest'] : ['forest', 'forest-code', 'forest-docs'],
+    failed,
+  }));
+}
+
+async function runCliKeepingProjectDir(options) {
+  const previousFlag = process.env.KEEP_TEMPORARY_FILES;
+  process.env.KEEP_TEMPORARY_FILES = '1';
+  try {
+    await testCli(options);
+  } finally {
+    if (previousFlag === undefined) delete process.env.KEEP_TEMPORARY_FILES;
+    else process.env.KEEP_TEMPORARY_FILES = previousFlag;
+  }
+  return options.files[0].chdir;
+}
+
+const skill = (...parts) => path.join(SKILLS_DIR, ...parts);
+
+describe('skills:init', () => {
+  describe('with a plugin-route agent (--agent claude)', () => {
+    it('drives the agent CLI and writes nothing into the repo but CLAUDE.md + the manifest', async () => {
+      expect.hasAssertions();
+      mockPipeline();
+
+      const projectDir = await runCliKeepingProjectDir({
+        commandClass: SkillsInitCommand,
+        commandArgs: ['--agent', 'claude'],
+        files: [{ name: 'placeholder', content: 'x' }],
+        std: [
+          { out: 'Claude Code: installed the Forest plugins' },
+          { out: 'Restart Claude Code to load the plugin' },
+        ],
+      });
+
+      try {
+        const at = p => path.join(projectDir, p);
+        expect(installPlugins).toHaveBeenCalledWith('claude', 'main');
+        // Plugin route: no tarball, no skills copied anywhere.
+        expect(fetchMarketplace).not.toHaveBeenCalled();
+        expect(fs.existsSync(at(SKILLS_DIR))).toBe(false);
+        expect(fs.existsSync(at('.claude/skills'))).toBe(false);
+        // The agent still needs to know this repo is a Forest project.
+        expect(fs.readFileSync(at('CLAUDE.md'), 'utf8')).toContain('`forest` plugin');
+        const manifest = JSON.parse(fs.readFileSync(at('.forest/skills-manifest.json'), 'utf8'));
+        expect(manifest.agents).toStrictEqual(['claude']);
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+
+    it('warns and skips the agent when its CLI is not on the PATH', async () => {
+      expect.hasAssertions();
+      mockPipeline({ cliPresent: false });
+
+      await testCli({
+        commandClass: SkillsInitCommand,
+        commandArgs: ['--agent', 'claude'],
+        std: [{ out: "Claude Code selected but its CLI isn't on your PATH" }],
+      });
+
+      expect(installPlugins).not.toHaveBeenCalled();
+    });
+
+    it('reports a plugin that failed to install without failing the whole run', async () => {
+      expect.hasAssertions();
+      mockPipeline({ failed: ['forest-docs'] });
+
+      await testCli({
+        commandClass: SkillsInitCommand,
+        commandArgs: ['--agent', 'claude'],
+        std: [
+          { out: 'Claude Code: installed the Forest plugin (forest).' },
+          { out: 'Claude Code: could not install forest-docs' },
+        ],
+      });
+
+      expect(installPlugins).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('with a copy-route agent (--agent cursor)', () => {
+    it('copies the curated skills into the cross-agent dir and records them', async () => {
+      expect.hasAssertions();
+      mockPipeline();
+
+      const projectDir = await runCliKeepingProjectDir({
+        commandClass: SkillsInitCommand,
+        commandArgs: ['--agent', 'cursor'],
+        files: [{ name: 'placeholder', content: 'x' }],
+        std: [
+          { out: 'Fetching Forest skills from ForestAdmin/ai-marketplace@main' },
+          { out: 'Forest skills copied to .agents/skills/' },
+        ],
+      });
+
+      try {
+        const at = p => path.join(projectDir, p);
+        expect(installPlugins).not.toHaveBeenCalled();
+        expect(fs.readFileSync(at(skill('layout', 'SKILL.md')), 'utf8')).toBe('# layout skill');
+        // AGENTS.md is the cross-agent context file; CLAUDE.md is not this agent's business.
+        expect(fs.readFileSync(at('AGENTS.md'), 'utf8')).toContain(SKILLS_DIR);
+        expect(fs.existsSync(at('CLAUDE.md'))).toBe(false);
+        const manifest = JSON.parse(fs.readFileSync(at('.forest/skills-manifest.json'), 'utf8'));
+        expect(manifest.files).toContain(skill('layout', 'SKILL.md'));
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+
+    it('never claims a pre-existing user skill dir in the manifest', async () => {
+      expect.hasAssertions();
+      mockPipeline();
+
+      const projectDir = await runCliKeepingProjectDir({
+        commandClass: SkillsInitCommand,
+        commandArgs: ['--agent', 'cursor'],
+        files: [{ name: skill('layout', 'SKILL.md'), content: 'my own skill' }],
+        std: [{ out: 'Forest skills copied to .agents/skills/' }],
+      });
+
+      try {
+        const at = p => path.join(projectDir, p);
+        // Untouched on disk…
+        expect(fs.readFileSync(at(skill('layout', 'SKILL.md')), 'utf8')).toBe('my own skill');
+        // …and never recorded as managed, or a later refresh would prune it.
+        const manifest = JSON.parse(fs.readFileSync(at('.forest/skills-manifest.json'), 'utf8'));
+        expect(manifest.files).not.toContain(skill('layout', 'SKILL.md'));
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('with both routes at once (--agent claude --agent cursor)', () => {
+    it('installs the plugin AND copies the skills, recording both agents', async () => {
+      expect.hasAssertions();
+      mockPipeline();
+
+      const projectDir = await runCliKeepingProjectDir({
+        commandClass: SkillsInitCommand,
+        commandArgs: ['--agent', 'claude', '--agent', 'cursor'],
+        files: [{ name: 'placeholder', content: 'x' }],
+        std: [
+          { out: 'Claude Code: installed the Forest plugins' },
+          { out: 'Forest skills copied to .agents/skills/' },
+        ],
+      });
+
+      try {
+        const at = p => path.join(projectDir, p);
+        expect(installPlugins).toHaveBeenCalledWith('claude', 'main');
+        expect(fs.existsSync(at(skill('layout', 'SKILL.md')))).toBe(true);
+        // Both context files, each worded for its own route.
+        expect(fs.readFileSync(at('CLAUDE.md'), 'utf8')).toContain('`forest` plugin');
+        expect(fs.readFileSync(at('AGENTS.md'), 'utf8')).toContain(SKILLS_DIR);
+        const manifest = JSON.parse(fs.readFileSync(at('.forest/skills-manifest.json'), 'utf8'));
+        expect(manifest.agents).toStrictEqual(['claude', 'cursor']);
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('--ref', () => {
+    it('is passed through to both routes and recorded in the manifest', async () => {
+      expect.hasAssertions();
+      mockPipeline();
+
+      const projectDir = await runCliKeepingProjectDir({
+        commandClass: SkillsInitCommand,
+        commandArgs: ['--agent', 'claude', '--agent', 'cursor', '--ref', 'v2.1.0'],
+        files: [{ name: 'placeholder', content: 'x' }],
+        std: [{ out: 'Fetching Forest skills from ForestAdmin/ai-marketplace@v2.1.0' }],
+      });
+
+      try {
+        expect(installPlugins).toHaveBeenCalledWith('claude', 'v2.1.0');
+        expect(fetchMarketplace).toHaveBeenCalledWith('v2.1.0');
+        const manifest = JSON.parse(
+          fs.readFileSync(path.join(projectDir, '.forest/skills-manifest.json'), 'utf8'),
+        );
+        expect(manifest.ref).toBe('v2.1.0');
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/test/commands/skills/update.test.js
+++ b/test/commands/skills/update.test.js
@@ -4,18 +4,27 @@ const path = require('path');
 
 const testCli = require('../test-cli-helper/test-cli');
 
-// Mock ONLY the network fetch: the command's real orchestration (validation, install, block
-// merge, stale-pruning, manifest rewrite) runs against a fake extracted bundle on disk.
+// Mock ONLY the network fetch and the agent-CLI calls: the command's real orchestration
+// (route split, install, block merge, stale-pruning, manifest rewrite) runs for real against a
+// fake extracted bundle on disk.
 jest.mock('../../../src/services/skills/skills-manager', () => ({
   ...jest.requireActual('../../../src/services/skills/skills-manager'),
   fetchMarketplace: jest.fn(),
+  hasPluginCli: jest.fn(),
+  upgradePlugins: jest.fn(),
 }));
 
 const SkillsUpdateCommand = require('../../../src/commands/skills/update').default;
-const { SKILL_SOURCES, fetchMarketplace } = require('../../../src/services/skills/skills-manager');
+const {
+  SKILLS_DIR,
+  SKILL_SOURCES,
+  fetchMarketplace,
+  hasPluginCli,
+  upgradePlugins,
+} = require('../../../src/services/skills/skills-manager');
 
 // Build a fake extracted marketplace holding every curated skill (derived from SKILL_SOURCES so
-// the fixture stays in sync with the real list) + forest-docs/.mcp.json.
+// the fixture stays in sync with the real list).
 function makeFakeBundle() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skills-update-test-'));
   const write = (p, c) => {
@@ -27,21 +36,19 @@ function makeFakeBundle() {
       write(path.join(root, plugin, 'skills', skill, 'SKILL.md'), `# ${skill} skill (fresh)`),
     ),
   );
-  write(
-    path.join(root, 'forest-docs', '.mcp.json'),
-    JSON.stringify({
-      mcpServers: { 'forest-docs': { type: 'http', url: 'https://docs.forest.app/mcp' } },
-    }),
-  );
   return root;
 }
 
-function mockMarketplaceFetch() {
+function mockPipeline({ cliPresent = true } = {}) {
   fetchMarketplace.mockReset();
   fetchMarketplace.mockImplementation(async () => {
     const root = makeFakeBundle();
     return { root, cleanup: () => fs.rmSync(root, { recursive: true, force: true }) };
   });
+  hasPluginCli.mockReset();
+  hasPluginCli.mockReturnValue(cliPresent);
+  upgradePlugins.mockReset();
+  upgradePlugins.mockImplementation(agent => ({ agent, installed: ['forest'], failed: [] }));
 }
 
 // Run testCli but keep the temporary project directory so the resulting disk state can be
@@ -59,14 +66,16 @@ async function runCliKeepingProjectDir(options) {
   return options.files[0].chdir;
 }
 
-const previousManifest = (ref, files) =>
-  JSON.stringify({ ref, installedAt: '2026-01-01T00:00:00.000Z', agents: ['claude'], files });
+const previousManifest = (ref, files, agents = ['cursor']) =>
+  JSON.stringify({ ref, installedAt: '2026-01-01T00:00:00.000Z', agents, files });
+
+const skill = (...parts) => path.join(SKILLS_DIR, ...parts);
 
 describe('skills:update', () => {
   describe('when no manifest exists', () => {
     it('exits with an error and never reaches the marketplace', async () => {
       expect.hasAssertions();
-      mockMarketplaceFetch();
+      mockPipeline();
 
       await testCli({
         commandClass: SkillsUpdateCommand,
@@ -82,46 +91,22 @@ describe('skills:update', () => {
     });
   });
 
-  describe('when the local .mcp.json is unparsable', () => {
-    it('fails fast before fetching or mutating anything', async () => {
-      expect.hasAssertions();
-      mockMarketplaceFetch();
-
-      await testCli({
-        commandClass: SkillsUpdateCommand,
-        files: [
-          {
-            name: '.forest/skills-manifest.json',
-            content: previousManifest('main', ['.claude/skills/layout/SKILL.md']),
-          },
-          { name: '.mcp.json', content: '{ not valid json' },
-        ],
-        exitMessage:
-          "Cannot parse existing .mcp.json; aborting before any changes so it isn't overwritten. " +
-          'Fix or remove it, then re-run.',
-      });
-
-      expect(fetchMarketplace).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('when a manifest exists', () => {
+  describe('on the copy route', () => {
     it('refreshes managed files, prunes stale ones and rewrites the manifest', async () => {
       expect.hasAssertions();
-      mockMarketplaceFetch();
+      mockPipeline();
 
       const files = [
         {
           name: '.forest/skills-manifest.json',
           content: previousManifest('main', [
-            '.claude/skills/layout/SKILL.md',
-            '.claude/skills/old-skill/SKILL.md', // left the upstream bundle since
-            'CLAUDE.md',
-            '.mcp.json',
+            skill('layout', 'SKILL.md'),
+            skill('old-skill', 'SKILL.md'), // left the upstream bundle since
+            'AGENTS.md',
           ]),
         },
-        { name: '.claude/skills/layout/SKILL.md', content: 'outdated content' },
-        { name: '.claude/skills/old-skill/SKILL.md', content: 'stale content' },
+        { name: skill('layout', 'SKILL.md'), content: 'outdated content' },
+        { name: skill('old-skill', 'SKILL.md'), content: 'stale content' },
       ];
 
       const projectDir = await runCliKeepingProjectDir({
@@ -129,25 +114,58 @@ describe('skills:update', () => {
         files,
         std: [
           { out: 'Refreshing Forest skills from ForestAdmin/ai-marketplace@main' },
-          { out: 'Forest skills refreshed for claude, codex' },
+          { out: 'Forest skills refreshed in .agents/skills/' },
         ],
       });
 
       try {
         const at = p => path.join(projectDir, p);
         // Managed file refreshed from the bundle.
-        expect(fs.readFileSync(at('.claude/skills/layout/SKILL.md'), 'utf8')).toBe(
+        expect(fs.readFileSync(at(skill('layout', 'SKILL.md')), 'utf8')).toBe(
           '# layout skill (fresh)',
         );
         // Stale managed file (in the old manifest, gone upstream) pruned.
-        expect(fs.existsSync(at('.claude/skills/old-skill/SKILL.md'))).toBe(false);
+        expect(fs.existsSync(at(skill('old-skill', 'SKILL.md')))).toBe(false);
         // Freshly installed files NOT pruned (removeStaleSkillFiles argument order).
-        expect(fs.existsSync(at('.claude/skills/forest-code/SKILL.md'))).toBe(true);
-        expect(fs.existsSync(at('.agents/skills/layout/SKILL.md'))).toBe(true);
+        expect(fs.existsSync(at(skill('forest-code', 'SKILL.md')))).toBe(true);
+        // Claude Code's dir is never written on the copy route — it gets the plugin instead.
+        expect(fs.existsSync(at('.claude/skills'))).toBe(false);
         // Manifest rewritten with the effective ref and the refreshed file list.
         const manifest = JSON.parse(fs.readFileSync(at('.forest/skills-manifest.json'), 'utf8'));
         expect(manifest.ref).toBe('main');
-        expect(manifest.files).toContain(path.join('.claude/skills', 'forest-code', 'SKILL.md'));
+        expect(manifest.files).toContain(skill('forest-code', 'SKILL.md'));
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+
+    it('keeps a user-authored file that collides with a bundle path instead of overwriting it', async () => {
+      expect.hasAssertions();
+      mockPipeline();
+
+      const files = [
+        {
+          name: '.forest/skills-manifest.json',
+          // The manifest never claimed layout/SKILL.md → we never wrote it → it is the user's.
+          content: previousManifest('main', [skill('onboard', 'SKILL.md')]),
+        },
+        { name: skill('onboard', 'SKILL.md'), content: 'managed, will be refreshed' },
+        { name: skill('layout', 'SKILL.md'), content: 'my own skill' },
+      ];
+
+      const projectDir = await runCliKeepingProjectDir({
+        commandClass: SkillsUpdateCommand,
+        files,
+        std: [{ out: "Kept your own version of 1 file(s) we've never written" }],
+      });
+
+      try {
+        const at = p => path.join(projectDir, p);
+        expect(fs.readFileSync(at(skill('layout', 'SKILL.md')), 'utf8')).toBe('my own skill');
+        // …while the file we did write is refreshed as usual.
+        expect(fs.readFileSync(at(skill('onboard', 'SKILL.md')), 'utf8')).toBe(
+          '# onboard skill (fresh)',
+        );
       } finally {
         fs.rmSync(projectDir, { recursive: true, force: true });
       }
@@ -155,14 +173,14 @@ describe('skills:update', () => {
 
     it('logs the ref transition when the manifest was pinned to another ref', async () => {
       expect.hasAssertions();
-      mockMarketplaceFetch();
+      mockPipeline();
 
       const files = [
         {
           name: '.forest/skills-manifest.json',
-          content: previousManifest('v2.1.0', ['.claude/skills/layout/SKILL.md']),
+          content: previousManifest('v2.1.0', [skill('layout', 'SKILL.md')]),
         },
-        { name: '.claude/skills/layout/SKILL.md', content: 'outdated content' },
+        { name: skill('layout', 'SKILL.md'), content: 'outdated content' },
       ];
 
       const projectDir = await runCliKeepingProjectDir({
@@ -188,14 +206,14 @@ describe('skills:update', () => {
 
     it('passes the requested --ref through to the fetch and the manifest', async () => {
       expect.hasAssertions();
-      mockMarketplaceFetch();
+      mockPipeline();
 
       const files = [
         {
           name: '.forest/skills-manifest.json',
-          content: previousManifest('v2.1.0', ['.claude/skills/layout/SKILL.md']),
+          content: previousManifest('v2.1.0', [skill('layout', 'SKILL.md')]),
         },
-        { name: '.claude/skills/layout/SKILL.md', content: 'outdated content' },
+        { name: skill('layout', 'SKILL.md'), content: 'outdated content' },
       ];
 
       const projectDir = await runCliKeepingProjectDir({
@@ -215,6 +233,46 @@ describe('skills:update', () => {
       } finally {
         fs.rmSync(projectDir, { recursive: true, force: true });
       }
+    });
+  });
+
+  describe('on the plugin route', () => {
+    it('re-installs the plugin and never fetches the tarball', async () => {
+      expect.hasAssertions();
+      mockPipeline();
+
+      await testCli({
+        commandClass: SkillsUpdateCommand,
+        files: [
+          {
+            name: '.forest/skills-manifest.json',
+            content: previousManifest('main', ['CLAUDE.md'], ['claude']),
+          },
+        ],
+        std: [{ out: 'Claude Code: Forest plugins refreshed (forest)' }],
+      });
+
+      expect(upgradePlugins).toHaveBeenCalledWith('claude', 'main');
+      // No copy route in play → the marketplace tarball is never downloaded.
+      expect(fetchMarketplace).not.toHaveBeenCalled();
+    });
+
+    it('warns and carries on when the agent CLI is not installed', async () => {
+      expect.hasAssertions();
+      mockPipeline({ cliPresent: false });
+
+      await testCli({
+        commandClass: SkillsUpdateCommand,
+        files: [
+          {
+            name: '.forest/skills-manifest.json',
+            content: previousManifest('main', ['CLAUDE.md'], ['claude']),
+          },
+        ],
+        std: [{ out: 'Claude Code: CLI not on your PATH' }],
+      });
+
+      expect(upgradePlugins).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/commands/skills/update.test.js
+++ b/test/commands/skills/update.test.js
@@ -17,21 +17,32 @@ jest.mock('../../../src/services/skills/skills-manager', () => ({
 const SkillsUpdateCommand = require('../../../src/commands/skills/update').default;
 const {
   SKILLS_DIR,
-  SKILL_SOURCES,
   fetchMarketplace,
   hasPluginCli,
   upgradePlugins,
 } = require('../../../src/services/skills/skills-manager');
 
-// Build a fake extracted marketplace holding every curated skill (derived from SKILL_SOURCES so
-// the fixture stays in sync with the real list).
+// Build a fake extracted marketplace: each plugin ships its skills as SKILL.md dirs, exactly as
+// the real bundle does — including deploy-heroku, which the old curated list dropped.
+const BUNDLE_SKILLS = {
+  forest: [
+    'boot-standalone-agent',
+    'deploy-heroku',
+    'layout',
+    'management',
+    'onboard',
+    'workflows',
+  ],
+  'forest-code': ['forest-code', 'forest-legacy'],
+};
+
 function makeFakeBundle() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skills-update-test-'));
   const write = (p, c) => {
     fs.mkdirSync(path.dirname(p), { recursive: true });
     fs.writeFileSync(p, c);
   };
-  SKILL_SOURCES.forEach(({ plugin, skills }) =>
+  Object.entries(BUNDLE_SKILLS).forEach(([plugin, skills]) =>
     skills.forEach(skill =>
       write(path.join(root, plugin, 'skills', skill, 'SKILL.md'), `# ${skill} skill (fresh)`),
     ),

--- a/test/commands/skills/update.test.js
+++ b/test/commands/skills/update.test.js
@@ -1,0 +1,220 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const testCli = require('../test-cli-helper/test-cli');
+
+// Mock ONLY the network fetch: the command's real orchestration (validation, install, block
+// merge, stale-pruning, manifest rewrite) runs against a fake extracted bundle on disk.
+jest.mock('../../../src/services/skills/skills-manager', () => ({
+  ...jest.requireActual('../../../src/services/skills/skills-manager'),
+  fetchMarketplace: jest.fn(),
+}));
+
+const SkillsUpdateCommand = require('../../../src/commands/skills/update').default;
+const { SKILL_SOURCES, fetchMarketplace } = require('../../../src/services/skills/skills-manager');
+
+// Build a fake extracted marketplace holding every curated skill (derived from SKILL_SOURCES so
+// the fixture stays in sync with the real list) + forest-docs/.mcp.json.
+function makeFakeBundle() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skills-update-test-'));
+  const write = (p, c) => {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, c);
+  };
+  SKILL_SOURCES.forEach(({ plugin, skills }) =>
+    skills.forEach(skill =>
+      write(path.join(root, plugin, 'skills', skill, 'SKILL.md'), `# ${skill} skill (fresh)`),
+    ),
+  );
+  write(
+    path.join(root, 'forest-docs', '.mcp.json'),
+    JSON.stringify({
+      mcpServers: { 'forest-docs': { type: 'http', url: 'https://docs.forest.app/mcp' } },
+    }),
+  );
+  return root;
+}
+
+function mockMarketplaceFetch() {
+  fetchMarketplace.mockReset();
+  fetchMarketplace.mockImplementation(async () => {
+    const root = makeFakeBundle();
+    return { root, cleanup: () => fs.rmSync(root, { recursive: true, force: true }) };
+  });
+}
+
+// Run testCli but keep the temporary project directory so the resulting disk state can be
+// asserted; returns that directory — the caller must remove it afterwards.
+async function runCliKeepingProjectDir(options) {
+  const previousFlag = process.env.KEEP_TEMPORARY_FILES;
+  process.env.KEEP_TEMPORARY_FILES = '1';
+  try {
+    await testCli(options);
+  } finally {
+    if (previousFlag === undefined) delete process.env.KEEP_TEMPORARY_FILES;
+    else process.env.KEEP_TEMPORARY_FILES = previousFlag;
+  }
+  // testCli assigns the temporary project directory to each file lacking an explicit chdir.
+  return options.files[0].chdir;
+}
+
+const previousManifest = (ref, files) =>
+  JSON.stringify({ ref, installedAt: '2026-01-01T00:00:00.000Z', agents: ['claude'], files });
+
+describe('skills:update', () => {
+  describe('when no manifest exists', () => {
+    it('exits with an error and never reaches the marketplace', async () => {
+      expect.hasAssertions();
+      mockMarketplaceFetch();
+
+      await testCli({
+        commandClass: SkillsUpdateCommand,
+        exitCode: 1,
+        std: [
+          { err: 'No Forest skills found in this repo.' },
+          { out: 'help: run forest skills:init first.' },
+        ],
+      });
+
+      // Bailed out before the pipeline: nothing fetched, hence nothing written.
+      expect(fetchMarketplace).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the local .mcp.json is unparsable', () => {
+    it('fails fast before fetching or mutating anything', async () => {
+      expect.hasAssertions();
+      mockMarketplaceFetch();
+
+      await testCli({
+        commandClass: SkillsUpdateCommand,
+        files: [
+          {
+            name: '.forest/skills-manifest.json',
+            content: previousManifest('main', ['.claude/skills/layout/SKILL.md']),
+          },
+          { name: '.mcp.json', content: '{ not valid json' },
+        ],
+        exitMessage:
+          "Cannot parse existing .mcp.json; aborting before any changes so it isn't overwritten. " +
+          'Fix or remove it, then re-run.',
+      });
+
+      expect(fetchMarketplace).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when a manifest exists', () => {
+    it('refreshes managed files, prunes stale ones and rewrites the manifest', async () => {
+      expect.hasAssertions();
+      mockMarketplaceFetch();
+
+      const files = [
+        {
+          name: '.forest/skills-manifest.json',
+          content: previousManifest('main', [
+            '.claude/skills/layout/SKILL.md',
+            '.claude/skills/old-skill/SKILL.md', // left the upstream bundle since
+            'CLAUDE.md',
+            '.mcp.json',
+          ]),
+        },
+        { name: '.claude/skills/layout/SKILL.md', content: 'outdated content' },
+        { name: '.claude/skills/old-skill/SKILL.md', content: 'stale content' },
+      ];
+
+      const projectDir = await runCliKeepingProjectDir({
+        commandClass: SkillsUpdateCommand,
+        files,
+        std: [
+          { out: 'Refreshing Forest skills from ForestAdmin/ai-marketplace@main' },
+          { out: 'Forest skills refreshed for claude, codex' },
+        ],
+      });
+
+      try {
+        const at = p => path.join(projectDir, p);
+        // Managed file refreshed from the bundle.
+        expect(fs.readFileSync(at('.claude/skills/layout/SKILL.md'), 'utf8')).toBe(
+          '# layout skill (fresh)',
+        );
+        // Stale managed file (in the old manifest, gone upstream) pruned.
+        expect(fs.existsSync(at('.claude/skills/old-skill/SKILL.md'))).toBe(false);
+        // Freshly installed files NOT pruned (removeStaleSkillFiles argument order).
+        expect(fs.existsSync(at('.claude/skills/forest-code/SKILL.md'))).toBe(true);
+        expect(fs.existsSync(at('.agents/skills/layout/SKILL.md'))).toBe(true);
+        // Manifest rewritten with the effective ref and the refreshed file list.
+        const manifest = JSON.parse(fs.readFileSync(at('.forest/skills-manifest.json'), 'utf8'));
+        expect(manifest.ref).toBe('main');
+        expect(manifest.files).toContain(path.join('.claude/skills', 'forest-code', 'SKILL.md'));
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+
+    it('logs the ref transition when the manifest was pinned to another ref', async () => {
+      expect.hasAssertions();
+      mockMarketplaceFetch();
+
+      const files = [
+        {
+          name: '.forest/skills-manifest.json',
+          content: previousManifest('v2.1.0', ['.claude/skills/layout/SKILL.md']),
+        },
+        { name: '.claude/skills/layout/SKILL.md', content: 'outdated content' },
+      ];
+
+      const projectDir = await runCliKeepingProjectDir({
+        commandClass: SkillsUpdateCommand,
+        files,
+        std: [
+          { out: 'Skills were installed from "v2.1.0"; updating to "main".' },
+          { out: '--ref v2.1.0' }, // the way back to the pin is spelled out
+          { out: 'Forest skills refreshed' },
+        ],
+      });
+
+      try {
+        // The de-pin is applied (and recorded) — only the silence around it was the bug.
+        const manifest = JSON.parse(
+          fs.readFileSync(path.join(projectDir, '.forest/skills-manifest.json'), 'utf8'),
+        );
+        expect(manifest.ref).toBe('main');
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+
+    it('passes the requested --ref through to the fetch and the manifest', async () => {
+      expect.hasAssertions();
+      mockMarketplaceFetch();
+
+      const files = [
+        {
+          name: '.forest/skills-manifest.json',
+          content: previousManifest('v2.1.0', ['.claude/skills/layout/SKILL.md']),
+        },
+        { name: '.claude/skills/layout/SKILL.md', content: 'outdated content' },
+      ];
+
+      const projectDir = await runCliKeepingProjectDir({
+        commandClass: SkillsUpdateCommand,
+        commandArgs: ['--ref', 'v2.1.0'],
+        files,
+        // Staying on the pinned ref: no transition warning to emit.
+        std: [{ out: 'Refreshing Forest skills from ForestAdmin/ai-marketplace@v2.1.0' }],
+      });
+
+      try {
+        expect(fetchMarketplace).toHaveBeenCalledWith('v2.1.0');
+        const manifest = JSON.parse(
+          fs.readFileSync(path.join(projectDir, '.forest/skills-manifest.json'), 'utf8'),
+        );
+        expect(manifest.ref).toBe('v2.1.0');
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/test/commands/skills/update.test.js
+++ b/test/commands/skills/update.test.js
@@ -182,6 +182,43 @@ describe('skills:update', () => {
       }
     });
 
+    it('treats a manifest with no `agents` as a copy install rather than refreshing nothing', async () => {
+      expect.hasAssertions();
+      mockPipeline();
+
+      const files = [
+        {
+          name: '.forest/skills-manifest.json',
+          // Predates the `agents` field: it can only have come from a copy-route install.
+          content: JSON.stringify({
+            ref: 'main',
+            installedAt: '2026-01-01T00:00:00.000Z',
+            files: [skill('layout', 'SKILL.md')],
+          }),
+        },
+        { name: skill('layout', 'SKILL.md'), content: 'outdated content' },
+      ];
+
+      const projectDir = await runCliKeepingProjectDir({
+        commandClass: SkillsUpdateCommand,
+        files,
+        std: [{ out: 'Forest skills refreshed in .agents/skills/' }],
+      });
+
+      try {
+        const at = p => path.join(projectDir, p);
+        // Refreshed, not ignored…
+        expect(fs.readFileSync(at(skill('layout', 'SKILL.md')), 'utf8')).toBe(
+          '# layout skill (fresh)',
+        );
+        // …and still tracked, so a later run can still prune what leaves the bundle.
+        const manifest = JSON.parse(fs.readFileSync(at('.forest/skills-manifest.json'), 'utf8'));
+        expect(manifest.files).toContain(skill('layout', 'SKILL.md'));
+      } finally {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+      }
+    });
+
     it('logs the ref transition when the manifest was pinned to another ref', async () => {
       expect.hasAssertions();
       mockPipeline();

--- a/test/services/skills/skills-manager.unit.test.ts
+++ b/test/services/skills/skills-manager.unit.test.ts
@@ -7,6 +7,7 @@ import {
   MARKETPLACE_REPO,
   SKILLS_DIR,
   contextFileFor,
+  contextFileGroups,
   copyDir,
   detectAgents,
   forestBlock,
@@ -101,9 +102,27 @@ describe('skills-manager', () => {
     });
 
     it('words the context block for the route actually applied', () => {
+      expect.assertions(4);
+      expect(forestBlock(['claude'])).toContain('`forest` plugin');
+      expect(forestBlock(['claude'])).not.toContain(SKILLS_DIR);
+      expect(forestBlock(['cursor'])).toContain(SKILLS_DIR);
+      expect(forestBlock(['cursor'])).not.toContain('`forest` plugin');
+    });
+
+    it('covers BOTH routes in one block when a single context file serves both', () => {
       expect.assertions(2);
-      expect(forestBlock('claude')).toContain('`forest` plugin');
-      expect(forestBlock('cursor')).toContain(SKILLS_DIR);
+      // AGENTS.md is Codex's (plugin) and Cursor's (copy) alike.
+      const block = forestBlock(['codex', 'cursor']);
+      expect(block).toContain('`forest` plugin');
+      expect(block).toContain(SKILLS_DIR);
+    });
+
+    it('groups agents by context file so each file is merged exactly once', () => {
+      expect.assertions(3);
+      const groups = contextFileGroups(['claude', 'codex', 'cursor', 'opencode']);
+      expect([...groups.keys()].sort()).toStrictEqual(['AGENTS.md', 'CLAUDE.md']);
+      expect(groups.get('CLAUDE.md')).toStrictEqual(['claude']);
+      expect(groups.get('AGENTS.md')).toStrictEqual(['codex', 'cursor', 'opencode']);
     });
   });
 
@@ -196,6 +215,34 @@ describe('skills-manager', () => {
         expect(() => installSkills(root, false, null)).toThrow(
           /No skills found in the marketplace/,
         );
+      });
+    });
+
+    it('never destroys a user file sitting where a skill dir belongs', () => {
+      expect.assertions(3);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        fs.mkdirSync(SKILLS_DIR, { recursive: true });
+        fs.writeFileSync(path.join(SKILLS_DIR, 'layout'), 'a file, not a dir — and mine');
+        const { written, skipped } = installSkills(root, false, null);
+        expect(fs.readFileSync(path.join(SKILLS_DIR, 'layout'), 'utf8')).toBe(
+          'a file, not a dir — and mine',
+        );
+        expect(skipped).toContain(path.join(SKILLS_DIR, 'layout'));
+        expect(written).not.toContain(layoutSkill);
+      });
+    });
+
+    it('does not let --force overwrite files no previous run wrote', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        fs.mkdirSync(path.join(SKILLS_DIR, 'layout'), { recursive: true });
+        fs.writeFileSync(layoutSkill, 'my own skill');
+        // --force with NO previous manifest: nothing is managed, so nothing may be overwritten.
+        const { skipped } = installSkills(root, true, null);
+        expect(fs.readFileSync(layoutSkill, 'utf8')).toBe('my own skill');
+        expect(skipped).toContain(layoutSkill);
       });
     });
 

--- a/test/services/skills/skills-manager.unit.test.ts
+++ b/test/services/skills/skills-manager.unit.test.ts
@@ -246,6 +246,36 @@ describe('skills-manager', () => {
       });
     });
 
+    it('refuses to write through a symlinked ancestor of the skills dir', () => {
+      expect.assertions(2);
+      const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'skills-outside-'));
+      try {
+        withTempDir(dir => {
+          const root = fakeMarketplace(path.join(dir, 'src'));
+          // `.agents` points elsewhere: mkdirSync -r would follow it and write outside the project.
+          fs.symlinkSync(outside, '.agents');
+          expect(() => installSkills(root, false, null)).toThrow(/symlinked directory/);
+          expect(fs.readdirSync(outside)).toStrictEqual([]);
+        });
+      } finally {
+        fs.rmSync(outside, { recursive: true, force: true });
+      }
+    });
+
+    it('refuses a symlinked <plugin>/skills root (crafted-marketplace ancestor escape)', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        fs.mkdirSync(path.join(dir, 'host', 'private'), { recursive: true });
+        fs.writeFileSync(path.join(dir, 'host', 'private', 'SKILL.md'), 'local secret');
+        fs.rmSync(path.join(root, 'forest-code', 'skills'), { recursive: true, force: true });
+        fs.symlinkSync(path.join(dir, 'host'), path.join(root, 'forest-code', 'skills'));
+        const { written } = installSkills(root, false, null);
+        expect(fs.existsSync(path.join(SKILLS_DIR, 'private'))).toBe(false);
+        expect(written.every(f => !f.includes('private'))).toBe(true);
+      });
+    });
+
     it('ignores a stray directory that carries no SKILL.md', () => {
       expect.assertions(1);
       withTempDir(dir => {
@@ -423,6 +453,35 @@ describe('skills-manager', () => {
       });
     });
 
+    it('refuses to delete through a skill dir symlinked at another directory INSIDE the project', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        // The classic near-miss: the link target stays under the project root, so a project-root
+        // containment check would authorise deleting straight through it.
+        fs.mkdirSync('src', { recursive: true });
+        fs.writeFileSync('src/index.ts', 'application code');
+        fs.mkdirSync(SKILLS_DIR, { recursive: true });
+        fs.symlinkSync(path.resolve('src'), path.join(SKILLS_DIR, 'layout'));
+        const removed = removeStaleSkillFiles([path.join(SKILLS_DIR, 'layout', 'index.ts')], []);
+        expect(removed).toStrictEqual([]);
+        expect(fs.readFileSync('src/index.ts', 'utf8')).toBe('application code');
+      });
+    });
+
+    it('prunes an entry written with Windows separators when running on Unix', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        const stale = path.join(SKILLS_DIR, 'layout', 'stale.md');
+        fs.mkdirSync(path.dirname(stale), { recursive: true });
+        fs.writeFileSync(stale, 'old');
+        // A manifest written on Windows: comparing on normalized paths is not enough, the
+        // existence check and the deletion must act on the normalized form too.
+        const removed = removeStaleSkillFiles(['.agents\\skills\\layout\\stale.md'], []);
+        expect(removed).toStrictEqual([stale]);
+        expect(fs.existsSync(stale)).toBe(false);
+      });
+    });
+
     it('refuses to delete through a symlinked skills dir pointing outside the project', () => {
       expect.assertions(2);
       // The link target must live OUTSIDE the project root, or it is legitimately in scope.
@@ -584,6 +643,21 @@ describe('skills-manager', () => {
         expect(readManifest()).toBeNull();
         fs.writeFileSync('.forest/skills-manifest.json', '{}'); // valid JSON, wrong shape
         expect(readManifest()).toBeNull();
+      });
+    });
+
+    it('normalizes a non-array `agents` away so callers never call .filter on it', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.mkdirSync('.forest', { recursive: true });
+        fs.writeFileSync(
+          '.forest/skills-manifest.json',
+          JSON.stringify({ ref: 'main', installedAt: 'x', agents: {}, files: [] }),
+        );
+        const manifest = readManifest();
+        // Still a usable manifest — `files` is what makes it valid — with `agents` neutralised.
+        expect(manifest?.files).toStrictEqual([]);
+        expect(manifest?.agents).toBeUndefined();
       });
     });
   });

--- a/test/services/skills/skills-manager.unit.test.ts
+++ b/test/services/skills/skills-manager.unit.test.ts
@@ -12,6 +12,8 @@ import {
   readManifest,
   removeStaleSkillFiles,
   skillDirEntries,
+  validateLocalMcp,
+  validateMarketplaceBundle,
   writeManifest,
 } from '../../../src/services/skills/skills-manager';
 
@@ -428,6 +430,62 @@ describe('skills-manager', () => {
         installDocsMcp(root);
         const mcp = JSON.parse(fs.readFileSync('.mcp.json', 'utf8'));
         expect(mcp.mcpServers['forest-docs']).toBeDefined();
+      });
+    });
+  });
+
+  describe('validateLocalMcp', () => {
+    it('passes when no .mcp.json exists', () => {
+      expect.assertions(1);
+      withTempDir(() => {
+        expect(() => validateLocalMcp()).not.toThrow();
+      });
+    });
+
+    it('passes on a parsable .mcp.json', () => {
+      expect.assertions(1);
+      withTempDir(() => {
+        fs.writeFileSync('.mcp.json', JSON.stringify({ mcpServers: {} }));
+        expect(() => validateLocalMcp()).not.toThrow();
+      });
+    });
+
+    it('throws a clear error on an unparsable .mcp.json (fail fast, before any install)', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.writeFileSync('.mcp.json', '{ not valid json');
+        expect(() => validateLocalMcp()).toThrow(/Cannot parse existing \.mcp\.json/);
+        expect(fs.readFileSync('.mcp.json', 'utf8')).toBe('{ not valid json'); // left untouched
+      });
+    });
+
+    it('passes on a symlinked .mcp.json (replaced, never read, at install time)', () => {
+      expect.assertions(1);
+      withTempDir(() => {
+        fs.writeFileSync('outside.json', '{ not valid json');
+        fs.symlinkSync(path.resolve('outside.json'), '.mcp.json');
+        expect(() => validateLocalMcp()).not.toThrow();
+      });
+    });
+  });
+
+  describe('validateMarketplaceBundle', () => {
+    it('passes when the bundle carries forest-docs/.mcp.json', () => {
+      expect.assertions(1);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        expect(() => validateMarketplaceBundle(root, 'main')).not.toThrow();
+      });
+    });
+
+    it('throws a clear error naming the ref when forest-docs/.mcp.json is missing', () => {
+      expect.assertions(1);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        fs.rmSync(path.join(root, 'forest-docs'), { recursive: true, force: true });
+        expect(() => validateMarketplaceBundle(root, 'v1.2.3')).toThrow(
+          /ref "v1\.2\.3" has no forest-docs\/\.mcp\.json/,
+        );
       });
     });
   });

--- a/test/services/skills/skills-manager.unit.test.ts
+++ b/test/services/skills/skills-manager.unit.test.ts
@@ -440,6 +440,24 @@ describe('skills-manager', () => {
       });
     });
 
+    it('lets a repo signal win over an installed CLI, so a machine with every agent does not pre-check them all', () => {
+      expect.assertions(1);
+      mockCli(); // claude AND codex both answer --version on this machine
+      withTempDir(() => {
+        fs.mkdirSync('.cursor');
+        // Only what this repo actually uses — not everything the developer happens to have.
+        expect(detectAgents()).toStrictEqual(['cursor']);
+      });
+    });
+
+    it('falls back to the installed CLIs when the repo carries no signal at all', () => {
+      expect.assertions(1);
+      mockCli();
+      withTempDir(() => {
+        expect(detectAgents()).toStrictEqual(['claude', 'codex']);
+      });
+    });
+
     it('returns nothing in a bare repo with no agent CLI installed', () => {
       expect.assertions(1);
       mockCli({ failing: /--version/ });

--- a/test/services/skills/skills-manager.unit.test.ts
+++ b/test/services/skills/skills-manager.unit.test.ts
@@ -6,7 +6,6 @@ import {
   FOREST_PLUGINS,
   MARKETPLACE_REPO,
   SKILLS_DIR,
-  SKILL_PLUGINS,
   contextFileFor,
   copyDir,
   detectAgents,
@@ -177,12 +176,26 @@ describe('skills-manager', () => {
       });
     });
 
-    it('throws when a plugin carries no skills at all (no misleading partial install)', () => {
+    it('skips a plugin that carries no skills instead of rejecting it (forest-docs is MCP-only)', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        // forest-docs is in FOREST_PLUGINS but ships no skills/ — that is normal, not an error.
+        expect(FOREST_PLUGINS).toContain('forest-docs');
+        expect(() => installSkills(root, false, null)).not.toThrow();
+      });
+    });
+
+    it('throws when the bundle yields no skill at all (marketplace layout moved)', () => {
       expect.assertions(1);
       withTempDir(dir => {
         const root = fakeMarketplace(path.join(dir, 'src'));
-        fs.rmSync(path.join(root, SKILL_PLUGINS[0], 'skills'), { recursive: true, force: true });
-        expect(() => installSkills(root, false, null)).toThrow(/has no skills\/ directory/);
+        Object.keys(BUNDLE_SKILLS).forEach(plugin =>
+          fs.rmSync(path.join(root, plugin, 'skills'), { recursive: true, force: true }),
+        );
+        expect(() => installSkills(root, false, null)).toThrow(
+          /No skills found in the marketplace/,
+        );
       });
     });
 

--- a/test/services/skills/skills-manager.unit.test.ts
+++ b/test/services/skills/skills-manager.unit.test.ts
@@ -1,0 +1,434 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  SKILL_SOURCES,
+  contextFileFor,
+  copyDir,
+  installDocsMcp,
+  installSkills,
+  mergeBlock,
+  readManifest,
+  removeStaleSkillFiles,
+  skillDirEntries,
+  writeManifest,
+} from '../../../src/services/skills/skills-manager';
+
+// Run `fn` inside a throwaway temp dir (cwd), restoring + cleaning up afterwards.
+// A helper (not a jest hook) — this repo forbids beforeEach/afterEach (jest/no-hooks).
+function withTempDir(run: (dir: string) => void): void {
+  const previousCwd = process.cwd();
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'skills-test-'));
+  process.chdir(tmp);
+  try {
+    run(tmp);
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+// Build a fake extracted marketplace holding every curated skill (derived from SKILL_SOURCES so
+// the fixture stays in sync with the real list) + forest-docs/.mcp.json.
+function fakeMarketplace(root: string): string {
+  const write = (p: string, c: string) => {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, c);
+  };
+  SKILL_SOURCES.forEach(({ plugin, skills }) =>
+    skills.forEach(skill =>
+      write(path.join(root, plugin, 'skills', skill, 'SKILL.md'), `# ${skill} skill`),
+    ),
+  );
+  write(path.join(root, 'forest', 'skills', 'layout', 'references', 'a.md'), 'ref a');
+  write(
+    path.join(root, 'forest-docs', '.mcp.json'),
+    JSON.stringify({
+      mcpServers: { 'forest-docs': { type: 'http', url: 'https://docs.forest.app/mcp' } },
+    }),
+  );
+
+  return root;
+}
+
+describe('skills-manager', () => {
+  describe('contextFileFor', () => {
+    it('maps claude to CLAUDE.md', () => {
+      expect.assertions(1);
+      expect(contextFileFor('claude')).toBe('CLAUDE.md');
+    });
+
+    it('maps any other agent to AGENTS.md', () => {
+      expect.assertions(1);
+      expect(contextFileFor('codex')).toBe('AGENTS.md');
+    });
+  });
+
+  describe('mergeBlock', () => {
+    it('creates the file with a delimited Forest block when absent', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        mergeBlock('CLAUDE.md', 'hello forest');
+        const content = fs.readFileSync('CLAUDE.md', 'utf8');
+        expect(content).toContain('<!-- forest:begin -->');
+        expect(content).toContain('hello forest');
+      });
+    });
+
+    it('preserves pre-existing user content and appends the block', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.writeFileSync('CLAUDE.md', '# My own notes\n');
+        mergeBlock('CLAUDE.md', 'forest block');
+        const content = fs.readFileSync('CLAUDE.md', 'utf8');
+        expect(content).toContain('# My own notes');
+        expect(content).toContain('forest block');
+      });
+    });
+
+    it('replaces only the Forest block on re-merge, keeping user content', () => {
+      expect.assertions(3);
+      withTempDir(() => {
+        fs.writeFileSync('CLAUDE.md', '# Notes\n');
+        mergeBlock('CLAUDE.md', 'version one');
+        mergeBlock('CLAUDE.md', 'version two');
+        const content = fs.readFileSync('CLAUDE.md', 'utf8');
+        expect(content).toContain('# Notes');
+        expect(content).toContain('version two');
+        expect(content).not.toContain('version one');
+      });
+    });
+  });
+
+  describe('installSkills', () => {
+    it('copies the curated skill bundles into the agent dir', () => {
+      expect.assertions(3);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        const written = installSkills(root, 'claude', false);
+        expect(fs.existsSync('.claude/skills/layout/SKILL.md')).toBe(true);
+        expect(fs.existsSync('.claude/skills/forest-code/SKILL.md')).toBe(true);
+        expect(written).toContain(path.join('.claude/skills', 'layout', 'references', 'a.md'));
+      });
+    });
+
+    it('throws when a curated skill is absent from the marketplace (no misleading partial install)', () => {
+      expect.assertions(1);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        const { plugin, skills } = SKILL_SOURCES[0];
+        fs.rmSync(path.join(root, plugin, 'skills', skills[0]), { recursive: true, force: true });
+        expect(() => installSkills(root, 'claude', false)).toThrow(/missing from the marketplace/);
+      });
+    });
+
+    it('skips an already-installed skill unless force is set', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        installSkills(root, 'claude', false);
+        fs.writeFileSync('.claude/skills/layout/SKILL.md', 'edited');
+        installSkills(root, 'claude', false); // no force → keep edit
+        expect(fs.readFileSync('.claude/skills/layout/SKILL.md', 'utf8')).toBe('edited');
+        installSkills(root, 'claude', true); // force → overwrite
+        expect(fs.readFileSync('.claude/skills/layout/SKILL.md', 'utf8')).toBe('# layout skill');
+      });
+    });
+
+    it('reports existing files on a no-force re-run so the manifest stays complete', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        const first = installSkills(root, 'claude', false);
+        const second = installSkills(root, 'claude', false); // skips copy, still lists the files
+        expect(second).toHaveLength(first.length);
+        expect(second).toContain(path.join('.claude/skills', 'layout', 'SKILL.md'));
+      });
+    });
+
+    it('overlays on force, preserving user-added files in the skill dir (no blind dir wipe)', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        installSkills(root, 'claude', false);
+        fs.writeFileSync('.claude/skills/layout/my-notes.md', 'mine');
+        installSkills(root, 'claude', true); // force → overlay, not a dir nuke
+        expect(fs.readFileSync('.claude/skills/layout/my-notes.md', 'utf8')).toBe('mine');
+        expect(fs.readFileSync('.claude/skills/layout/SKILL.md', 'utf8')).toBe('# layout skill');
+      });
+    });
+
+    it('replaces a stray non-directory sitting where a skill dir belongs', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        fs.mkdirSync('.claude/skills', { recursive: true });
+        fs.writeFileSync('.claude/skills/layout', 'stray file, not a dir');
+        installSkills(root, 'claude', false);
+        expect(fs.statSync('.claude/skills/layout').isDirectory()).toBe(true);
+        expect(fs.existsSync('.claude/skills/layout/SKILL.md')).toBe(true);
+      });
+    });
+
+    it('never reports user-added files as managed on a no-force re-run (so they are not pruned)', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        installSkills(root, 'claude', false);
+        fs.writeFileSync('.claude/skills/layout/my-notes.md', 'mine');
+        const reported = installSkills(root, 'claude', false);
+        expect(reported).not.toContain(path.join('.claude/skills', 'layout', 'my-notes.md'));
+        expect(reported).toContain(path.join('.claude/skills', 'layout', 'SKILL.md'));
+      });
+    });
+  });
+
+  describe('copyDir', () => {
+    it('replaces a destination symlink instead of following it (no writes outside the project)', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.mkdirSync('src-skill', { recursive: true });
+        fs.writeFileSync('src-skill/SKILL.md', 'new content');
+        fs.writeFileSync('outside.md', 'protected');
+        fs.mkdirSync('dest', { recursive: true });
+        fs.symlinkSync(path.resolve('outside.md'), 'dest/SKILL.md'); // planted link to a file outside
+        copyDir('src-skill', 'dest');
+        expect(fs.readFileSync('outside.md', 'utf8')).toBe('protected'); // link target untouched
+        expect(fs.readFileSync('dest/SKILL.md', 'utf8')).toBe('new content'); // real file written in place
+      });
+    });
+
+    it('skips a symlink in the SOURCE bundle (never copies through it)', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.mkdirSync('src-skill', { recursive: true });
+        fs.writeFileSync('src-skill/SKILL.md', 'real');
+        fs.writeFileSync('secret.txt', 'private'); // a file the crafted symlink would point at
+        fs.symlinkSync(path.resolve('secret.txt'), 'src-skill/leak');
+        const written = copyDir('src-skill', 'dest');
+        expect(fs.existsSync('dest/leak')).toBe(false); // symlink entry skipped, not followed
+        expect(written).toStrictEqual([path.join('dest', 'SKILL.md')]); // only the real file copied
+      });
+    });
+
+    it('refuses a SOURCE dir that is itself a symlink (crafted-marketplace escape)', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.mkdirSync('host-dir', { recursive: true });
+        fs.writeFileSync('host-dir/private.txt', 'local secret');
+        fs.symlinkSync(path.resolve('host-dir'), 'src-link'); // the skill dir IS a symlink
+        const written = copyDir('src-link', 'dest');
+        expect(written).toStrictEqual([]); // nothing copied
+        expect(fs.existsSync('dest/private.txt')).toBe(false); // host file not exfiltrated
+      });
+    });
+  });
+
+  describe('symlink-safe writes', () => {
+    it('mergeBlock replaces a symlinked context file instead of following it', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.writeFileSync('outside.md', 'protected');
+        fs.symlinkSync(path.resolve('outside.md'), 'CLAUDE.md');
+        mergeBlock('CLAUDE.md', 'forest');
+        expect(fs.readFileSync('outside.md', 'utf8')).toBe('protected');
+        expect(fs.lstatSync('CLAUDE.md').isSymbolicLink()).toBe(false);
+      });
+    });
+
+    it('installDocsMcp replaces a symlinked .mcp.json instead of overwriting its target', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        fs.writeFileSync('outside.json', 'protected');
+        fs.symlinkSync(path.resolve('outside.json'), '.mcp.json');
+        installDocsMcp(root);
+        expect(fs.readFileSync('outside.json', 'utf8')).toBe('protected');
+        expect(fs.lstatSync('.mcp.json').isSymbolicLink()).toBe(false);
+      });
+    });
+
+    it('writeManifest does not write through a symlinked .forest dir', () => {
+      expect.assertions(1);
+      withTempDir(() => {
+        fs.mkdirSync('outside-dir');
+        fs.symlinkSync(path.resolve('outside-dir'), '.forest');
+        writeManifest({ ref: 'main', installedAt: 'x', agents: ['claude'], files: [] });
+        expect(fs.existsSync('outside-dir/skills-manifest.json')).toBe(false);
+      });
+    });
+  });
+
+  describe('skillDirEntries', () => {
+    it('keeps only entries under the skill dirs (normalized), dropping context/mcp files', () => {
+      expect.assertions(1);
+      expect(
+        skillDirEntries([
+          '.claude/skills/layout/SKILL.md',
+          '.agents\\skills\\layout\\SKILL.md', // windows-style separators
+          'CLAUDE.md',
+          '.mcp.json',
+        ]),
+      ).toStrictEqual(['.claude/skills/layout/SKILL.md', '.agents\\skills\\layout\\SKILL.md']);
+    });
+  });
+
+  describe('removeStaleSkillFiles', () => {
+    it('removes a previously-installed file that is gone upstream', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.mkdirSync('.claude/skills/layout', { recursive: true });
+        fs.writeFileSync('.claude/skills/layout/stale.md', 'old');
+        const removed = removeStaleSkillFiles(
+          ['.claude/skills/layout/stale.md'],
+          ['.claude/skills/layout/fresh.md'],
+        );
+        expect(removed).toStrictEqual(['.claude/skills/layout/stale.md']);
+        expect(fs.existsSync('.claude/skills/layout/stale.md')).toBe(false);
+      });
+    });
+
+    it('keeps files still produced by the current run', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.mkdirSync('.claude/skills/layout', { recursive: true });
+        fs.writeFileSync('.claude/skills/layout/keep.md', 'x');
+        const removed = removeStaleSkillFiles(
+          ['.claude/skills/layout/keep.md'],
+          ['.claude/skills/layout/keep.md'],
+        );
+        expect(removed).toHaveLength(0);
+        expect(fs.existsSync('.claude/skills/layout/keep.md')).toBe(true);
+      });
+    });
+
+    it('ignores previous entries that no longer exist on disk', () => {
+      expect.assertions(1);
+      withTempDir(() => {
+        expect(removeStaleSkillFiles(['.claude/skills/layout/ghost.md'], [])).toHaveLength(0);
+      });
+    });
+
+    it('refuses to delete a path that escapes the skill dirs (`..` traversal)', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.writeFileSync('precious.txt', 'keep me');
+        const removed = removeStaleSkillFiles(['.claude/skills/../../precious.txt'], []);
+        expect(removed).toHaveLength(0);
+        expect(fs.existsSync('precious.txt')).toBe(true);
+      });
+    });
+
+    it('matches previous vs current across path separators (Unix manifest, Windows run)', () => {
+      expect.assertions(1);
+      withTempDir(() => {
+        fs.mkdirSync('.claude/skills/layout', { recursive: true });
+        fs.writeFileSync('.claude/skills/layout/SKILL.md', 'x');
+        // Backslash "previous" must be recognized as the same file as forward-slash "current".
+        const removed = removeStaleSkillFiles(
+          ['.claude\\skills\\layout\\SKILL.md'],
+          ['.claude/skills/layout/SKILL.md'],
+        );
+        expect(removed).toHaveLength(0);
+      });
+    });
+
+    it('refuses to delete through a skill dir symlinked outside the project', () => {
+      expect.assertions(2);
+      const external = fs.mkdtempSync(path.join(os.tmpdir(), 'ext-'));
+      try {
+        fs.mkdirSync(path.join(external, 'layout'));
+        fs.writeFileSync(path.join(external, 'layout', 'old.md'), 'external file');
+        withTempDir(() => {
+          fs.mkdirSync('.claude', { recursive: true });
+          fs.symlinkSync(external, '.claude/skills'); // skills dir → outside the project
+          const removed = removeStaleSkillFiles(['.claude/skills/layout/old.md'], []);
+          expect(removed).toHaveLength(0);
+          expect(fs.existsSync(path.join(external, 'layout', 'old.md'))).toBe(true);
+        });
+      } finally {
+        fs.rmSync(external, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('installDocsMcp', () => {
+    it('writes the forest-docs MCP server from the marketplace', () => {
+      expect.assertions(1);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        installDocsMcp(root);
+        const mcp = JSON.parse(fs.readFileSync('.mcp.json', 'utf8'));
+        expect(mcp.mcpServers['forest-docs'].url).toBe('https://docs.forest.app/mcp');
+      });
+    });
+
+    it('preserves an existing MCP server the user already had', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        fs.writeFileSync('.mcp.json', JSON.stringify({ mcpServers: { other: { url: 'x' } } }));
+        installDocsMcp(root);
+        const mcp = JSON.parse(fs.readFileSync('.mcp.json', 'utf8'));
+        expect(mcp.mcpServers.other).toBeDefined();
+        expect(mcp.mcpServers['forest-docs']).toBeDefined();
+      });
+    });
+
+    it('aborts on a malformed existing .mcp.json instead of clobbering it', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        fs.writeFileSync('.mcp.json', '{ not valid json');
+        expect(() => installDocsMcp(root)).toThrow(/Cannot parse existing/);
+        expect(fs.readFileSync('.mcp.json', 'utf8')).toBe('{ not valid json');
+      });
+    });
+
+    it('treats a valid-but-non-object .mcp.json (JSON null) as empty instead of crashing', () => {
+      expect.assertions(1);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        fs.writeFileSync('.mcp.json', 'null');
+        installDocsMcp(root);
+        const mcp = JSON.parse(fs.readFileSync('.mcp.json', 'utf8'));
+        expect(mcp.mcpServers['forest-docs']).toBeDefined();
+      });
+    });
+  });
+
+  describe('manifest', () => {
+    it('returns null when no manifest exists', () => {
+      expect.assertions(1);
+      withTempDir(() => {
+        expect(readManifest()).toBeNull();
+      });
+    });
+
+    it('returns null for a valid-but-malformed manifest (no files array)', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.mkdirSync('.forest', { recursive: true });
+        fs.writeFileSync('.forest/skills-manifest.json', '{}');
+        expect(readManifest()).toBeNull();
+        fs.writeFileSync('.forest/skills-manifest.json', '[]');
+        expect(readManifest()).toBeNull();
+      });
+    });
+
+    it('round-trips through write/read', () => {
+      expect.assertions(1);
+      withTempDir(() => {
+        const manifest = {
+          ref: 'main',
+          installedAt: '2026-01-01',
+          agents: ['claude'],
+          files: ['a'],
+        };
+        writeManifest(manifest);
+        expect(readManifest()).toStrictEqual(manifest);
+      });
+    });
+  });
+});

--- a/test/services/skills/skills-manager.unit.test.ts
+++ b/test/services/skills/skills-manager.unit.test.ts
@@ -6,7 +6,7 @@ import {
   FOREST_PLUGINS,
   MARKETPLACE_REPO,
   SKILLS_DIR,
-  SKILL_SOURCES,
+  SKILL_PLUGINS,
   contextFileFor,
   copyDir,
   detectAgents,
@@ -50,14 +50,27 @@ function withTempDir(run: (dir: string) => void): void {
   }
 }
 
-// Build a fake extracted marketplace holding every curated skill (derived from SKILL_SOURCES so
-// the fixture stays in sync with the real list).
+// Build a fake extracted marketplace: each plugin ships its skills as SKILL.md dirs, exactly as
+// the real bundle does. `deploy-heroku` is in there on purpose — the old curated list excluded it
+// while the plugin route shipped it, which is the drift this fixture must be able to catch.
+const BUNDLE_SKILLS: Record<string, string[]> = {
+  forest: [
+    'boot-standalone-agent',
+    'deploy-heroku',
+    'layout',
+    'management',
+    'onboard',
+    'workflows',
+  ],
+  'forest-code': ['forest-code', 'forest-legacy'],
+};
+
 function fakeMarketplace(root: string): string {
   const write = (p: string, c: string) => {
     fs.mkdirSync(path.dirname(p), { recursive: true });
     fs.writeFileSync(p, c);
   };
-  SKILL_SOURCES.forEach(({ plugin, skills }) =>
+  Object.entries(BUNDLE_SKILLS).forEach(([plugin, skills]) =>
     skills.forEach(skill =>
       write(path.join(root, plugin, 'skills', skill, 'SKILL.md'), `# ${skill} skill`),
     ),
@@ -132,7 +145,7 @@ describe('skills-manager', () => {
   });
 
   describe('installSkills', () => {
-    it('copies the curated skill bundles into the single cross-agent skills dir', () => {
+    it('copies the skill bundles into the single cross-agent skills dir', () => {
       expect.assertions(3);
       withTempDir(dir => {
         const root = fakeMarketplace(path.join(dir, 'src'));
@@ -152,13 +165,34 @@ describe('skills-manager', () => {
       });
     });
 
-    it('throws when a curated skill is absent from the marketplace (no misleading partial install)', () => {
+    it('ships every skill the plugins carry, so the copy route matches the plugin route', () => {
+      expect.assertions(2);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        installSkills(root, false, null);
+        const shipped = fs.readdirSync(SKILLS_DIR).sort();
+        expect(shipped).toStrictEqual(Object.values(BUNDLE_SKILLS).flat().sort());
+        // The one the old curated list dropped, while `onboard` kept pointing at it.
+        expect(shipped).toContain('deploy-heroku');
+      });
+    });
+
+    it('throws when a plugin carries no skills at all (no misleading partial install)', () => {
       expect.assertions(1);
       withTempDir(dir => {
         const root = fakeMarketplace(path.join(dir, 'src'));
-        const { plugin, skills } = SKILL_SOURCES[0];
-        fs.rmSync(path.join(root, plugin, 'skills', skills[0]), { recursive: true, force: true });
-        expect(() => installSkills(root, false, null)).toThrow(/missing from the marketplace/);
+        fs.rmSync(path.join(root, SKILL_PLUGINS[0], 'skills'), { recursive: true, force: true });
+        expect(() => installSkills(root, false, null)).toThrow(/has no skills\/ directory/);
+      });
+    });
+
+    it('ignores a stray directory that carries no SKILL.md', () => {
+      expect.assertions(1);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        fs.mkdirSync(path.join(root, 'forest', 'skills', 'not-a-skill'), { recursive: true });
+        installSkills(root, false, null);
+        expect(fs.existsSync(path.join(SKILLS_DIR, 'not-a-skill'))).toBe(false);
       });
     });
 

--- a/test/services/skills/skills-manager.unit.test.ts
+++ b/test/services/skills/skills-manager.unit.test.ts
@@ -3,19 +3,38 @@ import os from 'os';
 import path from 'path';
 
 import {
+  FOREST_PLUGINS,
+  MARKETPLACE_REPO,
+  SKILLS_DIR,
   SKILL_SOURCES,
   contextFileFor,
   copyDir,
-  installDocsMcp,
+  detectAgents,
+  forestBlock,
+  hasPluginCli,
+  installPlugins,
   installSkills,
+  isPluginAgent,
   mergeBlock,
   readManifest,
   removeStaleSkillFiles,
   skillDirEntries,
-  validateLocalMcp,
-  validateMarketplaceBundle,
   writeManifest,
 } from '../../../src/services/skills/skills-manager';
+
+const spawnSync = jest.fn();
+
+jest.mock('child_process', () => ({ spawnSync: (...args) => spawnSync(...args) }));
+
+// Every CLI call succeeds, unless `failing` matches the joined args.
+function mockCli({ failing = null }: { failing?: RegExp | null } = {}) {
+  spawnSync.mockReset();
+  spawnSync.mockImplementation((bin, args) => ({
+    status: failing && failing.test(args.join(' ')) ? 1 : 0,
+    stdout: '',
+    stderr: '',
+  }));
+}
 
 // Run `fn` inside a throwaway temp dir (cwd), restoring + cleaning up afterwards.
 // A helper (not a jest hook) — this repo forbids beforeEach/afterEach (jest/no-hooks).
@@ -32,7 +51,7 @@ function withTempDir(run: (dir: string) => void): void {
 }
 
 // Build a fake extracted marketplace holding every curated skill (derived from SKILL_SOURCES so
-// the fixture stays in sync with the real list) + forest-docs/.mcp.json.
+// the fixture stays in sync with the real list).
 function fakeMarketplace(root: string): string {
   const write = (p: string, c: string) => {
     fs.mkdirSync(path.dirname(p), { recursive: true });
@@ -44,26 +63,35 @@ function fakeMarketplace(root: string): string {
     ),
   );
   write(path.join(root, 'forest', 'skills', 'layout', 'references', 'a.md'), 'ref a');
-  write(
-    path.join(root, 'forest-docs', '.mcp.json'),
-    JSON.stringify({
-      mcpServers: { 'forest-docs': { type: 'http', url: 'https://docs.forest.app/mcp' } },
-    }),
-  );
 
   return root;
 }
 
+const layoutSkill = path.join(SKILLS_DIR, 'layout', 'SKILL.md');
+
 describe('skills-manager', () => {
-  describe('contextFileFor', () => {
-    it('maps claude to CLAUDE.md', () => {
-      expect.assertions(1);
-      expect(contextFileFor('claude')).toBe('CLAUDE.md');
+  describe('agent families', () => {
+    it('routes claude and codex through their plugin CLI, everyone else through file copy', () => {
+      expect.assertions(5);
+      expect(isPluginAgent('claude')).toBe(true);
+      expect(isPluginAgent('codex')).toBe(true);
+      expect(isPluginAgent('cursor')).toBe(false);
+      expect(isPluginAgent('opencode')).toBe(false);
+      expect(isPluginAgent('other')).toBe(false);
     });
 
-    it('maps any other agent to AGENTS.md', () => {
-      expect.assertions(1);
+    it('maps claude to CLAUDE.md and every other agent to the cross-agent AGENTS.md', () => {
+      expect.assertions(4);
+      expect(contextFileFor('claude')).toBe('CLAUDE.md');
       expect(contextFileFor('codex')).toBe('AGENTS.md');
+      expect(contextFileFor('cursor')).toBe('AGENTS.md');
+      expect(contextFileFor('opencode')).toBe('AGENTS.md');
+    });
+
+    it('words the context block for the route actually applied', () => {
+      expect.assertions(2);
+      expect(forestBlock('claude')).toContain('`forest` plugin');
+      expect(forestBlock('cursor')).toContain(SKILLS_DIR);
     });
   });
 
@@ -104,14 +132,23 @@ describe('skills-manager', () => {
   });
 
   describe('installSkills', () => {
-    it('copies the curated skill bundles into the agent dir', () => {
+    it('copies the curated skill bundles into the single cross-agent skills dir', () => {
       expect.assertions(3);
       withTempDir(dir => {
         const root = fakeMarketplace(path.join(dir, 'src'));
-        const written = installSkills(root, 'claude', false, null);
-        expect(fs.existsSync('.claude/skills/layout/SKILL.md')).toBe(true);
-        expect(fs.existsSync('.claude/skills/forest-code/SKILL.md')).toBe(true);
-        expect(written).toContain(path.join('.claude/skills', 'layout', 'references', 'a.md'));
+        const { written } = installSkills(root, false, null);
+        expect(fs.existsSync(layoutSkill)).toBe(true);
+        expect(fs.existsSync(path.join(SKILLS_DIR, 'forest-code', 'SKILL.md'))).toBe(true);
+        expect(written).toContain(path.join(SKILLS_DIR, 'layout', 'references', 'a.md'));
+      });
+    });
+
+    it('never writes into .claude/skills (Claude Code is served by the plugin route)', () => {
+      expect.assertions(1);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        installSkills(root, false, null);
+        expect(fs.existsSync('.claude')).toBe(false);
       });
     });
 
@@ -121,9 +158,7 @@ describe('skills-manager', () => {
         const root = fakeMarketplace(path.join(dir, 'src'));
         const { plugin, skills } = SKILL_SOURCES[0];
         fs.rmSync(path.join(root, plugin, 'skills', skills[0]), { recursive: true, force: true });
-        expect(() => installSkills(root, 'claude', false, null)).toThrow(
-          /missing from the marketplace/,
-        );
+        expect(() => installSkills(root, false, null)).toThrow(/missing from the marketplace/);
       });
     });
 
@@ -131,91 +166,39 @@ describe('skills-manager', () => {
       expect.assertions(2);
       withTempDir(dir => {
         const root = fakeMarketplace(path.join(dir, 'src'));
-        const first = installSkills(root, 'claude', false, null);
-        fs.writeFileSync('.claude/skills/layout/SKILL.md', 'edited');
-        installSkills(root, 'claude', false, first); // no force → keep edit
-        expect(fs.readFileSync('.claude/skills/layout/SKILL.md', 'utf8')).toBe('edited');
-        installSkills(root, 'claude', true, first); // force → overwrite
-        expect(fs.readFileSync('.claude/skills/layout/SKILL.md', 'utf8')).toBe('# layout skill');
+        const { written: first } = installSkills(root, false, null);
+        fs.writeFileSync(layoutSkill, 'edited');
+        installSkills(root, false, first); // no force → keep edit
+        expect(fs.readFileSync(layoutSkill, 'utf8')).toBe('edited');
+        installSkills(root, true, first); // force → overwrite a file we wrote before
+        expect(fs.readFileSync(layoutSkill, 'utf8')).toBe('# layout skill');
       });
     });
 
-    it('reports existing files on a no-force re-run so the manifest stays complete', () => {
+    it('claims nothing on a first run over a pre-existing user skill dir', () => {
       expect.assertions(2);
       withTempDir(dir => {
         const root = fakeMarketplace(path.join(dir, 'src'));
-        const first = installSkills(root, 'claude', false, null);
-        const second = installSkills(root, 'claude', false, first); // skips copy, still lists them
-        expect(second).toHaveLength(first.length);
-        expect(second).toContain(path.join('.claude/skills', 'layout', 'SKILL.md'));
+        fs.mkdirSync(path.join(SKILLS_DIR, 'layout'), { recursive: true });
+        fs.writeFileSync(layoutSkill, 'my own skill');
+        const { written } = installSkills(root, false, null); // first run: no manifest
+        expect(written).not.toContain(layoutSkill); // never recorded as managed…
+        expect(fs.readFileSync(layoutSkill, 'utf8')).toBe('my own skill'); // …and untouched
       });
     });
 
-    it('overlays on force, preserving user-added files in the skill dir (no blind dir wipe)', () => {
-      expect.assertions(2);
-      withTempDir(dir => {
-        const root = fakeMarketplace(path.join(dir, 'src'));
-        const first = installSkills(root, 'claude', false, null);
-        fs.writeFileSync('.claude/skills/layout/my-notes.md', 'mine');
-        installSkills(root, 'claude', true, first); // force → overlay, not a dir nuke
-        expect(fs.readFileSync('.claude/skills/layout/my-notes.md', 'utf8')).toBe('mine');
-        expect(fs.readFileSync('.claude/skills/layout/SKILL.md', 'utf8')).toBe('# layout skill');
-      });
-    });
-
-    it('replaces a stray non-directory sitting where a skill dir belongs', () => {
-      expect.assertions(2);
-      withTempDir(dir => {
-        const root = fakeMarketplace(path.join(dir, 'src'));
-        fs.mkdirSync('.claude/skills', { recursive: true });
-        fs.writeFileSync('.claude/skills/layout', 'stray file, not a dir');
-        installSkills(root, 'claude', false, null);
-        expect(fs.statSync('.claude/skills/layout').isDirectory()).toBe(true);
-        expect(fs.existsSync('.claude/skills/layout/SKILL.md')).toBe(true);
-      });
-    });
-
-    it('never reports user-added files as managed on a no-force re-run (so they are not pruned)', () => {
-      expect.assertions(2);
-      withTempDir(dir => {
-        const root = fakeMarketplace(path.join(dir, 'src'));
-        const first = installSkills(root, 'claude', false, null);
-        fs.writeFileSync('.claude/skills/layout/my-notes.md', 'mine');
-        const reported = installSkills(root, 'claude', false, first);
-        expect(reported).not.toContain(path.join('.claude/skills', 'layout', 'my-notes.md'));
-        expect(reported).toContain(path.join('.claude/skills', 'layout', 'SKILL.md'));
-      });
-    });
-
-    it('claims nothing for a skill dir that pre-existed the first run (later prune spares it)', () => {
+    it('does not overwrite a user-authored file that collides with a bundle path, even with force', () => {
       expect.assertions(3);
       withTempDir(dir => {
         const root = fakeMarketplace(path.join(dir, 'src'));
-        // The user authored their own layout skill BEFORE ever running skills:init.
-        fs.mkdirSync('.claude/skills/layout', { recursive: true });
-        fs.writeFileSync('.claude/skills/layout/SKILL.md', 'user-authored');
-        // First run (no manifest), no --force: the dir is skipped, so nothing in it was written
-        // by us and nothing in it may be claimed as managed.
-        const written = installSkills(root, 'claude', false, null);
-        expect(written).not.toContain(path.join('.claude/skills', 'layout', 'SKILL.md'));
-        // Later refresh where `layout` left the upstream bundle: the prune (manifest-scoped) must
-        // not touch the user's file, since the manifest never claimed it.
-        const removed = removeStaleSkillFiles(skillDirEntries(written), []);
-        expect(removed).not.toContain(path.join('.claude/skills', 'layout', 'SKILL.md'));
-        expect(fs.readFileSync('.claude/skills/layout/SKILL.md', 'utf8')).toBe('user-authored');
-      });
-    });
-
-    it('matches previous manifest entries across path separators on the skip path', () => {
-      expect.assertions(1);
-      withTempDir(dir => {
-        const root = fakeMarketplace(path.join(dir, 'src'));
-        installSkills(root, 'claude', false, null);
-        // A manifest written on Windows (backslashes) must still vouch for the same file here.
-        const reported = installSkills(root, 'claude', false, [
-          '.claude\\skills\\layout\\SKILL.md',
-        ]);
-        expect(reported).toContain(path.join('.claude/skills', 'layout', 'SKILL.md'));
+        fs.mkdirSync(path.join(SKILLS_DIR, 'layout'), { recursive: true });
+        fs.writeFileSync(layoutSkill, 'my own skill');
+        // A previous run managed another skill, so the manifest exists but never claimed this file.
+        const previous = [path.join(SKILLS_DIR, 'onboard', 'SKILL.md')];
+        const { written, skipped } = installSkills(root, true, previous);
+        expect(fs.readFileSync(layoutSkill, 'utf8')).toBe('my own skill');
+        expect(skipped).toContain(layoutSkill);
+        expect(written).not.toContain(layoutSkill);
       });
     });
   });
@@ -242,7 +225,7 @@ describe('skills-manager', () => {
         fs.writeFileSync('src-skill/SKILL.md', 'real');
         fs.writeFileSync('secret.txt', 'private'); // a file the crafted symlink would point at
         fs.symlinkSync(path.resolve('secret.txt'), 'src-skill/leak');
-        const written = copyDir('src-skill', 'dest');
+        const { written } = copyDir('src-skill', 'dest');
         expect(fs.existsSync('dest/leak')).toBe(false); // symlink entry skipped, not followed
         expect(written).toStrictEqual([path.join('dest', 'SKILL.md')]); // only the real file copied
       });
@@ -254,9 +237,22 @@ describe('skills-manager', () => {
         fs.mkdirSync('host-dir', { recursive: true });
         fs.writeFileSync('host-dir/private.txt', 'local secret');
         fs.symlinkSync(path.resolve('host-dir'), 'src-link'); // the skill dir IS a symlink
-        const written = copyDir('src-link', 'dest');
+        const { written } = copyDir('src-link', 'dest');
         expect(written).toStrictEqual([]); // nothing copied
         expect(fs.existsSync('dest/private.txt')).toBe(false); // host file not exfiltrated
+      });
+    });
+
+    it('reports an unmanaged destination file as skipped instead of overwriting it', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.mkdirSync('src-skill', { recursive: true });
+        fs.writeFileSync('src-skill/SKILL.md', 'incoming');
+        fs.mkdirSync('dest', { recursive: true });
+        fs.writeFileSync('dest/SKILL.md', 'mine');
+        const { written, skipped } = copyDir('src-skill', 'dest', () => false);
+        expect(written).toStrictEqual([]);
+        expect(skipped).toStrictEqual([path.join('dest', 'SKILL.md')]);
       });
     });
   });
@@ -273,40 +269,28 @@ describe('skills-manager', () => {
       });
     });
 
-    it('installDocsMcp replaces a symlinked .mcp.json instead of overwriting its target', () => {
-      expect.assertions(2);
-      withTempDir(dir => {
-        const root = fakeMarketplace(path.join(dir, 'src'));
-        fs.writeFileSync('outside.json', 'protected');
-        fs.symlinkSync(path.resolve('outside.json'), '.mcp.json');
-        installDocsMcp(root);
-        expect(fs.readFileSync('outside.json', 'utf8')).toBe('protected');
-        expect(fs.lstatSync('.mcp.json').isSymbolicLink()).toBe(false);
-      });
-    });
-
     it('writeManifest does not write through a symlinked .forest dir', () => {
       expect.assertions(1);
       withTempDir(() => {
         fs.mkdirSync('outside-dir');
         fs.symlinkSync(path.resolve('outside-dir'), '.forest');
-        writeManifest({ ref: 'main', installedAt: 'x', agents: ['claude'], files: [] });
+        writeManifest({ ref: 'main', installedAt: 'x', agents: ['cursor'], files: [] });
         expect(fs.existsSync('outside-dir/skills-manifest.json')).toBe(false);
       });
     });
   });
 
   describe('skillDirEntries', () => {
-    it('keeps only entries under the skill dirs (normalized), dropping context/mcp files', () => {
+    it('keeps only entries under the skills dir (normalized), dropping context files', () => {
       expect.assertions(1);
       expect(
         skillDirEntries([
-          '.claude/skills/layout/SKILL.md',
-          '.agents\\skills\\layout\\SKILL.md', // windows-style separators
+          '.agents/skills/layout/SKILL.md',
+          '.agents\\skills\\onboard\\SKILL.md', // windows-style separators
+          'AGENTS.md',
           'CLAUDE.md',
-          '.mcp.json',
         ]),
-      ).toStrictEqual(['.claude/skills/layout/SKILL.md', '.agents\\skills\\layout\\SKILL.md']);
+      ).toStrictEqual(['.agents/skills/layout/SKILL.md', '.agents\\skills\\onboard\\SKILL.md']);
     });
   });
 
@@ -314,212 +298,180 @@ describe('skills-manager', () => {
     it('removes a previously-installed file that is gone upstream', () => {
       expect.assertions(2);
       withTempDir(() => {
-        fs.mkdirSync('.claude/skills/layout', { recursive: true });
-        fs.writeFileSync('.claude/skills/layout/stale.md', 'old');
-        const removed = removeStaleSkillFiles(
-          ['.claude/skills/layout/stale.md'],
-          ['.claude/skills/layout/fresh.md'],
-        );
-        expect(removed).toStrictEqual(['.claude/skills/layout/stale.md']);
-        expect(fs.existsSync('.claude/skills/layout/stale.md')).toBe(false);
+        const stale = path.join(SKILLS_DIR, 'layout', 'stale.md');
+        fs.mkdirSync(path.dirname(stale), { recursive: true });
+        fs.writeFileSync(stale, 'old');
+        const removed = removeStaleSkillFiles([stale], [path.join(SKILLS_DIR, 'layout/fresh.md')]);
+        expect(removed).toStrictEqual([stale]);
+        expect(fs.existsSync(stale)).toBe(false);
       });
     });
 
     it('keeps files still produced by the current run', () => {
       expect.assertions(2);
       withTempDir(() => {
-        fs.mkdirSync('.claude/skills/layout', { recursive: true });
-        fs.writeFileSync('.claude/skills/layout/keep.md', 'x');
-        const removed = removeStaleSkillFiles(
-          ['.claude/skills/layout/keep.md'],
-          ['.claude/skills/layout/keep.md'],
-        );
-        expect(removed).toHaveLength(0);
-        expect(fs.existsSync('.claude/skills/layout/keep.md')).toBe(true);
+        const kept = path.join(SKILLS_DIR, 'layout', 'SKILL.md');
+        fs.mkdirSync(path.dirname(kept), { recursive: true });
+        fs.writeFileSync(kept, 'current');
+        const removed = removeStaleSkillFiles([kept], [kept]);
+        expect(removed).toStrictEqual([]);
+        expect(fs.existsSync(kept)).toBe(true);
       });
     });
 
-    it('ignores previous entries that no longer exist on disk', () => {
-      expect.assertions(1);
-      withTempDir(() => {
-        expect(removeStaleSkillFiles(['.claude/skills/layout/ghost.md'], [])).toHaveLength(0);
-      });
-    });
-
-    it('refuses to delete a path that escapes the skill dirs (`..` traversal)', () => {
+    it('refuses a manifest entry escaping the skills dir via ..', () => {
       expect.assertions(2);
       withTempDir(() => {
-        fs.writeFileSync('precious.txt', 'keep me');
-        const removed = removeStaleSkillFiles(['.claude/skills/../../precious.txt'], []);
-        expect(removed).toHaveLength(0);
-        expect(fs.existsSync('precious.txt')).toBe(true);
+        fs.writeFileSync('victim.md', 'protected');
+        const removed = removeStaleSkillFiles([path.join(SKILLS_DIR, '..', '..', 'victim.md')], []);
+        expect(removed).toStrictEqual([]);
+        expect(fs.existsSync('victim.md')).toBe(true);
       });
     });
 
-    it('matches previous vs current across path separators (Unix manifest, Windows run)', () => {
-      expect.assertions(1);
-      withTempDir(() => {
-        fs.mkdirSync('.claude/skills/layout', { recursive: true });
-        fs.writeFileSync('.claude/skills/layout/SKILL.md', 'x');
-        // Backslash "previous" must be recognized as the same file as forward-slash "current".
-        const removed = removeStaleSkillFiles(
-          ['.claude\\skills\\layout\\SKILL.md'],
-          ['.claude/skills/layout/SKILL.md'],
-        );
-        expect(removed).toHaveLength(0);
-      });
-    });
-
-    it('refuses to delete through a skill dir symlinked outside the project', () => {
+    it('refuses to delete through a symlinked skills dir pointing outside the project', () => {
       expect.assertions(2);
-      const external = fs.mkdtempSync(path.join(os.tmpdir(), 'ext-'));
+      // The link target must live OUTSIDE the project root, or it is legitimately in scope.
+      const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'skills-outside-'));
+      const victim = path.join(outside, 'victim.md');
+      fs.writeFileSync(victim, 'protected');
       try {
-        fs.mkdirSync(path.join(external, 'layout'));
-        fs.writeFileSync(path.join(external, 'layout', 'old.md'), 'external file');
         withTempDir(() => {
-          fs.mkdirSync('.claude', { recursive: true });
-          fs.symlinkSync(external, '.claude/skills'); // skills dir → outside the project
-          const removed = removeStaleSkillFiles(['.claude/skills/layout/old.md'], []);
-          expect(removed).toHaveLength(0);
-          expect(fs.existsSync(path.join(external, 'layout', 'old.md'))).toBe(true);
+          fs.mkdirSync(path.dirname(SKILLS_DIR), { recursive: true });
+          fs.symlinkSync(outside, SKILLS_DIR);
+          const removed = removeStaleSkillFiles([path.join(SKILLS_DIR, 'victim.md')], []);
+          expect(removed).toStrictEqual([]);
+          expect(fs.existsSync(victim)).toBe(true);
         });
       } finally {
-        fs.rmSync(external, { recursive: true, force: true });
+        fs.rmSync(outside, { recursive: true, force: true });
       }
     });
-  });
 
-  describe('installDocsMcp', () => {
-    it('writes the forest-docs MCP server from the marketplace', () => {
+    it('ignores manifest entries that no longer exist on disk', () => {
       expect.assertions(1);
-      withTempDir(dir => {
-        const root = fakeMarketplace(path.join(dir, 'src'));
-        installDocsMcp(root);
-        const mcp = JSON.parse(fs.readFileSync('.mcp.json', 'utf8'));
-        expect(mcp.mcpServers['forest-docs'].url).toBe('https://docs.forest.app/mcp');
-      });
-    });
-
-    it('preserves an existing MCP server the user already had', () => {
-      expect.assertions(2);
-      withTempDir(dir => {
-        const root = fakeMarketplace(path.join(dir, 'src'));
-        fs.writeFileSync('.mcp.json', JSON.stringify({ mcpServers: { other: { url: 'x' } } }));
-        installDocsMcp(root);
-        const mcp = JSON.parse(fs.readFileSync('.mcp.json', 'utf8'));
-        expect(mcp.mcpServers.other).toBeDefined();
-        expect(mcp.mcpServers['forest-docs']).toBeDefined();
-      });
-    });
-
-    it('aborts on a malformed existing .mcp.json instead of clobbering it', () => {
-      expect.assertions(2);
-      withTempDir(dir => {
-        const root = fakeMarketplace(path.join(dir, 'src'));
-        fs.writeFileSync('.mcp.json', '{ not valid json');
-        expect(() => installDocsMcp(root)).toThrow(/Cannot parse existing/);
-        expect(fs.readFileSync('.mcp.json', 'utf8')).toBe('{ not valid json');
-      });
-    });
-
-    it('treats a valid-but-non-object .mcp.json (JSON null) as empty instead of crashing', () => {
-      expect.assertions(1);
-      withTempDir(dir => {
-        const root = fakeMarketplace(path.join(dir, 'src'));
-        fs.writeFileSync('.mcp.json', 'null');
-        installDocsMcp(root);
-        const mcp = JSON.parse(fs.readFileSync('.mcp.json', 'utf8'));
-        expect(mcp.mcpServers['forest-docs']).toBeDefined();
+      withTempDir(() => {
+        expect(removeStaleSkillFiles([path.join(SKILLS_DIR, 'ghost.md')], [])).toStrictEqual([]);
       });
     });
   });
 
-  describe('validateLocalMcp', () => {
-    it('passes when no .mcp.json exists', () => {
-      expect.assertions(1);
-      withTempDir(() => {
-        expect(() => validateLocalMcp()).not.toThrow();
-      });
+  describe('plugin route', () => {
+    it('adds the marketplace at project scope then installs every Forest plugin (Claude Code)', () => {
+      expect.assertions(3);
+      mockCli();
+      const { installed, failed } = installPlugins('claude');
+      expect(spawnSync).toHaveBeenCalledWith(
+        'claude',
+        ['plugin', 'marketplace', 'add', MARKETPLACE_REPO, '--scope', 'project'],
+        expect.anything(),
+      );
+      expect(installed).toStrictEqual(FOREST_PLUGINS);
+      expect(failed).toStrictEqual([]);
     });
 
-    it('passes on a parsable .mcp.json', () => {
-      expect.assertions(1);
-      withTempDir(() => {
-        fs.writeFileSync('.mcp.json', JSON.stringify({ mcpServers: {} }));
-        expect(() => validateLocalMcp()).not.toThrow();
-      });
-    });
-
-    it('throws a clear error on an unparsable .mcp.json (fail fast, before any install)', () => {
+    it('uses codex own verbs (`plugin add`, no project scope) and passes a non-default ref', () => {
       expect.assertions(2);
-      withTempDir(() => {
-        fs.writeFileSync('.mcp.json', '{ not valid json');
-        expect(() => validateLocalMcp()).toThrow(/Cannot parse existing \.mcp\.json/);
-        expect(fs.readFileSync('.mcp.json', 'utf8')).toBe('{ not valid json'); // left untouched
-      });
+      mockCli();
+      installPlugins('codex', 'v1.2.3');
+      expect(spawnSync).toHaveBeenCalledWith(
+        'codex',
+        ['plugin', 'marketplace', 'add', MARKETPLACE_REPO, '--ref', 'v1.2.3'],
+        expect.anything(),
+      );
+      expect(spawnSync).toHaveBeenCalledWith(
+        'codex',
+        ['plugin', 'add', `${FOREST_PLUGINS[0]}@forest-admin-ai`, '--json'],
+        expect.anything(),
+      );
     });
 
-    it('passes on a symlinked .mcp.json (replaced, never read, at install time)', () => {
+    it('pins Claude Code to a non-default ref via the git-URL form', () => {
       expect.assertions(1);
-      withTempDir(() => {
-        fs.writeFileSync('outside.json', '{ not valid json');
-        fs.symlinkSync(path.resolve('outside.json'), '.mcp.json');
-        expect(() => validateLocalMcp()).not.toThrow();
-      });
+      mockCli();
+      installPlugins('claude', 'v1.2.3');
+      expect(spawnSync).toHaveBeenCalledWith(
+        'claude',
+        [
+          'plugin',
+          'marketplace',
+          'add',
+          `https://github.com/${MARKETPLACE_REPO}.git#v1.2.3`,
+          '--scope',
+          'project',
+        ],
+        expect.anything(),
+      );
+    });
+
+    it('throws without installing anything when the marketplace cannot be added', () => {
+      expect.assertions(2);
+      mockCli({ failing: /marketplace add/ });
+      expect(() => installPlugins('claude')).toThrow(/marketplace add` failed/);
+      expect(spawnSync).toHaveBeenCalledTimes(1); // no install attempted
+    });
+
+    it('reports a single failing plugin without losing the others', () => {
+      expect.assertions(2);
+      mockCli({ failing: new RegExp(`install ${FOREST_PLUGINS[1]}@`) });
+      const { installed, failed } = installPlugins('claude');
+      expect(failed).toStrictEqual([FOREST_PLUGINS[1]]);
+      expect(installed).toStrictEqual([FOREST_PLUGINS[0], FOREST_PLUGINS[2]]);
+    });
+
+    it('reports a missing CLI rather than throwing', () => {
+      expect.assertions(1);
+      spawnSync.mockReset();
+      spawnSync.mockReturnValue({ error: new Error('spawn claude ENOENT') });
+      expect(hasPluginCli('claude')).toBe(false);
     });
   });
 
-  describe('validateMarketplaceBundle', () => {
-    it('passes when the bundle carries forest-docs/.mcp.json', () => {
-      expect.assertions(1);
-      withTempDir(dir => {
-        const root = fakeMarketplace(path.join(dir, 'src'));
-        expect(() => validateMarketplaceBundle(root, 'main')).not.toThrow();
+  describe('detectAgents', () => {
+    it('detects agents from the marks they leave in a repo', () => {
+      expect.assertions(2);
+      mockCli({ failing: /--version/ }); // no agent CLI on this machine
+      withTempDir(() => {
+        fs.mkdirSync('.cursor');
+        fs.writeFileSync('opencode.json', '{}');
+        const detected = detectAgents();
+        expect(detected).toContain('cursor');
+        expect(detected).toContain('opencode');
       });
     });
 
-    it('throws a clear error naming the ref when forest-docs/.mcp.json is missing', () => {
+    it('returns nothing in a bare repo with no agent CLI installed', () => {
       expect.assertions(1);
-      withTempDir(dir => {
-        const root = fakeMarketplace(path.join(dir, 'src'));
-        fs.rmSync(path.join(root, 'forest-docs'), { recursive: true, force: true });
-        expect(() => validateMarketplaceBundle(root, 'v1.2.3')).toThrow(
-          /ref "v1\.2\.3" has no forest-docs\/\.mcp\.json/,
-        );
+      mockCli({ failing: /--version/ });
+      withTempDir(() => {
+        expect(detectAgents()).toStrictEqual([]);
       });
     });
   });
 
   describe('manifest', () => {
-    it('returns null when no manifest exists', () => {
-      expect.assertions(1);
-      withTempDir(() => {
-        expect(readManifest()).toBeNull();
-      });
-    });
-
-    it('returns null for a valid-but-malformed manifest (no files array)', () => {
-      expect.assertions(2);
-      withTempDir(() => {
-        fs.mkdirSync('.forest', { recursive: true });
-        fs.writeFileSync('.forest/skills-manifest.json', '{}');
-        expect(readManifest()).toBeNull();
-        fs.writeFileSync('.forest/skills-manifest.json', '[]');
-        expect(readManifest()).toBeNull();
-      });
-    });
-
-    it('round-trips through write/read', () => {
+    it('round-trips ref, agents and files', () => {
       expect.assertions(1);
       withTempDir(() => {
         const manifest = {
           ref: 'main',
-          installedAt: '2026-01-01',
-          agents: ['claude'],
-          files: ['a'],
+          installedAt: '2026-01-01T00:00:00.000Z',
+          agents: ['claude', 'cursor'],
+          files: [layoutSkill],
         };
         writeManifest(manifest);
         expect(readManifest()).toStrictEqual(manifest);
+      });
+    });
+
+    it('reads a malformed manifest as absent rather than crashing callers', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.mkdirSync('.forest', { recursive: true });
+        fs.writeFileSync('.forest/skills-manifest.json', '{ not json');
+        expect(readManifest()).toBeNull();
+        fs.writeFileSync('.forest/skills-manifest.json', '{}'); // valid JSON, wrong shape
+        expect(readManifest()).toBeNull();
       });
     });
   });

--- a/test/services/skills/skills-manager.unit.test.ts
+++ b/test/services/skills/skills-manager.unit.test.ts
@@ -106,7 +106,7 @@ describe('skills-manager', () => {
       expect.assertions(3);
       withTempDir(dir => {
         const root = fakeMarketplace(path.join(dir, 'src'));
-        const written = installSkills(root, 'claude', false);
+        const written = installSkills(root, 'claude', false, null);
         expect(fs.existsSync('.claude/skills/layout/SKILL.md')).toBe(true);
         expect(fs.existsSync('.claude/skills/forest-code/SKILL.md')).toBe(true);
         expect(written).toContain(path.join('.claude/skills', 'layout', 'references', 'a.md'));
@@ -119,7 +119,9 @@ describe('skills-manager', () => {
         const root = fakeMarketplace(path.join(dir, 'src'));
         const { plugin, skills } = SKILL_SOURCES[0];
         fs.rmSync(path.join(root, plugin, 'skills', skills[0]), { recursive: true, force: true });
-        expect(() => installSkills(root, 'claude', false)).toThrow(/missing from the marketplace/);
+        expect(() => installSkills(root, 'claude', false, null)).toThrow(
+          /missing from the marketplace/,
+        );
       });
     });
 
@@ -127,11 +129,11 @@ describe('skills-manager', () => {
       expect.assertions(2);
       withTempDir(dir => {
         const root = fakeMarketplace(path.join(dir, 'src'));
-        installSkills(root, 'claude', false);
+        const first = installSkills(root, 'claude', false, null);
         fs.writeFileSync('.claude/skills/layout/SKILL.md', 'edited');
-        installSkills(root, 'claude', false); // no force → keep edit
+        installSkills(root, 'claude', false, first); // no force → keep edit
         expect(fs.readFileSync('.claude/skills/layout/SKILL.md', 'utf8')).toBe('edited');
-        installSkills(root, 'claude', true); // force → overwrite
+        installSkills(root, 'claude', true, first); // force → overwrite
         expect(fs.readFileSync('.claude/skills/layout/SKILL.md', 'utf8')).toBe('# layout skill');
       });
     });
@@ -140,8 +142,8 @@ describe('skills-manager', () => {
       expect.assertions(2);
       withTempDir(dir => {
         const root = fakeMarketplace(path.join(dir, 'src'));
-        const first = installSkills(root, 'claude', false);
-        const second = installSkills(root, 'claude', false); // skips copy, still lists the files
+        const first = installSkills(root, 'claude', false, null);
+        const second = installSkills(root, 'claude', false, first); // skips copy, still lists them
         expect(second).toHaveLength(first.length);
         expect(second).toContain(path.join('.claude/skills', 'layout', 'SKILL.md'));
       });
@@ -151,9 +153,9 @@ describe('skills-manager', () => {
       expect.assertions(2);
       withTempDir(dir => {
         const root = fakeMarketplace(path.join(dir, 'src'));
-        installSkills(root, 'claude', false);
+        const first = installSkills(root, 'claude', false, null);
         fs.writeFileSync('.claude/skills/layout/my-notes.md', 'mine');
-        installSkills(root, 'claude', true); // force → overlay, not a dir nuke
+        installSkills(root, 'claude', true, first); // force → overlay, not a dir nuke
         expect(fs.readFileSync('.claude/skills/layout/my-notes.md', 'utf8')).toBe('mine');
         expect(fs.readFileSync('.claude/skills/layout/SKILL.md', 'utf8')).toBe('# layout skill');
       });
@@ -165,7 +167,7 @@ describe('skills-manager', () => {
         const root = fakeMarketplace(path.join(dir, 'src'));
         fs.mkdirSync('.claude/skills', { recursive: true });
         fs.writeFileSync('.claude/skills/layout', 'stray file, not a dir');
-        installSkills(root, 'claude', false);
+        installSkills(root, 'claude', false, null);
         expect(fs.statSync('.claude/skills/layout').isDirectory()).toBe(true);
         expect(fs.existsSync('.claude/skills/layout/SKILL.md')).toBe(true);
       });
@@ -175,10 +177,42 @@ describe('skills-manager', () => {
       expect.assertions(2);
       withTempDir(dir => {
         const root = fakeMarketplace(path.join(dir, 'src'));
-        installSkills(root, 'claude', false);
+        const first = installSkills(root, 'claude', false, null);
         fs.writeFileSync('.claude/skills/layout/my-notes.md', 'mine');
-        const reported = installSkills(root, 'claude', false);
+        const reported = installSkills(root, 'claude', false, first);
         expect(reported).not.toContain(path.join('.claude/skills', 'layout', 'my-notes.md'));
+        expect(reported).toContain(path.join('.claude/skills', 'layout', 'SKILL.md'));
+      });
+    });
+
+    it('claims nothing for a skill dir that pre-existed the first run (later prune spares it)', () => {
+      expect.assertions(3);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        // The user authored their own layout skill BEFORE ever running skills:init.
+        fs.mkdirSync('.claude/skills/layout', { recursive: true });
+        fs.writeFileSync('.claude/skills/layout/SKILL.md', 'user-authored');
+        // First run (no manifest), no --force: the dir is skipped, so nothing in it was written
+        // by us and nothing in it may be claimed as managed.
+        const written = installSkills(root, 'claude', false, null);
+        expect(written).not.toContain(path.join('.claude/skills', 'layout', 'SKILL.md'));
+        // Later refresh where `layout` left the upstream bundle: the prune (manifest-scoped) must
+        // not touch the user's file, since the manifest never claimed it.
+        const removed = removeStaleSkillFiles(skillDirEntries(written), []);
+        expect(removed).not.toContain(path.join('.claude/skills', 'layout', 'SKILL.md'));
+        expect(fs.readFileSync('.claude/skills/layout/SKILL.md', 'utf8')).toBe('user-authored');
+      });
+    });
+
+    it('matches previous manifest entries across path separators on the skip path', () => {
+      expect.assertions(1);
+      withTempDir(dir => {
+        const root = fakeMarketplace(path.join(dir, 'src'));
+        installSkills(root, 'claude', false, null);
+        // A manifest written on Windows (backslashes) must still vouch for the same file here.
+        const reported = installSkills(root, 'claude', false, [
+          '.claude\\skills\\layout\\SKILL.md',
+        ]);
         expect(reported).toContain(path.join('.claude/skills', 'layout', 'SKILL.md'));
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11773,7 +11773,7 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11789,15 +11789,6 @@ string-width@^2.1.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -11863,7 +11854,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11883,13 +11874,6 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.2"
@@ -12043,6 +12027,17 @@ tar@^7.4.3, tar@^7.5.1:
   version "7.5.19"
   resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.19.tgz#d8915e6b717f8036a79d839ca9448198b002b0a7"
   integrity sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==
+  dependencies:
+    "@isaacs/fs-minipass" "^4.0.0"
+    chownr "^3.0.0"
+    minipass "^7.1.2"
+    minizlib "^3.1.0"
+    yallist "^5.0.0"
+
+tar@^7.5.9:
+  version "7.5.21"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.21.tgz#b3405af2eb493523ce4379f531e9ebda0601bc59"
+  integrity sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"
@@ -12862,7 +12857,7 @@ wordwrap@>=0.0.2, wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12875,15 +12870,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
> **Replaces #804 and #805**, which are closed in favour of this one. Their commits are here, rebased, with @PMerlet's review fixes intact — only the distribution design changed, and enough to deserve a diff you can read in one pass rather than a force-push under the old description.

## What

`forest skills:init` / `forest skills:update` — give a client's coding agent the Forest skills. Two routes, because coding agents split in two families:

| | route | what lands in the repo |
| :-- | :-- | :-- |
| **Claude Code**, **Codex** | we drive **their** plugin CLI | `.claude/settings.json` (12 lines, committable) — nothing else |
| **Cursor**, **OpenCode**, other | we copy `SKILL.md` files | `.agents/skills/` (8 skills) |

The command asks which agent(s) you use — multi-select, since Claude Code + Cursor is a common pair — pre-checked from repo detection, skippable with a repeatable `--agent` flag that is required in non-interactive runs (`npx`, CI).

## Why not copy files for everyone (what #804 did)

Claude Code and Codex both have a plugin system with a **non-interactive CLI**, and both read the **same** `.claude-plugin/marketplace.json` — so our existing catalog serves both with no second manifest. Driving it gives us versioning, auto-update, the docs MCP and the plugin's slash commands (`/forest:start`, `/forest:deploy`) for free, and copies nothing into the client's repo.

That deletes the whole class of machinery #804 had to hand-roll: the `.mcp.json` merge and its two preflight validators (`.mcp.json` is a Claude Code file — Cursor reads `.cursor/mcp.json`, OpenCode reads `opencode.json` — and Claude Code now gets the docs MCP from the `forest-docs` plugin), plus the duplicate `.claude/skills/` copy. One skills dir remains, `.agents/skills/`, which Cursor, OpenCode **and** Codex all read.

Verified against `claude-code 2.1.100` and `codex-cli 0.147.0`.

## Two bugs fixed on the way

**Data loss on refresh.** `skills:update` overwrote a user-authored `SKILL.md` that collided with a bundle path, even though `skills:init` correctly refused to claim it. `previousFiles` now bounds what may be **overwritten**, not just what may be claimed, and kept files are reported. Reproduced end-to-end before and after.

**Dangling skill reference, already shipped.** The copy route followed a hand-picked list of skill names while the plugin route installs whole plugins. The list dropped `deploy-heroku` as "internal/test-only" — it is the user-facing production deploy, referenced by `onboard` (4×), `management`, `boot-standalone-agent` and the `/forest:deploy` command. Every Cursor/OpenCode user had an `onboard` skill pointing at a skill that was never installed, at the most important step of the flow. There is now **one** list, `FOREST_PLUGINS`, read by both routes, and nothing is filtered below the plugin: a plugin is the unit of distribution and is coherent only as a whole. `forest-mcp` stays out — it is data access, not developer help.

## Detection and the prompt

Repo signals (`.claude/`, `CLAUDE.md`, `.cursor/`, `.opencode/`, …) decide on their own when there is at least one; the PATH is consulted only when the repo is silent — the fresh-project case, where what you have installed is the only signal. Otherwise anyone with several agent CLIs installed gets them all pre-checked in every repo, and confirming the prompt installs plugins they never picked. The "press space" hint lives in the question text, because inquirer's own hint is appended to the first render only and vanishes on the first keypress — exactly when it is needed, since arrow keys move without selecting.

## Tested

- **53 tests** on the skills paths. `skills:init` gains the command-level suite it never had: both routes, their combination, `--ref` passthrough, missing CLI, partial plugin failure. The service suite covers the plugin-CLI argv per agent, ref pinning per CLI syntax, detection precedence, and the overwrite guard.
- Full suite: **626 passed**, lint clean. (The DB-backed suites need a live Postgres/MySQL/Mongo and are excluded locally, as on `main`.)
- **End-to-end with the real CLIs**, on throwaway repos: plugin route installs `forest`, `forest-code`, `forest-docs` on both agents and writes only `.claude/settings.json`; copy route lands 8 skills in `.agents/skills/`; `skills:update` refreshes both; and the clobber regression is reproduced green.

## Note for the reviewer

@PMerlet — your two `skills:init` fixes and the `skills:update` hardening are all still in here and still load-bearing: the manifest-claiming guard is what the new overwrite guard extends, and the ref-transition warning is unchanged. What went away is only what the plugin route makes redundant. Sorry for the moving target on the design — the Codex plugin CLI turned out to read our Claude marketplace, which is what made this shape possible.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `forest skills:init` and `forest skills:update` commands to install Forest skills for coding agents
> - `skills:init` installs Forest skills via native plugin CLIs for Claude Code and Codex, and copies skill files into `.agents/skills/` for Cursor, OpenCode, and others.
> - `skills:update` re-runs the appropriate install route using a persisted manifest at `.forest/skills-manifest.json`, overwriting previously managed files and pruning those removed upstream.
> - Both commands merge a delimited Forest information block into `CLAUDE.md` or `AGENTS.md` without clobbering user content, and detect installed agents automatically when no `--agent` flag is provided.
> - The marketplace tarball is fetched from GitHub at a configurable `--ref` (default `main`) and extracted using the new `tar` dependency.
> - Risk: plugin installation uses `spawnSync` against agent CLIs; missing or incompatible CLIs silently skip that agent rather than aborting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3dbc585.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->