### PR TITLE
feat(services): add a process runner that can actually stop what it started

### DIFF
--- a/src/services/process-runner.ts
+++ b/src/services/process-runner.ts
@@ -140,11 +140,15 @@ export function runCapture(
     let stdout = '';
     let stderr = '';
 
-    child.stdout?.on('data', chunk => {
-      stdout += chunk.toString();
+    // Decoded by the stream, not per chunk: a multibyte character split across two reads would
+    // otherwise become two replacement characters — silently changing a value we then JSON.parse.
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
+
+    child.stdout?.on('data', (text: string) => {
+      stdout += text;
     });
-    child.stderr?.on('data', chunk => {
-      const text = chunk.toString();
+    child.stderr?.on('data', (text: string) => {
       stderr += text;
       onProgress?.(text);
     });
@@ -228,8 +232,7 @@ export function startProcess(
       reject(error);
     };
 
-    const onData = (chunk: Buffer) => {
-      const text = chunk.toString();
+    const onData = (text: string) => {
       stream?.(text);
       if (settled) return;
       scanned += text;
@@ -247,6 +250,10 @@ export function startProcess(
       timeoutMs,
     );
 
+    // Same reason as `runCapture`, with a sharper consequence: a `ready` pattern straddling a
+    // chunk boundary would never match, and the process would be killed on a false timeout.
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
     child.stdout?.on('data', onData);
     child.stderr?.on('data', onData);
     child.on('error', error => fail(error));

--- a/src/services/process-runner.ts
+++ b/src/services/process-runner.ts
@@ -219,17 +219,26 @@ export function startProcess(
   };
 
   const readyPromise = new Promise<void>((resolve, reject) => {
-    // Only accumulated until `ready` matches, then released. Keeping it would mean re-running the
-    // regex over an ever-growing string for the process's whole life — quadratic, on a buffer a
-    // long-lived server grows to hundreds of megabytes.
-    let scanned = '';
+    // Rebuilt without `g`/`y`: those flags make `.test()` stateful, so a caller passing `/x/g`
+    // would have its `lastIndex` advance between chunks and skip the very announcement we wait
+    // for — the process then dies on a timeout that had no cause.
+    const readyPattern = new RegExp(ready.source, ready.flags.replace(/[gy]/g, ''));
+
+    // One buffer PER STREAM. Sharing one would let a token straddling stdout and stderr match
+    // when neither stream ever produced it. Each is capped to a suffix: a chatty process that
+    // never announces itself would otherwise exhaust the heap long before the timeout fires,
+    // crashing instead of reporting. The window is far wider than any readiness line, so a
+    // pattern split across chunk boundaries still matches.
+    const WINDOW = 8192;
+    const scanned = { stdout: '', stderr: '' };
     let settled = false;
     let timeout: NodeJS.Timeout;
 
     const settle = () => {
       settled = true;
       clearTimeout(timeout);
-      scanned = ''; // release the buffer; `onData` keeps streaming but stops scanning
+      scanned.stdout = '';
+      scanned.stderr = '';
     };
 
     // A failed start must not leave the process behind: its open pipes would also keep this CLI's
@@ -241,15 +250,15 @@ export function startProcess(
       reject(error);
     };
 
-    const onData = (text: string) => {
+    const onData = (source: 'stdout' | 'stderr') => (text: string) => {
       stream?.(text);
       if (settled) return;
-      scanned += text;
+      scanned[source] = (scanned[source] + text).slice(-WINDOW);
 
-      if (ready.test(scanned)) {
+      if (readyPattern.test(scanned[source])) {
         settle();
         resolve();
-      } else if (/EADDRINUSE/.test(scanned)) {
+      } else if (/EADDRINUSE/.test(scanned[source])) {
         fail(new Error('Port already in use — free it with `lsof -ti :<port> | xargs kill`.'));
       }
     };
@@ -259,12 +268,13 @@ export function startProcess(
       timeoutMs,
     );
 
-    // Same reason as `runCapture`, with a sharper consequence: a `ready` pattern straddling a
-    // chunk boundary would never match, and the process would be killed on a false timeout.
+    // Decoded by the stream, not per chunk: a multibyte character split across two reads would
+    // otherwise become replacement characters, and a `ready` pattern containing one would never
+    // match — the process killed on a false timeout.
     child.stdout?.setEncoding('utf8');
     child.stderr?.setEncoding('utf8');
-    child.stdout?.on('data', onData);
-    child.stderr?.on('data', onData);
+    child.stdout?.on('data', onData('stdout'));
+    child.stderr?.on('data', onData('stderr'));
     child.on('error', error => fail(error));
     child.on('close', code =>
       fail(new Error(`\`${command}\` stopped before it was ready (exit code ${code}).`)),

--- a/src/services/process-runner.ts
+++ b/src/services/process-runner.ts
@@ -11,6 +11,11 @@ import { spawn } from 'child_process';
  * signals the wrapper, leaves the server running, and — since its pipes stay open — keeps this
  * CLI alive too. Every long-running process is therefore started in its own process group, and
  * stopped by signalling that group.
+ *
+ * KNOWN LIMITATION — Windows. `process.kill(-pid)` does not exist there and `detached` creates no
+ * signalable group, so `stopProcess` falls back to signalling the wrapper alone: the server it
+ * spawned survives, which is the very bug this module fixes elsewhere. CI is Linux-only and the
+ * onboarding is not offered on Windows; if that changes, this needs `taskkill /T /F`.
  */
 
 export type RunOptions = {
@@ -22,9 +27,65 @@ export type StartedProcess = {
   child: ChildProcess;
   /** Resolves when the process prints something matching `ready`, rejects on timeout or a taken port. */
   ready: Promise<void>;
+  /** Stop streaming output — before handing the terminal to something else, typically. */
+  mute: () => void;
 };
 
+export type CaptureResult = { stdout: string; stderr: string };
+
 const READY_TIMEOUT_MS = 120_000;
+
+/**
+ * Every process we started and have not stopped. Registered so the CLI can take them down with it:
+ * a detached child survives its parent by design, and the terminal's Ctrl-C never reaches it (it
+ * sits in its own process group), so without this a crash or an interrupt strands a server holding
+ * a port the user then has to hunt down with `lsof`.
+ */
+const running = new Set<ChildProcess>();
+let exitHookInstalled = false;
+
+/**
+ * Stop a process started by `startProcess`, and everything it spawned.
+ *
+ * A negative pid signals the whole process group — the only way to reach the server a package
+ * manager launched on our behalf. Never throws: stopping something already stopped is a success.
+ */
+export function stopProcess(child: ChildProcess | undefined, signal: NodeJS.Signals = 'SIGTERM') {
+  // `child.killed` is not the state we need: it only records that `child.kill()` was called, and
+  // the group path uses `process.kill()`, which never sets it. `exitCode`/`signalCode` are what
+  // actually say the process is gone — and they stop us re-signalling a pid the OS may have reused.
+  if (!child?.pid || child.exitCode !== null || child.signalCode !== null) return;
+
+  running.delete(child);
+
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // Already dead — nothing left to stop.
+    }
+  }
+}
+
+function installExitHook() {
+  if (exitHookInstalled) return;
+  exitHookInstalled = true;
+
+  const stopAll = () => running.forEach(child => stopProcess(child));
+
+  // `exit` covers a normal end and an uncaught throw. The signals cover the terminal, which would
+  // otherwise kill this process and leave the group behind. `once` so a second Ctrl-C is never
+  // swallowed — the user must always be able to give up.
+  process.on('exit', stopAll);
+  (['SIGINT', 'SIGTERM', 'SIGHUP'] as const).forEach(signal =>
+    process.once(signal, () => {
+      stopAll();
+      process.exit(signal === 'SIGINT' ? 130 : 143);
+    }),
+  );
+}
 
 function spawnOptions(options: RunOptions, extra: SpawnOptions = {}): SpawnOptions {
   return {
@@ -34,12 +95,12 @@ function spawnOptions(options: RunOptions, extra: SpawnOptions = {}): SpawnOptio
   };
 }
 
+const formatCommand = (command: string, args: string[]) => `${command} ${args.join(' ')}`.trim();
+
 /**
  * Run a command to completion. stdio is inherited so the child owns the terminal: `forest login`
  * can open a browser, and a package manager's own prompts and progress render natively instead of
  * being buffered into silence.
- *
- * Rejects with the exit code when the command fails — the caller decides whether that is fatal.
  */
 export function runStep(command: string, args: string[], options: RunOptions = {}): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -49,37 +110,61 @@ export function runStep(command: string, args: string[], options: RunOptions = {
     child.on('close', code =>
       code === 0
         ? resolve()
-        : reject(new Error(`\`${command} ${args.join(' ')}\` exited with code ${code}`)),
+        : reject(new Error(`\`${formatCommand(command, args)}\` exited with code ${code}`)),
     );
   });
 }
 
-/** Same, but capturing stdout instead of inheriting it — for commands we need to read back. */
+/**
+ * Run a command, capturing its streams SEPARATELY.
+ *
+ * Keeping them apart is the point: a command whose stdout is a machine-readable document writes
+ * its progress to stderr, so merging the two corrupts the document — the parse then fails silently
+ * and the caller proceeds with nothing. stderr is streamed through `onProgress` instead, so the
+ * user still sees what is happening.
+ *
+ * On failure the error carries the captured stderr: piping it means the sub-command's own message
+ * never reached the terminal, and "exited with code 2" alone tells the user nothing.
+ */
 export function runCapture(
   command: string,
   args: string[],
-  options: RunOptions = {},
-): Promise<string> {
+  { onProgress, ...options }: RunOptions & { onProgress?: (chunk: string) => void } = {},
+): Promise<CaptureResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(
       command,
       args,
       spawnOptions(options, { stdio: ['inherit', 'pipe', 'pipe'] }),
     );
-    let output = '';
+    let stdout = '';
+    let stderr = '';
 
     child.stdout?.on('data', chunk => {
-      output += chunk.toString();
+      stdout += chunk.toString();
     });
     child.stderr?.on('data', chunk => {
-      output += chunk.toString();
+      const text = chunk.toString();
+      stderr += text;
+      onProgress?.(text);
     });
     child.on('error', reject);
-    child.on('close', code =>
-      code === 0
-        ? resolve(output)
-        : reject(new Error(`\`${command} ${args.join(' ')}\` exited with code ${code}`)),
-    );
+    child.on('close', code => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+
+        return;
+      }
+
+      const detail = (stderr || stdout).trim();
+      reject(
+        new Error(
+          `\`${formatCommand(command, args)}\` exited with code ${code}${
+            detail ? `:\n${detail}` : ''
+          }`,
+        ),
+      );
+    });
   });
 }
 
@@ -88,8 +173,7 @@ export function runCapture(
  * resolve `ready` once it prints something matching `ready` — for an agent, the line that says its
  * schema reached Forest.
  *
- * `detached` is the important part: it makes the child a process-group leader so `stopAgent` can
- * take the whole tree down. Without it, a package-manager wrapper survives its own `kill`.
+ * `detached` makes the child a process-group leader so `stopProcess` can take the whole tree down.
  */
 export function startProcess(
   command: string,
@@ -105,70 +189,75 @@ export function startProcess(
     timeoutMs?: number;
   },
 ): StartedProcess {
+  installExitHook();
+
   const child = spawn(
     command,
     args,
     spawnOptions(options, { stdio: ['ignore', 'pipe', 'pipe'], detached: true }),
   );
 
+  running.add(child);
+  child.on('close', () => running.delete(child));
+
+  let stream = onOutput;
+  const mute = () => {
+    stream = undefined;
+  };
+
   const readyPromise = new Promise<void>((resolve, reject) => {
-    let output = '';
-    const timeout = setTimeout(
-      () => reject(new Error(`Timed out after ${timeoutMs / 1000}s waiting for \`${command}\`.`)),
-      timeoutMs,
-    );
+    // Only accumulated until `ready` matches, then released. Keeping it would mean re-running the
+    // regex over an ever-growing string for the process's whole life — quadratic, on a buffer a
+    // long-lived server grows to hundreds of megabytes.
+    let scanned = '';
+    let settled = false;
+    let timeout: NodeJS.Timeout;
+
+    const settle = () => {
+      settled = true;
+      clearTimeout(timeout);
+      scanned = ''; // release the buffer; `onData` keeps streaming but stops scanning
+    };
+
+    // A failed start must not leave the process behind: its open pipes would also keep this CLI's
+    // event loop alive, so the user would get an error and then a prompt that never returns.
+    const fail = (error: Error) => {
+      if (settled) return;
+      settle();
+      stopProcess(child);
+      reject(error);
+    };
 
     const onData = (chunk: Buffer) => {
       const text = chunk.toString();
-      output += text;
-      onOutput?.(text);
+      stream?.(text);
+      if (settled) return;
+      scanned += text;
 
-      if (ready.test(output)) {
-        clearTimeout(timeout);
+      if (ready.test(scanned)) {
+        settle();
         resolve();
-      } else if (/EADDRINUSE/.test(output)) {
-        clearTimeout(timeout);
-        reject(new Error('Port already in use — free it with `lsof -ti :<port> | xargs kill`.'));
+      } else if (/EADDRINUSE/.test(scanned)) {
+        fail(new Error('Port already in use — free it with `lsof -ti :<port> | xargs kill`.'));
       }
     };
 
+    timeout = setTimeout(
+      () => fail(new Error(`Timed out after ${timeoutMs / 1000}s waiting for \`${command}\`.`)),
+      timeoutMs,
+    );
+
     child.stdout?.on('data', onData);
     child.stderr?.on('data', onData);
-    child.on('error', error => {
-      clearTimeout(timeout);
-      reject(error);
-    });
-    child.on('close', code => {
-      clearTimeout(timeout);
-      reject(new Error(`\`${command}\` stopped before it was ready (exit code ${code}).`));
-    });
+    child.on('error', error => fail(error));
+    child.on('close', code =>
+      fail(new Error(`\`${command}\` stopped before it was ready (exit code ${code}).`)),
+    );
   });
 
   // The rejection is delivered to whoever awaits `ready`. Without this attachment, a process that
   // dies before being ready produces an unhandled rejection and can take the CLI down with it.
   readyPromise.catch(() => undefined);
 
-  return { child, ready: readyPromise };
-}
-
-/**
- * Stop a process started by `startProcess`, and everything it spawned.
- *
- * A negative pid signals the whole process group — the only way to reach the server a package
- * manager launched on our behalf. Falls back to signalling the child alone when the group is
- * already gone (or when the process was never detached), and never throws: stopping something
- * that has already stopped is a success, not an error.
- */
-export function stopProcess(child: ChildProcess | undefined, signal: NodeJS.Signals = 'SIGTERM') {
-  if (!child?.pid || child.killed) return;
-
-  try {
-    process.kill(-child.pid, signal);
-  } catch {
-    try {
-      child.kill(signal);
-    } catch {
-      // Already dead — nothing left to stop.
-    }
-  }
+  return { child, ready: readyPromise, mute };
 }

--- a/src/services/process-runner.ts
+++ b/src/services/process-runner.ts
@@ -1,0 +1,174 @@
+import type { ChildProcess, SpawnOptions } from 'child_process';
+
+import { spawn } from 'child_process';
+
+/**
+ * Running the commands an onboarding has to drive — `npm install`, `npm start`, `bundle add`,
+ * `bin/rails server` — and stopping them for real afterwards.
+ *
+ * Everything here exists because of one property of package managers: `npm start` is a WRAPPER.
+ * The process that holds the port is its child, not the one we spawned. So a naive `child.kill()`
+ * signals the wrapper, leaves the server running, and — since its pipes stay open — keeps this
+ * CLI alive too. Every long-running process is therefore started in its own process group, and
+ * stopped by signalling that group.
+ */
+
+export type RunOptions = {
+  cwd?: string;
+  env?: Record<string, string>;
+};
+
+export type StartedProcess = {
+  child: ChildProcess;
+  /** Resolves when the process prints something matching `ready`, rejects on timeout or a taken port. */
+  ready: Promise<void>;
+};
+
+const READY_TIMEOUT_MS = 120_000;
+
+function spawnOptions(options: RunOptions, extra: SpawnOptions = {}): SpawnOptions {
+  return {
+    cwd: options.cwd,
+    env: options.env ? { ...process.env, ...options.env } : process.env,
+    ...extra,
+  };
+}
+
+/**
+ * Run a command to completion. stdio is inherited so the child owns the terminal: `forest login`
+ * can open a browser, and a package manager's own prompts and progress render natively instead of
+ * being buffered into silence.
+ *
+ * Rejects with the exit code when the command fails — the caller decides whether that is fatal.
+ */
+export function runStep(command: string, args: string[], options: RunOptions = {}): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, spawnOptions(options, { stdio: 'inherit' }));
+
+    child.on('error', reject);
+    child.on('close', code =>
+      code === 0
+        ? resolve()
+        : reject(new Error(`\`${command} ${args.join(' ')}\` exited with code ${code}`)),
+    );
+  });
+}
+
+/** Same, but capturing stdout instead of inheriting it — for commands we need to read back. */
+export function runCapture(
+  command: string,
+  args: string[],
+  options: RunOptions = {},
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      command,
+      args,
+      spawnOptions(options, { stdio: ['inherit', 'pipe', 'pipe'] }),
+    );
+    let output = '';
+
+    child.stdout?.on('data', chunk => {
+      output += chunk.toString();
+    });
+    child.stderr?.on('data', chunk => {
+      output += chunk.toString();
+    });
+    child.on('error', reject);
+    child.on('close', code =>
+      code === 0
+        ? resolve(output)
+        : reject(new Error(`\`${command} ${args.join(' ')}\` exited with code ${code}`)),
+    );
+  });
+}
+
+/**
+ * Start a long-running process in the background, streaming its output through `onOutput`, and
+ * resolve `ready` once it prints something matching `ready` — for an agent, the line that says its
+ * schema reached Forest.
+ *
+ * `detached` is the important part: it makes the child a process-group leader so `stopAgent` can
+ * take the whole tree down. Without it, a package-manager wrapper survives its own `kill`.
+ */
+export function startProcess(
+  command: string,
+  args: string[],
+  {
+    ready,
+    onOutput,
+    timeoutMs = READY_TIMEOUT_MS,
+    ...options
+  }: RunOptions & {
+    ready: RegExp;
+    onOutput?: (chunk: string) => void;
+    timeoutMs?: number;
+  },
+): StartedProcess {
+  const child = spawn(
+    command,
+    args,
+    spawnOptions(options, { stdio: ['ignore', 'pipe', 'pipe'], detached: true }),
+  );
+
+  const readyPromise = new Promise<void>((resolve, reject) => {
+    let output = '';
+    const timeout = setTimeout(
+      () => reject(new Error(`Timed out after ${timeoutMs / 1000}s waiting for \`${command}\`.`)),
+      timeoutMs,
+    );
+
+    const onData = (chunk: Buffer) => {
+      const text = chunk.toString();
+      output += text;
+      onOutput?.(text);
+
+      if (ready.test(output)) {
+        clearTimeout(timeout);
+        resolve();
+      } else if (/EADDRINUSE/.test(output)) {
+        clearTimeout(timeout);
+        reject(new Error('Port already in use — free it with `lsof -ti :<port> | xargs kill`.'));
+      }
+    };
+
+    child.stdout?.on('data', onData);
+    child.stderr?.on('data', onData);
+    child.on('error', error => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on('close', code => {
+      clearTimeout(timeout);
+      reject(new Error(`\`${command}\` stopped before it was ready (exit code ${code}).`));
+    });
+  });
+
+  // The rejection is delivered to whoever awaits `ready`. Without this attachment, a process that
+  // dies before being ready produces an unhandled rejection and can take the CLI down with it.
+  readyPromise.catch(() => undefined);
+
+  return { child, ready: readyPromise };
+}
+
+/**
+ * Stop a process started by `startProcess`, and everything it spawned.
+ *
+ * A negative pid signals the whole process group — the only way to reach the server a package
+ * manager launched on our behalf. Falls back to signalling the child alone when the group is
+ * already gone (or when the process was never detached), and never throws: stopping something
+ * that has already stopped is a success, not an error.
+ */
+export function stopProcess(child: ChildProcess | undefined, signal: NodeJS.Signals = 'SIGTERM') {
+  if (!child?.pid || child.killed) return;
+
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // Already dead — nothing left to stop.
+    }
+  }
+}

