### PR TITLE
chore(security): patch 2 Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,8 +143,9 @@
     "uuid": "^11.1.1",
     "inquirer/**/tmp": "^0.2.6",
     "brace-expansion": "^1.1.16 || ^2.1.2",
-    "fast-uri": "^3.1.4",
-    "undici": "^6.28.0",
-    "ip-address": "^10.3.1"
+    "@oclif/core/js-yaml": "^3.15.1",
+    "**/@istanbuljs/load-nyc-config/js-yaml": "^3.15.1",
+    "eslint/**/js-yaml": "^4.3.1",
+    "cosmiconfig/**/js-yaml": "^4.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6636,29 +6636,29 @@ fast-safe-stringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
-fast-uri@^3.0.1, fast-uri@^3.1.4:
+fast-uri@^3.0.1:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
   integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
 
 fast-xml-builder@^1.2.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz#bc849804796fe47bf915022dd939b0fc30ba455d"
-  integrity sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz#ef05b353b45597483dfb09d450a062a2baec3a82"
+  integrity sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==
   dependencies:
     path-expression-matcher "^1.6.2"
     xml-naming "^0.3.0"
 
 fast-xml-parser@5.3.6, fast-xml-parser@>=5.7.0:
-  version "5.10.1"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz#19313f7c9386c47fa4a1de527547b73ed2cfcede"
-  integrity sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.11.0.tgz#7cd9ea0e34c15619c1af0c7e2d8e183c891ee832"
+  integrity sha512-9IGxMqvqLOnqP+Egi1nqDHKv5k8aZ7r9n558enxcucmyVGEBNPAU+MOg/8jPIS7rO7sSq4gFm1/nHtiaubMruw==
   dependencies:
     "@nodable/entities" "^3.0.0"
     fast-xml-builder "^1.2.0"
     is-unsafe "^2.0.0"
     path-expression-matcher "^1.6.2"
-    strnum "^2.4.1"
+    strnum "^2.4.2"
     xml-naming "^0.3.0"
 
 fastest-levenshtein@^1.0.16, fastest-levenshtein@^1.0.7:
@@ -7551,7 +7551,7 @@ into-stream@^7.0.0:
     from2 "^2.3.0"
     p-is-promise "^3.0.0"
 
-ip-address@^10.0.1, ip-address@^10.3.1:
+ip-address@^10.0.1:
   version "10.5.0"
   resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.5.0.tgz#fcd6d7dfe9e68416b7cb71afe9bc960b3e38c13b"
   integrity sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==
@@ -7867,9 +7867,9 @@ is-unicode-supported@^2.0.0:
   integrity sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==
 
 is-unsafe@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-unsafe/-/is-unsafe-2.0.0.tgz#c0dce4e06742662dde26360160e414ea487da2e9"
-  integrity sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-unsafe/-/is-unsafe-2.0.2.tgz#bb1ead17f1aa688f6433258b561e98b1a45a1afc"
+  integrity sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==
 
 is-weakmap@^2.0.2:
   version "2.0.2"
@@ -8435,18 +8435,18 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1, js-yaml@^3.14.1:
-  version "3.15.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
-  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
+js-yaml@^3.13.1, js-yaml@^3.14.1, js-yaml@^3.15.1:
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.1.tgz#24bc95028f361cdaaa84745b06a109c4486773c0"
+  integrity sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+js-yaml@^4.1.0, js-yaml@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 
@@ -11945,10 +11945,10 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
-strnum@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.4.1.tgz#85417f683113badea0fe7e17227676f889ff7e58"
-  integrity sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==
+strnum@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.4.2.tgz#af43ab51a06d04227023fc2e42ca229214ec10f0"
+  integrity sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==
   dependencies:
     anynum "^1.0.1"
 
@@ -12471,7 +12471,7 @@ undici-types@~7.16.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
   integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
-undici@^6.23.0, undici@^6.28.0:
+undici@^6.23.0:
   version "6.28.0"
   resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
   integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==