--- a/src/services/process-runner.ts
+++ b/src/services/process-runner.ts
@@ -69,6 +69,15 @@ export function stopProcess(child: ChildProcess | undefined, signal: NodeJS.Sign
   }
 }
 
+/**
+ * Stop everything still running. For a caller unwinding on an error: a detached back-end survives
+ * its parent, and its open pipes can keep the CLI's event loop alive, so an unhandled failure
+ * would otherwise leave both a hung command and a server holding a port.
+ */
+export function stopAllProcesses(signal: NodeJS.Signals = 'SIGTERM') {
+  [...running].forEach(child => stopProcess(child, signal));
+}
+
 function installExitHook() {
   if (exitHookInstalled) return;
   exitHookInstalled = true;

--- a/test/services/process-runner.unit.test.ts
+++ b/test/services/process-runner.unit.test.ts
@@ -107,6 +107,43 @@ describe('process-runner', () => {
       }
     });
 
+    it('matches a stateful ready pattern, whose lastIndex would otherwise skip the announcement', async () => {
+      expect.assertions(1);
+      const { child, ready } = startProcess(
+        'sh',
+        ['-c', 'node -e "setInterval(()=>console.log(\'server listening now\'), 30)" & wait'],
+        // `/y/` is sticky: `.test()` advances lastIndex, so a second call misses a match the
+        // first one already passed — the process would die on a timeout that had no cause.
+        { ready: /listening/y, timeoutMs: 3000 },
+      );
+
+      try {
+        await expect(ready).resolves.toBeUndefined();
+      } finally {
+        stopProcess(child);
+        await wait(300);
+      }
+    });
+
+    it('does not accept a token straddling stdout and stderr, which neither stream produced', async () => {
+      expect.assertions(1);
+      const { child, ready } = startProcess(
+        'sh',
+        [
+          '-c',
+          "node -e \"process.stdout.write('READ'); process.stderr.write('Y-NOW'); setInterval(()=>{},1e3)\" & wait",
+        ],
+        { ready: /READY-NOW/, timeoutMs: 800 },
+      );
+
+      try {
+        await expect(ready).rejects.toThrow(/Timed out/);
+      } finally {
+        stopProcess(child);
+        await wait(300);
+      }
+    });
+
     it('rejects when the process dies before it is ready', async () => {
       expect.assertions(1);
       const { ready } = startProcess('node', ['-e', 'process.exit(1)'], { ready: /never/ });
@@ -213,32 +250,22 @@ describe('process-runner', () => {
       await expect(isPortFree(39326)).resolves.toBe(true);
     });
 
-    it('stops scanning once ready, so a chatty back-end does not grow an unbounded buffer', async () => {
-      expect.assertions(2);
-      const scans: number[] = [];
-      const ready = {
-        test: (s: string) => {
-          scans.push(s.length);
-          return /listening/.test(s);
-        },
-      } as RegExp;
-      const { child, ready: readyPromise } = startProcess(
+    it('keeps only a bounded window, so a chatty process cannot exhaust the heap before timing out', async () => {
+      expect.assertions(1);
+      // 40 KB of noise between the two halves of the pattern. Retaining everything would match;
+      // a bounded window cannot — which is the point: before the cap, a process that never
+      // announced itself grew the buffer until the CLI crashed, instead of reporting a timeout.
+      const { child, ready } = startProcess(
         'sh',
         [
           '-c',
-          "node -e \"console.log('listening'); setInterval(()=>console.log('x'.repeat(500)), 20)\" & wait",
+          "node -e \"process.stdout.write('BEGIN'); process.stdout.write('x'.repeat(40000)); process.stdout.write('END'); setInterval(()=>{},1e3)\" & wait",
         ],
-        { ready },
+        { ready: /BEGIN[\s\S]*END/, timeoutMs: 900 },
       );
 
       try {
-        await readyPromise;
-        const atReady = scans.length;
-        await wait(600);
-        // The regex is not re-run at all after ready; before the fix it ran on every chunk, over
-        // an ever-growing string, for the whole life of the process.
-        expect(scans).toHaveLength(atReady);
-        expect(Math.max(...scans)).toBeLessThan(2000);
+        await expect(ready).rejects.toThrow(/Timed out/);
       } finally {
         stopProcess(child);
         await wait(300);

--- a/test/services/process-runner.unit.test.ts
+++ b/test/services/process-runner.unit.test.ts
@@ -58,6 +58,19 @@ describe('process-runner', () => {
       expect(progress.join('')).toContain('spinner');
     });
 
+    it('decodes multibyte characters split across pipe chunks', async () => {
+      expect.assertions(1);
+      // Written one byte at a time, so every accented character straddles a chunk boundary.
+      // Decoding per chunk turns each into replacement characters — and the JSON below then
+      // parses to a different string than the command produced.
+      const { stdout } = await runCapture('node', [
+        '-e',
+        'const s = JSON.stringify({ v: "créé-àé€" }); for (const b of Buffer.from(s)) process.stdout.write(Buffer.from([b]));',
+      ]);
+
+      expect(JSON.parse(stdout)).toStrictEqual({ v: 'créé-àé€' });
+    });
+
     it('carries the failed command own message, not just its exit code', async () => {
       expect.assertions(1);
       await expect(

--- a/test/services/process-runner.unit.test.ts
+++ b/test/services/process-runner.unit.test.ts
@@ -42,11 +42,30 @@ describe('process-runner', () => {
   });
 
   describe('runCapture', () => {
-    it('returns stdout and stderr, so secrets printed either way can be read back', async () => {
-      expect.assertions(2);
-      const output = await runCapture('node', ['-e', 'console.log("out"); console.error("err")']);
-      expect(output).toContain('out');
-      expect(output).toContain('err');
+    it('keeps the streams apart, so progress on stderr cannot corrupt a JSON stdout', async () => {
+      expect.assertions(3);
+      const progress: string[] = [];
+      const { stdout, stderr } = await runCapture(
+        'node',
+        ['-e', 'console.error("spinner"); console.log(JSON.stringify({ secret: "s3cret" }))'],
+        { onProgress: chunk => progress.push(chunk) },
+      );
+
+      // Merging the two would make this parse throw, and the caller would silently get nothing.
+      expect(JSON.parse(stdout)).toStrictEqual({ secret: 's3cret' });
+      expect(stderr).toContain('spinner');
+      // …while the user still sees the progress that was written to stderr.
+      expect(progress.join('')).toContain('spinner');
+    });
+
+    it('carries the failed command own message, not just its exit code', async () => {
+      expect.assertions(1);
+      await expect(
+        runCapture('node', [
+          '-e',
+          'console.error("A project with this name already exists"); process.exit(2)',
+        ]),
+      ).rejects.toThrow(/A project with this name already exists/);
     });
   });
 
@@ -119,16 +138,102 @@ describe('process-runner', () => {
       await expect(isPortFree(39324)).resolves.toBe(true);
     });
 
-    it('does nothing, and does not throw, when there is no process or it is already stopped', async () => {
-      expect.assertions(2);
+    it('does not re-signal a process that already exited, whose pid the OS may have reused', async () => {
+      expect.assertions(3);
       expect(() => stopProcess(undefined)).not.toThrow();
 
       const { child, ready } = startProcess('sh', wrapper(39325), { ready: /listening/ });
       await ready;
       stopProcess(child);
-      await wait(300);
+      await wait(500);
 
-      expect(() => stopProcess(child)).not.toThrow();
+      // `child.killed` stays false on the group path — `process.kill()` never sets it — so the
+      // guard has to read the exit state instead, or a second call signals a recycled pid.
+      expect(child.killed).toBe(false);
+      const signalled: number[] = [];
+      const realKill = process.kill.bind(process);
+      jest.spyOn(process, 'kill').mockImplementation(((pid: number, sig?: NodeJS.Signals) => {
+        signalled.push(pid);
+
+        return realKill(pid, sig);
+      }) as typeof process.kill);
+      try {
+        stopProcess(child);
+        expect(signalled).toStrictEqual([]);
+      } finally {
+        jest.restoreAllMocks();
+      }
+    });
+
+    it('kills the process when the start fails, instead of leaving it holding the port', async () => {
+      expect.assertions(2);
+      const { ready } = startProcess('sh', wrapper(39326), {
+        ready: /never-matches/,
+        timeoutMs: 600,
+      });
+
+      await expect(ready).rejects.toThrow(/Timed out/);
+      await wait(500);
+      // Before the fix the rejection left the child alive — and its open pipes kept the CLI's
+      // event loop alive with it, so the command never returned to the prompt.
+      await expect(isPortFree(39326)).resolves.toBe(true);
+    });
+
+    it('stops scanning once ready, so a chatty back-end does not grow an unbounded buffer', async () => {
+      expect.assertions(2);
+      const scans: number[] = [];
+      const ready = {
+        test: (s: string) => {
+          scans.push(s.length);
+          return /listening/.test(s);
+        },
+      } as RegExp;
+      const { child, ready: readyPromise } = startProcess(
+        'sh',
+        [
+          '-c',
+          "node -e \"console.log('listening'); setInterval(()=>console.log('x'.repeat(500)), 20)\" & wait",
+        ],
+        { ready },
+      );
+
+      try {
+        await readyPromise;
+        const atReady = scans.length;
+        await wait(600);
+        // The regex is not re-run at all after ready; before the fix it ran on every chunk, over
+        // an ever-growing string, for the whole life of the process.
+        expect(scans).toHaveLength(atReady);
+        expect(Math.max(...scans)).toBeLessThan(2000);
+      } finally {
+        stopProcess(child);
+        await wait(300);
+      }
+    });
+
+    it('mutes the stream on request, so back-end logs stop corrupting a handed-over terminal', async () => {
+      expect.assertions(2);
+      const chunks: string[] = [];
+      const { child, ready, mute } = startProcess(
+        'sh',
+        [
+          '-c',
+          "node -e \"console.log('listening'); setInterval(()=>console.log('noise'), 20)\" & wait",
+        ],
+        { ready: /listening/, onOutput: chunk => chunks.push(chunk) },
+      );
+
+      try {
+        await ready;
+        mute();
+        const afterMute = chunks.length;
+        await wait(400);
+        expect(chunks).toHaveLength(afterMute);
+        expect(chunks.join('')).toContain('listening');
+      } finally {
+        stopProcess(child);
+        await wait(300);
+      }
     });
   });
 });

--- a/test/services/process-runner.unit.test.ts
+++ b/test/services/process-runner.unit.test.ts
@@ -1,0 +1,134 @@
+import net from 'net';
+
+import { runCapture, runStep, startProcess, stopProcess } from '../../src/services/process-runner';
+
+// A wrapper that stays alive and whose CHILD holds the port — the shape of `npm start`, and the
+// whole reason this service exists. `sh -c 'cmd'` alone would exec and collapse into one process,
+// which is exactly the case that never reproduced the bug.
+const SERVER = `node -e "require('net').createServer().listen(PORT,()=>console.log('listening'));setInterval(()=>{},1e3)"`;
+const wrapper = (port: number) => ['-c', `${SERVER.replace('PORT', String(port))} & wait`];
+
+function isPortFree(port: number): Promise<boolean> {
+  return new Promise(resolve => {
+    const probe = net.connect(port, '127.0.0.1');
+    probe.on('connect', () => {
+      probe.destroy();
+      resolve(false);
+    });
+    probe.on('error', () => resolve(true));
+  });
+}
+
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+describe('process-runner', () => {
+  describe('runStep', () => {
+    it('resolves when the command succeeds', async () => {
+      expect.assertions(1);
+      await expect(runStep('node', ['-e', 'process.exit(0)'])).resolves.toBeUndefined();
+    });
+
+    it('rejects with the exit code when the command fails', async () => {
+      expect.assertions(1);
+      await expect(runStep('node', ['-e', 'process.exit(3)'])).rejects.toThrow(
+        /exited with code 3/,
+      );
+    });
+
+    it('rejects when the command does not exist rather than hanging', async () => {
+      expect.assertions(1);
+      await expect(runStep('definitely-not-a-command', [])).rejects.toThrow(/ENOENT/);
+    });
+  });
+
+  describe('runCapture', () => {
+    it('returns stdout and stderr, so secrets printed either way can be read back', async () => {
+      expect.assertions(2);
+      const output = await runCapture('node', ['-e', 'console.log("out"); console.error("err")']);
+      expect(output).toContain('out');
+      expect(output).toContain('err');
+    });
+  });
+
+  describe('startProcess', () => {
+    it('resolves ready on the expected output and streams it to the caller', async () => {
+      expect.assertions(2);
+      const chunks: string[] = [];
+      const { child, ready } = startProcess('sh', wrapper(39321), {
+        ready: /listening/,
+        onOutput: chunk => chunks.push(chunk),
+      });
+
+      try {
+        await ready;
+        expect(chunks.join('')).toContain('listening');
+        await expect(isPortFree(39321)).resolves.toBe(false);
+      } finally {
+        stopProcess(child);
+        await wait(300);
+      }
+    });
+
+    it('rejects when the process dies before it is ready', async () => {
+      expect.assertions(1);
+      const { ready } = startProcess('node', ['-e', 'process.exit(1)'], { ready: /never/ });
+
+      await expect(ready).rejects.toThrow(/stopped before it was ready/);
+    });
+
+    it('rejects on a taken port instead of waiting for the timeout', async () => {
+      expect.assertions(1);
+      const blocker = net.createServer().listen(39322);
+
+      try {
+        const { ready } = startProcess('sh', wrapper(39322), { ready: /never-matches/ });
+        await expect(ready).rejects.toThrow(/Port already in use/);
+      } finally {
+        blocker.close();
+      }
+    });
+
+    it('rejects on timeout when the process never announces itself', async () => {
+      expect.assertions(1);
+      const { child, ready } = startProcess('sh', wrapper(39323), {
+        ready: /never-matches/,
+        timeoutMs: 700,
+      });
+
+      try {
+        await expect(ready).rejects.toThrow(/Timed out after 0.7s/);
+      } finally {
+        stopProcess(child);
+        await wait(300);
+      }
+    });
+  });
+
+  describe('stopProcess', () => {
+    it('frees the port held by a GRANDCHILD, which killing the wrapper alone does not', async () => {
+      expect.assertions(2);
+      const { child, ready } = startProcess('sh', wrapper(39324), { ready: /listening/ });
+      await ready;
+      await expect(isPortFree(39324)).resolves.toBe(false);
+
+      stopProcess(child);
+      await wait(500);
+
+      // The whole point: `npm start` spawns the real server as its child, so signalling the
+      // process we spawned leaves the port held and the CLI hanging on its open pipes.
+      await expect(isPortFree(39324)).resolves.toBe(true);
+    });
+
+    it('does nothing, and does not throw, when there is no process or it is already stopped', async () => {
+      expect.assertions(2);
+      expect(() => stopProcess(undefined)).not.toThrow();
+
+      const { child, ready } = startProcess('sh', wrapper(39325), { ready: /listening/ });
+      await ready;
+      stopProcess(child);
+      await wait(300);
+
+      expect(() => stopProcess(child)).not.toThrow();
+    });
+  });
+});

--- a/test/services/process-runner.unit.test.ts
+++ b/test/services/process-runner.unit.test.ts
@@ -1,6 +1,12 @@
 import net from 'net';
 
-import { runCapture, runStep, startProcess, stopProcess } from '../../src/services/process-runner';
+import {
+  runCapture,
+  runStep,
+  startProcess,
+  stopAllProcesses,
+  stopProcess,
+} from '../../src/services/process-runner';
 
 // A wrapper that stays alive and whose CHILD holds the port — the shape of `npm start`, and the
 // whole reason this service exists. `sh -c 'cmd'` alone would exec and collapse into one process,
@@ -133,6 +139,21 @@ describe('process-runner', () => {
         stopProcess(child);
         await wait(300);
       }
+    });
+  });
+
+  describe('stopAllProcesses', () => {
+    it('takes down everything still running, for a caller unwinding on an error', async () => {
+      expect.assertions(2);
+      const a = startProcess('sh', wrapper(39327), { ready: /listening/ });
+      const b = startProcess('sh', wrapper(39328), { ready: /listening/ });
+      await Promise.all([a.ready, b.ready]);
+
+      stopAllProcesses();
+      await wait(500);
+
+      await expect(isPortFree(39327)).resolves.toBe(true);
+      await expect(isPortFree(39328)).resolves.toBe(true);
     });
   });
 


### PR DESCRIPTION
Groundwork for `forest start` (#next), which has to drive `npm install`, `npm start`, `bundle add` and `bin/rails server` — the toolbelt has no way to run a long-lived process today.

## Why a service, and why it looks like this

One property of package managers explains the whole design: **`npm start` is a wrapper**. The process holding the port is its *child*, not the one we spawned. Signalling what we spawned leaves the server running **and** keeps this CLI alive on its still-open pipes — which is exactly how "Stop" ended up doing nothing in the onboarding prototype.

So long-running processes are started in their own process group, and stopped by signalling that group. And stopping means stopped: SIGTERM is a request a back-end is free to trap and decline, so the group is killed outright if it is still there after a grace period.

## What it provides

| | |
| :-- | :-- |
| `runStep` | inherits stdio, so `forest login` can open a browser and a package manager's prompts render natively instead of being buffered into silence |
| `runCapture` | captures stdout and stderr **separately**, streams stderr through `onProgress`, and puts the sub-command's own message in the error |
| `startProcess` | streams output, resolves once the process announces itself, fails fast on a taken port, returns `exited` and `mute()` |
| `stopProcess` | signals the group, escalates to SIGKILL, reads the exit state, never throws |

Credentials never reach an error message: passwords are stripped from anything URL-shaped in both the arguments and the captured output, and the value of a flag whose name says it is a secret is dropped whole. The host and database survive, because they are what makes a failure diagnosable and they are not the secret.

## Findings folded in

Two adversarial reviews ran against this branch. Every defect below was reproduced first, and each is covered by a test that fails without its fix.

**First round — on the original implementation:**

- **Listeners were never released** once ready settled, so the buffer grew for the process's whole life and the ready regex re-ran over all of it on every chunk — quadratic, measured at 33 MB of heap after 8 s of logs, on a service designed to run for hours.
- **A ready rejection left the child running**, and its open pipes kept the CLI's event loop alive: "Timed out…" followed by a prompt that never came back.
- **`detached: true` meant Ctrl-C never reached the child**, so any interrupt or crash stranded a server holding a port. Started processes are tracked and stopped on exit and on SIGINT/SIGTERM/SIGHUP.
- **`stopProcess` guarded on `child.killed`**, which `process.kill()` never sets — so it re-signalled a pid the OS may have reused.
- **`runCapture` merged the streams**, which breaks by construction against a command whose stdout is a machine-readable document and whose progress goes to stderr.

**Second round — five more, on the hardened version:**

- **`stopProcess` did nothing at all once the wrapper had exited.** It read the *leader's* exit state, but the wrapper can return while the server it launched keeps the port — the exact failure this module exists to prevent, reached from the other side. What must not be repeated is the signal, so that is what is tracked now; a signal-0 probe on the group rules out the recycled pid the old guard was there for, and POSIX forbids recycling a pid while a process group still carries it as its id.
- **Nothing escalated past SIGTERM**, so a server that traps it — puma, and most back-ends — kept the port for good. The group is now killed outright after a grace period, on an unref'd timer. On the way out that timer can never run, so the exit hook takes the same grace synchronously.
- **Every argument was pasted into the failure message**, with the captured stderr on top, so a connection URL or a registry token was handed straight back into the terminal and into whatever collects its output. The CLI masks that connection URL at the prompt; it must not print it back in the failure it caused.
- **EADDRINUSE was fatal even when the process recovered from it.** Plenty of dev servers report the clash and then bind the next port up; an unanchored substring match killed a back-end that was about to serve. It starts a countdown now, which announcing readiness cancels — and the countdown does not depend on finding the port in the message, which Ruby writes before the word and a unix socket does not write at all.
- **A crash after `ready` was silent.** `ready` only ever describes the start, so a back-end that died twenty minutes in left a caller with no way to notice. `exited` resolves whenever the process ends, carrying the signal as well as the code so a caller can tell a crash from its own stop.

**Third round — Macroscope, on the reviewed version:** a group dropped from the register as soon as its wrapper closed, and again at signal time, putting a still-running server out of reach of the exit hook; "already signalled" remembered instead of asked, so a `SIGKILL` after a declined `SIGTERM` did nothing; a POSIX `child.kill` fallback that could reach a recycled pid; and two credential shapes the redaction was written past — `redis://:secret@host`, and a secret value starting with `-`.

One of its findings was declined: swapping `close` for `exit` in the startup watch would reject a start that succeeds, since a launcher that hands over and leaves exits long before the server it left behind announces itself. That case is now a test.

Also fixed along the way: SIGHUP exited 143, which belongs to SIGTERM — the convention is 128 + the signal number, so 129.

## Tested

**38 tests**, on real processes rather than mocks. The key one spawns a real wrapper whose *child* holds a port, because `sh -c 'cmd'` alone execs into a single process and cannot reproduce the bug; it asserts the port is free after `stopProcess`.

Also covered: the wrapper that exits before its child, the server that traps SIGTERM, the exit hook asserted on the signals it has already sent by the time it calls `process.exit` (the kernel freeing the socket is not synchronous, so asserting on the port there is a race that loses on Linux), the buffer released at ready, the port freed after a failed start, no re-signal after exit, muting, stderr not corrupting a JSON stdout, and credentials absent from every error the module raises.

Ports are asked of the OS rather than hardcoded in the newer tests: these are tests about servers that outlive what started them, so a run that leaves one behind must not be able to poison the next.

⚠️ **Windows is a documented limitation, not an oversight**: `process.kill(-pid)` does not exist there and `detached` creates no signalable group, so the fallback signals the wrapper alone. CI is Linux-only and the onboarding is not offered on Windows; if that changes this needs `taskkill /T /F`.

## Known, and deliberately left

- `installExitHook()` is a side effect of `startProcess`: it installs global signal handlers that are never removed and calls `process.exit()` directly, where the repo has `src/context/process-plan.js` to make that injectable. Changing it means changing who calls what, which is a design decision rather than a fix.
- `runCapture` buffers stdout and stderr without a bound, where `startProcess` is carefully capped — defensible, since the point is to get the whole document.
- Redaction is deliberately narrow: a secret that is neither shaped like a URL nor the value of a secret-looking flag still goes through.
- **Nothing imports this module yet.** That is what `forest start` is for, and it is where the API will first meet its real usage.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `process-runner` service with group shutdown and readiness tracking
> - Introduces [process-runner.ts](https://github.com/ForestAdmin/toolbelt/pull/816/files#diff-8792b9366db21ee8c5b5272531b5b3a1e99429c29cd902fc1e0f272d67a98429) to run commands via `runStep`, `runCapture`, and `startProcess`.
> - `startProcess` launches detached background processes, monitors output for readiness or `EADDRINUSE` port clashes, and supports log muting.
> - `stopProcess` and `stopAllProcesses` use process-group signaling on POSIX to stop descendants, escalating from graceful termination to `SIGKILL` after a grace period.
> - Exit hooks clean up tracked process groups synchronously on normal and signal-based exits. Error messages redact secrets in connection URLs and arguments.
> - Risk: `signalGroup` relies on POSIX process groups; Windows falls back to direct child signaling and may leave descendants running.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #816 opened
>
> - Replaced the `stopped` WeakSet with an `escalating` WeakSet in the process runner module to track which `ChildProcess` instances already have an escalation countdown scheduled, allowing `stopProcess` to send additional signals to still-alive process groups while preventing multiple escalation timers from being stacked on the same child, and modified the `close` event handler in `startProcess` to only remove a child from the `running` registry when `groupAlive` confirms the entire process group has terminated rather than when the wrapper process exits [3c8b07e]
> - Modified the `signalGroup` utility to explicitly check `CAN_SIGNAL_GROUPS` and attempt `child.kill(signal)` on platforms without group signaling support before returning, and on POSIX-capable systems to signal the negative pid for the process group while ignoring failures as already dead, removing the previous implicit fallback from group signaling failure to signaling the leader pid [3c8b07e]
> - Updated the `stopProcess` function to change its early-return guard to only check for an existing pid and whether the process group is alive via `groupAlive`, removing reliance on the `stopped` WeakSet and no longer deleting the child from the `running` registry within the function, and to always attempt signaling the group via `signalGroup` and allow `SIGKILL` to be sent immediately even if a prior `SIGTERM` was sent [3c8b07e]
> - Adjusted the `URL_CREDENTIALS` regular expression to allow an empty username segment before the password by changing the quantifier from `+` to `*`, enabling redaction of credentials in URLs with patterns like `redis://:password@host`, and introduced a `LONG_FLAG` constant to detect double-dash flags and updated `redactArgs` to consider a secret value as the next token unless it matches `LONG_FLAG` rather than any token starting with a dash [3c8b07e]
> - Added test cases covering processes remaining reachable for exit hooks when trapping signals, servers remaining in the running registry after their wrapper processes exit, waiting for readiness even when wrappers exit early, redacting credentials in URLs with empty usernames, and redacting secret values beginning with a single dash without consuming subsequent long flags, and updated existing tests to reflect the new behavior where `stopProcess` does not suppress re-signaling and probes group liveness via signal 0 [3c8b07e]
> - Modified `startProcess` function to wait for entire process group termination before resolving the `exited` promise, introduced `ended` WeakSet to permanently track terminated process groups, and updated `groupAlive` function to mark groups as ended and remove them from the `running` set when detected as not alive [e1302de]
> - Modified `watchStartup` function buffering logic to concatenate prior window with new chunks before classification to detect readiness tokens split across I/O boundaries [e1302de]
> - Introduced `REAP_POLL_MS` constant set to 250 milliseconds defining polling frequency for process group liveness checks after wrapper process exits [e1302de]
> - Modified `readPortClash` utility to strip time-like tokens from log lines before extracting port numbers to avoid misinterpreting timestamp components as ports [e1302de]
> - Extracted `probeGroup` function to centralize process group liveness checking logic using signal 0 on the negative pid [e1302de]
> - Updated and expanded test coverage for process runner to verify process group lifecycle management, readiness detection across chunk boundaries, timestamp handling in port clash detection, and that ended groups are not probed or signaled after termination [e1302de]
> - Replaced single-buffer stream output detection with sliding window scanning to detect ready patterns and port clashes that span read boundaries [7d8fc75]
> - Encapsulated process group end tracking into reusable helper [7d8fc75]
> - Consolidated POSIX and Windows process signaling paths in `signalGroup` util [7d8fc75]
> - Introduced synchronous blocking helper and updated synchronous shutdown to use it [7d8fc75]
> - Refactored port clash detection in `readPortClash` util with reusable time-stripping regex [7d8fc75]
> - Added stream scanning and time pattern constants [7d8fc75]
> - Updated comments across implementation and test files for clarity [7d8fc75]
> - Replaced `escalating` WeakSet with `escalations` WeakMap in process-runner to store escalation timeout handles per child process, and modified `stopProcess` to clear any existing escalation timer before scheduling a new one [af0a821]
> - Replaced regex-based secret flag detection with word-boundary-aware detection using `isSecretFlag` helper function [af0a821]
> - Updated test suite to use dynamically allocated ports instead of fixed ports, reduced timeout values in EADDRINUSE tests, and added tests verifying escalation timer replacement and word-boundary-based flag redaction [af0a821]
> - Implemented suffix-based secret detection for command flags with digit stripping and exclusion list [2b92710]
> - Modified port clash detection to prioritize clashes containing port values [2b92710]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 761411b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->