### PR DESCRIPTION
> 👋 First-level support: see [Handling automated security PRs](https://forest.slite.com/app/docs/rmjdwFgmV2RzUp) for how to triage and merge this PR.

## Summary
2 fixed, 0 ignored, 0 deferred, 4 resolutions added, 3 resolutions removed. | label: :lock: security applied

## Fixed
| Done | Alert | Package | Ecosystem | From → To | Severity | What was bumped |
|---|---|---|---|---|---|---|
| - [x] | [#249](https://github.com/ForestAdmin/toolbelt/security/dependabot/249) | js-yaml | npm | 4.3.0 → 4.3.1 | high | resolutions: pinned `eslint/**/js-yaml` and `cosmiconfig/**/js-yaml` to `^4.3.1` (all 4.x parents accept ^4.1.0 which the patched 4.3.1 satisfies) |
| - [x] | [#248](https://github.com/ForestAdmin/toolbelt/security/dependabot/248) | js-yaml | npm | 3.15.0 → 3.15.1 | high | resolutions: pinned `@oclif/core/js-yaml` and `**/@istanbuljs/load-nyc-config/js-yaml` to `^3.15.1` (both 3.x parents accept `^3.13.1` / `^3.14.1` which the patched 3.15.1 satisfies) |

## Ignored
| Dismissed | Alert | Reason |
|---|---|---|
| _(none)_ | | |

## Deferred
_None._

## Resolutions added
| Alert | Package + pinned range | Parent chain tried | Why the bump wasn't viable | package.json | Form |
|---|---|---|---|---|---|
| [#249](https://github.com/ForestAdmin/toolbelt/security/dependabot/249) | `eslint/**/js-yaml`: `^4.3.1` | `eslint#js-yaml`, `eslint#@eslint/eslintrc#js-yaml` | js-yaml is transitive under eslint; parent range `^4.1.0` already accepts the patched 4.3.1, but the lockfile pinned 4.3.0. Since js-yaml has coexisting 3.x and 4.x majors in the tree, an unconditional root pin would collapse both branches (incompatible argparse ABI); parent-scoped avoids that risk. | root `package.json` | scoped |
| [#249](https://github.com/ForestAdmin/toolbelt/security/dependabot/249) | `cosmiconfig/**/js-yaml`: `^4.3.1` | `semantic-release#cosmiconfig#js-yaml`, `@commitlint/cli#@commitlint/load#cosmiconfig#js-yaml` | Same reasoning: 4.x-only consumers via cosmiconfig; parent-scoped pin keeps 3.x branches untouched. | root `package.json` | scoped |
| [#248](https://github.com/ForestAdmin/toolbelt/security/dependabot/248) | `@oclif/core/js-yaml`: `^3.15.1` | `@oclif/core#js-yaml` (parent range `^3.14.1`) | Direct scoping to the sole 3.x consumer chain via @oclif/core. An unconditional root pin would break the 4.x branches. | root `package.json` | scoped |
| [#248](https://github.com/ForestAdmin/toolbelt/security/dependabot/248) | `**/@istanbuljs/load-nyc-config/js-yaml`: `^3.15.1` | `jest#@jest/core#@jest/transform#babel-plugin-istanbul#@istanbuljs/load-nyc-config#js-yaml` (parent range `^3.13.1`) | Yarn v1 parent-scoping doesn't traverse scoped packages via the short form (`@scope/pkg/dep`), so the pattern needs a leading `**/` glob to match anywhere under the scoped parent. Otherwise identical to the previous entry. | root `package.json` | scoped |

## Resolutions removed
| File | Package + pinned version | Reason |
|---|---|---|
| root `package.json` | `fast-uri`: `^3.1.4` | Redundant — natural fresh resolution picks 3.1.5 (via ajv), which satisfies `^3.1.4`. |
| root `package.json` | `undici`: `^6.28.0` | Redundant — natural fresh resolution picks 6.28.0 (latest 6.x available on npm; parent `^6.23.0` accepts it), which satisfies `^6.28.0`. |
| root `package.json` | `ip-address`: `^10.3.1` | Redundant — natural fresh resolution picks 10.5.0 (parent `^10.0.1` accepts it), which satisfies `^10.3.1`. |

## Risks
- js-yaml 3.15.0 → 3.15.1: patch-only backport for CVE-2026-59870 (quadratic CPU consumption in `!!omap` resolution). No API changes.
- js-yaml 4.3.0 → 4.3.1: same CVE, patch-only. No API changes.
- Removed resolutions (`fast-uri`, `undici`, `ip-address`) have no version drift: fresh install resolves to the same or newer versions that still satisfy the previously-pinned floor. No behavior change.

## Manual testing
Covered by CI.

## Validation
✅ CI green

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Patch 2 Dependabot alerts by removing `fast-uri`, `undici`, `ip-address` and pinning `js-yaml`
> - Removes direct dependencies `fast-uri`, `undici`, and `ip-address` from [package.json](https://github.com/ForestAdmin/toolbelt/pull/815/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)
> - Adds dependency overrides pinning `js-yaml` to `^3.15.1` for `@oclif/core` and `@istanbuljs/load-nyc-config`, and to `^4.3.1` for `eslint` and `cosmiconfig` trees
> - Updates [yarn.lock](https://github.com/ForestAdmin/toolbelt/pull/815/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de) to match the new dependency graph
> - Risk: any code importing the removed packages directly will break at build/runtime; verify no in-tree usage of `fast-uri`, `undici`, or `ip-address` remains
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b78e77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->