### PR TITLE
feat(start): move the onboarding into the CLI as `forest start`

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -11,7 +11,13 @@ import {
   detectRails,
   mountHelper,
 } from '../services/onboarding/detect';
-import { runCapture, runStep, startProcess, stopProcess } from '../services/process-runner';
+import {
+  runCapture,
+  runStep,
+  startProcess,
+  stopAllProcesses,
+  stopProcess,
+} from '../services/process-runner';
 
 const DOCS_URL = 'https://docs.forest.app';
 const DEMO_PORT = 3310;
@@ -90,6 +96,19 @@ export default class StartCommand extends AbstractCommand {
     const { flags } = await this.parse(StartCommand);
     this.dryRun = flags['dry-run'];
 
+    try {
+      await this.onboard(flags as Record<string, string | undefined>);
+    } catch (error) {
+      // Anything after a boot — `layout:apply`, `skills:init`, the agent launch — can fail. The
+      // back-end is detached, so it would survive, and its open pipes can keep this command alive
+      // with it: an error message followed by a prompt that never returns, and a port still held.
+      stopAllProcesses();
+
+      throw error;
+    }
+  }
+
+  private async onboard(flags: Record<string, string | undefined>): Promise<void> {
     this.logger.log(
       `\nWelcome to ${this.chalk.green('Forest')}. Let's get your back-office running.`,
     );
@@ -416,6 +435,15 @@ export default class StartCommand extends AbstractCommand {
     ]);
     const secrets = StartCommand.parseSecrets(output);
 
+    // Checked before `bundle add`: past that point five gems and a lockfile change are in the
+    // user's repo, and throwing "nothing was generated" would be false.
+    if (!secrets.envSecret && !this.dryRun) {
+      throw new Error(
+        'Could not read FOREST_ENV_SECRET from `projects:create:in-app`. Nothing was installed — ' +
+          'run it by hand and pass the secret to `bin/rails g forest_admin_rails:install`.',
+      );
+    }
+
     // Five gems, not the three the docs list: forest_admin_rails alone installs but fails to boot,
     // because it does not declare its companions as runtime dependencies.
     await this.run$('bundle', [
@@ -426,15 +454,6 @@ export default class StartCommand extends AbstractCommand {
       'forest_admin_datasource_toolkit',
       'forest_admin_datasource_customizer',
     ]);
-    // Without it the generator writes a literal placeholder into the Rails initializer, on disk,
-    // and the app boots against nothing. Fail here instead, while nothing has been generated.
-    if (!secrets.envSecret && !this.dryRun) {
-      throw new Error(
-        'Could not read FOREST_ENV_SECRET from `projects:create:in-app`. Nothing was generated — ' +
-          'run it by hand and pass the secret to `bin/rails g forest_admin_rails:install`.',
-      );
-    }
-
     await this.run$('bin/rails', [
       'g',
       'forest_admin_rails:install',
@@ -586,22 +605,34 @@ export default class StartCommand extends AbstractCommand {
       return;
     }
 
-    // Must match the package just installed: telling a mongoose app to call
-    // `createSequelizeDataSource` sends the user straight into an import that does not exist.
-    const datasource = {
-      sql: 'createSqlDataSource(process.env.DATABASE_URL)',
-      sequelize: 'createSequelizeDataSource(sequelize)',
-      mongoose: 'createMongooseDataSource(connection)',
-      typeorm: 'createTypeOrmDataSource(dataSource)',
-      prisma: 'createPrismaDataSource(prisma)',
+    // Must match the package just installed, IMPORT INCLUDED: a snippet calling
+    // `createMongooseDataSource` while importing only `createAgent` does not compile, and the
+    // reader has no way to know which package the missing symbol comes from.
+    const { factory, call } = {
+      sql: {
+        factory: 'createSqlDataSource',
+        call: 'createSqlDataSource(process.env.DATABASE_URL)',
+      },
+      sequelize: {
+        factory: 'createSequelizeDataSource',
+        call: 'createSequelizeDataSource(sequelize)',
+      },
+      mongoose: {
+        factory: 'createMongooseDataSource',
+        call: 'createMongooseDataSource(connection)',
+      },
+      typeorm: { factory: 'createTypeOrmDataSource', call: 'createTypeOrmDataSource(dataSource)' },
+      prisma: { factory: 'createPrismaDataSource', call: 'createPrismaDataSource(prisma)' },
     }[stack.orm];
+
     this.instruct('Add to your server (after your ORM is ready, before app.listen):', [
       this.chalk.cyan("import { createAgent } from '@forestadmin/agent';"),
+      this.chalk.cyan(`import { ${factory} } from '${NODE_DATASOURCE[stack.orm]}';`),
       this.chalk.cyan(
         'createAgent({ authSecret: process.env.FOREST_AUTH_SECRET, envSecret: process.env.FOREST_ENV_SECRET, isProduction: false })',
       ),
       this.chalk.cyan(
-        `  .addDataSource(${datasource}).mountOn${mountHelper(stack.framework)}(app).start();`,
+        `  .addDataSource(${call}).mountOn${mountHelper(stack.framework)}(app).start();`,
       ),
       this.chalk.grey(`Exact per-stack snippet → ${DOCS_URL}/…/in-app/${stack.framework}`),
     ]);

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -35,6 +35,8 @@ type Tail = {
   demo?: boolean;
   /** Stops streaming the back-end's logs — they would otherwise be drawn into a full-screen TUI. */
   mute?: () => void;
+  /** How to start this back-end again. Rails is not started with `npm start`. */
+  restart: string;
 };
 
 /**
@@ -106,9 +108,27 @@ export default class StartCommand extends AbstractCommand {
 
   // ---------- primitives ----------
 
+  /**
+   * Values that must never reach the terminal, a scrollback or a CI log. The echo is a feature —
+   * it teaches what the wrapper does — but a database URL carries credentials and an env secret is
+   * a long-lived one, so what is shown and what is run are not the same string.
+   */
+  private static redact(command: string, args: string[]): string {
+    const shown = args.map((arg, index) => {
+      const previous = args[index - 1];
+
+      if (previous === '--databaseConnectionURL' || previous === '-c') return '<redacted>';
+      if (command === 'bin/rails' && previous === 'forest_admin_rails:install') return '<redacted>';
+
+      return arg;
+    });
+
+    return `${command} ${shown.join(' ')}`.trim();
+  }
+
   /** Run a command, echoing it first. The echo is the point: it teaches what the wrapper does. */
   private async run$(command: string, args: string[], cwd?: string): Promise<void> {
-    this.logger.log(this.chalk.grey(`\n$ ${`${command} ${args.join(' ')}`.trim()}`));
+    this.logger.log(this.chalk.grey(`\n$ ${StartCommand.redact(command, args)}`));
     if (this.dryRun) return this.logger.log(this.chalk.grey('  (dry-run — not executed)'));
 
     return runStep(command, args, { cwd });
@@ -117,7 +137,7 @@ export default class StartCommand extends AbstractCommand {
   /** Invoke one of our own commands. Resolved through this executable, never through the PATH:
    *  under `npx forest-cli@latest start` there may be no `forest` installed anywhere. */
   private forest(args: string[], cwd?: string): Promise<void> {
-    this.logger.log(this.chalk.grey(`\n$ forest ${args.join(' ')}`));
+    this.logger.log(this.chalk.grey(`\n$ ${StartCommand.redact('forest', args)}`));
     if (this.dryRun) {
       this.logger.log(this.chalk.grey('  (dry-run — not executed)'));
 
@@ -134,7 +154,7 @@ export default class StartCommand extends AbstractCommand {
    * there, and a silent terminal during project creation reads as a hang.
    */
   private async forestCapture(args: string[]): Promise<string> {
-    this.logger.log(this.chalk.grey(`\n$ forest ${args.join(' ')}`));
+    this.logger.log(this.chalk.grey(`\n$ ${StartCommand.redact('forest', args)}`));
     if (this.dryRun) {
       this.logger.log(this.chalk.grey('  (dry-run — not executed)'));
 
@@ -151,8 +171,11 @@ export default class StartCommand extends AbstractCommand {
 
       return stdout;
     } catch (error) {
-      if (!/--format|Nonexistent flag/.test((error as Error).message) || !args.includes('--format'))
-        throw error;
+      // The error message opens with the command, which contains `--format` — testing the whole
+      // message would match every failure and re-run a command that creates a project.
+      // Only the diagnostic below the first line can say the flag is unknown.
+      const [, ...detail] = (error as Error).message.split('\n');
+      if (!args.includes('--format') || !/Nonexistent flag/i.test(detail.join('\n'))) throw error;
 
       const withoutFormat = args.filter(
         (arg, index) => arg !== '--format' && args[index - 1] !== '--format',
@@ -353,22 +376,29 @@ export default class StartCommand extends AbstractCommand {
     const tail: Tail = {
       name,
       dir: name, // `create:sql` scaffolded ./<name>
+      restart: 'npm start',
       stack: "standalone Forest agent (TypeScript) on the user's own database",
       url: `http://localhost:${DEMO_PORT}`,
     };
 
     if (this.dryRun) {
       this.logger.log(this.chalk.grey(`\n$ npm start   (back-end stays live on :${DEMO_PORT})`));
-      this.doneStandalone(name);
+      this.doneStandalone(name, DEMO_PORT);
       await this.handoff(tail);
 
       return;
     }
 
+    // Without --db the port came from `create:sql`'s own prompt, so DEMO_PORT is a guess. The
+    // generated .env records what was actually chosen — reporting the wrong one would send both
+    // the user and the coding agent to a back-end that is not listening there.
+    const port = StartCommand.readPort(name) ?? DEMO_PORT;
+    tail.url = `http://localhost:${port}`;
+
     const booted = this.boot('npm', ['start'], { cwd: name });
     this.logger.log(this.chalk.grey('  (waiting for the schema push…)'));
     await booted.ready;
-    this.doneStandalone(name);
+    this.doneStandalone(name, port);
     await this.handoff({ ...tail, child: booted.child, mute: booted.mute });
   }
 
@@ -414,6 +444,7 @@ export default class StartCommand extends AbstractCommand {
     const tail: Tail = {
       name,
       dir: '.', // in-app scaffolds nothing: the repo is the user's own
+      restart: `bin/rails server -p ${RAILS_PORT}`,
       stack: "Forest mounted inside the user's Ruby on Rails app",
       url: `http://localhost:${RAILS_PORT}`,
     };
@@ -480,6 +511,7 @@ export default class StartCommand extends AbstractCommand {
     const tail: Tail = {
       name,
       dir: '.', // in-app scaffolds nothing: the repo is the user's own
+      restart: 'npm start',
       stack: "Forest mounted inside the user's Node.js app",
       url: `http://localhost:${NODE_PORT}`,
     };
@@ -495,14 +527,12 @@ export default class StartCommand extends AbstractCommand {
     }
 
     if (!this.interactive) {
-      // The secrets are what the app needs to boot, so they have to be shown — but they are
-      // long-lived credentials and this path is where CI logs are written, hence the warning.
-      this.logger.warn('The value below is a SECRET — do not commit it or paste it into logs.');
-      this.logger.log(
-        this.chalk.grey(
-          `  Then run:  FOREST_ENV_SECRET=${secrets.envSecret} FOREST_AUTH_SECRET=${secrets.authSecret} PORT=${NODE_PORT} npm start`,
-        ),
-      );
+      // Written, never printed: this path is where CI logs are produced, and `FOREST_ENV_SECRET`
+      // is a long-lived credential — anyone who can read the retained log gets the project. A
+      // warning next to the value would not have stopped that.
+      const envFile = StartCommand.writeSecrets(secrets);
+      this.logger.success(`Secrets written to ${envFile} — do not commit it.`);
+      this.logger.log(this.chalk.grey(`  Then run:  PORT=${NODE_PORT} npm start`));
 
       return;
     }
@@ -613,7 +643,7 @@ export default class StartCommand extends AbstractCommand {
     }
 
     if (next === 'stay') {
-      if (child) await this.keepAlive(child, name);
+      if (child) await this.keepAlive(child, name, 'npm start');
 
       return;
     }
@@ -632,7 +662,7 @@ export default class StartCommand extends AbstractCommand {
     if (!this.interactive) {
       if (tail.child) {
         stopProcess(tail.child);
-        this.logger.log(this.chalk.grey(`  Launch it anytime: cd ${tail.dir} && npm start`));
+        this.logger.log(this.chalk.grey(`  Launch it anytime: cd ${tail.dir} && ${tail.restart}`));
       }
 
       return;
@@ -659,7 +689,7 @@ export default class StartCommand extends AbstractCommand {
       done = next === 'stay';
     }
 
-    if (tail.child) await this.keepAlive(tail.child, tail.dir);
+    if (tail.child) await this.keepAlive(tail.child, tail.dir, tail.restart);
   }
 
   /** One menu choice. Returns true when the terminal was handed to a coding agent. */
@@ -682,6 +712,18 @@ export default class StartCommand extends AbstractCommand {
       // Deploying lives in the `deploy-heroku` SKILL, so it needs the skills installed first —
       // `forest deploy` ships layout changes, it does not deploy the app.
       if (await this.launch(tail, StartCommand.seed('deploy', tail))) return true;
+
+      // Skills present, but no agent we can start from here — Cursor and OpenCode have them and
+      // are not launchable. Sending those users back to `skills:init` loops them on a step they
+      // have already done, with no way to ever reach a deploy.
+      if (StartCommand.hasSkills(tail.dir)) {
+        this.instruct('Ask your coding agent to deploy:', [
+          this.chalk.cyan('"deploy this Forest project to production"'),
+          this.chalk.grey('It has the Forest skills — the steps are in `deploy-heroku`.'),
+        ]);
+
+        return false;
+      }
 
       this.instruct('Deploying needs your coding agent set up first:', [
         `Pick ${this.chalk.cyan(
@@ -712,24 +754,27 @@ export default class StartCommand extends AbstractCommand {
         `\n  (your Forest back-end keeps running underneath — opening ${agent.label}…)`,
       ),
     );
+    // The agent takes over a full-screen terminal; back-end log lines drawn into it corrupt the
+    // display for the whole session. It keeps running, we just stop echoing it.
+    tail.mute?.();
     await this.run$(agent.bin, [seed], tail.dir);
     stopProcess(tail.child, 'SIGINT');
     this.logger.log(
-      this.chalk.grey(`\n  Forest back-end stopped. Restart it: cd ${tail.dir} && npm start`),
+      this.chalk.grey(`\n  Forest back-end stopped. Restart it: cd ${tail.dir} && ${tail.restart}`),
     );
 
     return true;
   }
 
   /** Hold the back-end in the foreground so a closed window is never a dead end. */
-  private keepAlive(child: ChildProcess, name: string): Promise<void> {
+  private keepAlive(child: ChildProcess, dir: string, restart: string): Promise<void> {
     this.logger.log(
       this.chalk.grey(
         '\n  ▸ This terminal now runs your back-end (live logs below). Keep it open.',
       ),
     );
     this.logger.log(
-      this.chalk.grey(`     Ctrl-C to stop  ·  restart later: cd ${name} && npm start`),
+      this.chalk.grey(`     Ctrl-C to stop  ·  restart later: cd ${dir} && ${restart}`),
     );
 
     return new Promise(resolve => {
@@ -739,7 +784,7 @@ export default class StartCommand extends AbstractCommand {
         stopped = true;
         this.logger.log(
           `\n\n${this.chalk.yellow('■')} Back-end stopped. Restart it anytime → ${this.chalk.cyan(
-            `cd ${name} && npm start`,
+            `cd ${dir} && ${restart}`,
           )}`,
         );
         stopProcess(child, 'SIGINT');
@@ -809,6 +854,27 @@ export default class StartCommand extends AbstractCommand {
    * fallback is what makes this work against a CLI that predates the flag rather than dying on
    * `Nonexistent flag: --format`.
    */
+  /**
+   * Put the secrets where the app reads them from, rather than on the terminal. Existing values
+   * are left alone: overwriting a secret the user already configured would be worse than not
+   * writing at all.
+   */
+  private static writeSecrets(secrets: { envSecret?: string; authSecret?: string }): string {
+    const file = '.env';
+    const current = fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '';
+    const missing = Object.entries({
+      FOREST_ENV_SECRET: secrets.envSecret,
+      FOREST_AUTH_SECRET: secrets.authSecret,
+    }).filter(([key, value]) => value && !new RegExp(`^${key}=`, 'm').test(current));
+
+    if (missing.length) {
+      const separator = current && !current.endsWith('\n') ? '\n' : '';
+      fs.appendFileSync(file, `${separator}${missing.map(([k, v]) => `${k}=${v}`).join('\n')}\n`);
+    }
+
+    return file;
+  }
+
   private static parseSecrets(output: string): { envSecret?: string; authSecret?: string } {
     try {
       const parsed = JSON.parse(output.trim());
@@ -829,13 +895,24 @@ export default class StartCommand extends AbstractCommand {
     );
   }
 
-  private doneStandalone(name: string): void {
+  /** The port the scaffolded project actually runs on, from its generated .env. */
+  private static readPort(dir: string): number | undefined {
+    try {
+      const port = /^APPLICATION_PORT=(\d+)/m.exec(fs.readFileSync(`${dir}/.env`, 'utf8'))?.[1];
+
+      return port ? Number(port) : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private doneStandalone(name: string, port: number): void {
     this.logger.success('Your back-office is live!');
     this.logger.log(
       `  ${this.chalk.bold('Open it →')} ${this.chalk.cyan(`https://app.forestadmin.com/${name}`)}`,
     );
     this.logger.log(
-      `  ${this.chalk.bold('Served by →')} http://localhost:${DEMO_PORT}   (this terminal)`,
+      `  ${this.chalk.bold('Served by →')} http://localhost:${port}   (this terminal)`,
     );
   }
 

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -567,9 +567,12 @@ export default class StartCommand extends AbstractCommand {
       message: 'Once Forest is mounted in your server, press Enter to boot it',
     });
     const booted = this.boot('npm', ['start'], {
+      // Only what we actually have. An empty string is not a neutral default: it SHADOWS the
+      // value dotenv would have loaded from the .env we just wrote, so the app boots with no
+      // secret at all — the one case this whole path exists to prevent.
       env: {
-        FOREST_ENV_SECRET: secrets.envSecret ?? '',
-        FOREST_AUTH_SECRET: secrets.authSecret ?? '',
+        ...(secrets.envSecret ? { FOREST_ENV_SECRET: secrets.envSecret } : {}),
+        ...(secrets.authSecret ? { FOREST_AUTH_SECRET: secrets.authSecret } : {}),
         PORT: String(NODE_PORT),
       },
     });

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,0 +1,741 @@
+import type { NodeStack } from '../services/onboarding/detect';
+import type { ChildProcess } from 'child_process';
+
+import { Flags } from '@oclif/core';
+import fs from 'fs';
+
+import AbstractCommand from '../abstract-command';
+import {
+  NODE_DATASOURCE,
+  detectNodeStack,
+  detectRails,
+  mountHelper,
+} from '../services/onboarding/detect';
+import { runCapture, runStep, startProcess, stopProcess } from '../services/process-runner';
+
+const DOCS_URL = 'https://docs.forest.app';
+const DEMO_PORT = 3310;
+const RAILS_PORT = 3002;
+const NODE_PORT = 3001;
+
+// Broad "the back-end is up" marker: covers standalone ("mounted on Standalone server"), in-app
+// Node ("mounted on Express.js") and Rails ("schema was updated" / Puma).
+const READY = /Successfully mounted on|schema was (updated|not updated)|Listening on http/i;
+
+type Flow = 'demo' | 'standalone' | 'inapp';
+type Tail = { child?: ChildProcess; name: string; stack: string; url: string; demo?: boolean };
+
+/**
+ * `forest start` — the whole onboarding, from an empty terminal to a running back-office.
+ *
+ * A deterministic orchestrator over this CLI's own commands. It prints every command before
+ * running it, on purpose: the wrapper stays legible instead of magical, and the developer learns
+ * the toolbelt while it works for them.
+ *
+ * FOUR FLOWS (shared head: log in → pick how you run Forest):
+ *   1. Demo data      create:demo   → boot → layout:apply → TRAMPOLINE (connect real data)
+ *   2. Standalone     create:sql    → boot                → HANDOFF
+ *   3. In-app Rails   create:in-app → gems → generator → boot → HANDOFF
+ *   4. In-app Node    create:in-app → install → mount → boot   → HANDOFF
+ *
+ * Two tails, both interactive loops over a live back-end — never a dead-end wall of text. Neither
+ * invites teammates: the first production deploy is what creates the project's first role, so an
+ * invite before it lands nowhere.
+ */
+export default class StartCommand extends AbstractCommand {
+  static override description =
+    'Set up Forest from scratch: log in, create a project, boot its back-end, and hand your coding agent the skills to build on it.';
+
+  static override flags = {
+    'dry-run': Flags.boolean({
+      description: 'Print every command instead of running it — to review the flow.',
+      default: false,
+    }),
+    flow: Flags.string({
+      description: 'Skip the first question. Required in non-interactive runs.',
+      options: ['demo', 'standalone', 'inapp'],
+    }),
+    stack: Flags.string({ description: 'In-app stack.', options: ['rails', 'node'] }),
+    name: Flags.string({ description: 'Project name (skips the prompt).' }),
+    db: Flags.string({ description: 'Database connection URL (skips the database prompts).' }),
+    mount: Flags.string({
+      description: 'How to mount Forest in a Node app.',
+      options: ['ai', 'manual', 'standalone'],
+    }),
+  };
+
+  private dryRun = false;
+
+  // eslint-disable-next-line class-methods-use-this -- reads the ambient TTY, not instance state
+  private get interactive(): boolean {
+    return Boolean(process.stdin.isTTY);
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(StartCommand);
+    this.dryRun = flags['dry-run'];
+
+    this.logger.log(
+      `\nWelcome to ${this.chalk.green('Forest')}. Let's get your back-office running.`,
+    );
+
+    await this.forest(['login']); // OIDC device flow (browser signup/login)
+
+    const flow = await this.pickFlow(flags.flow as Flow | undefined);
+
+    if (flow === 'demo') return this.flowDemo();
+    if (flow === 'standalone') return this.flowStandalone(flags);
+
+    const stack = await this.pickStack(flags.stack as 'rails' | 'node' | undefined);
+
+    return stack === 'rails' ? this.flowInAppRails(flags) : this.flowInAppNode(flags);
+  }
+
+  // ---------- primitives ----------
+
+  /** Run a command, echoing it first. The echo is the point: it teaches what the wrapper does. */
+  private async run$(command: string, args: string[], cwd?: string): Promise<void> {
+    this.logger.log(this.chalk.grey(`\n$ ${`${command} ${args.join(' ')}`.trim()}`));
+    if (this.dryRun) return this.logger.log(this.chalk.grey('  (dry-run — not executed)'));
+
+    return runStep(command, args, { cwd });
+  }
+
+  /** Invoke one of our own commands. Resolved through this executable, never through the PATH:
+   *  under `npx forest-cli@latest start` there may be no `forest` installed anywhere. */
+  private forest(args: string[], cwd?: string): Promise<void> {
+    this.logger.log(this.chalk.grey(`\n$ forest ${args.join(' ')}`));
+    if (this.dryRun) {
+      this.logger.log(this.chalk.grey('  (dry-run — not executed)'));
+
+      return Promise.resolve();
+    }
+
+    return runStep(process.execPath, [process.argv[1], ...args], { cwd });
+  }
+
+  private async forestCapture(args: string[]): Promise<string> {
+    this.logger.log(this.chalk.grey(`\n$ forest ${args.join(' ')}`));
+    if (this.dryRun) {
+      this.logger.log(this.chalk.grey('  (dry-run — not executed)'));
+
+      return '';
+    }
+
+    return runCapture(process.execPath, [process.argv[1], ...args]);
+  }
+
+  /** Boot a back-end, streaming its logs, and wait until its schema reached Forest. */
+  private boot(
+    command: string,
+    args: string[],
+    options: { cwd?: string; env?: Record<string, string>; ready?: RegExp } = {},
+  ) {
+    return startProcess(command, args, {
+      ready: options.ready ?? READY,
+      cwd: options.cwd,
+      env: options.env,
+      onOutput: chunk => this.logger.log(this.chalk.grey(`  | ${chunk.replace(/\n$/, '')}`)),
+    });
+  }
+
+  private ask(question: Record<string, unknown>) {
+    return this.context.inquirer.prompt([question]);
+  }
+
+  private async confirm(message: string): Promise<boolean> {
+    return (await this.ask({ type: 'confirm', name: 'value', message, default: true })).value;
+  }
+
+  private instruct(title: string, lines: string[]): void {
+    this.logger.log(`\n${this.chalk.bold(title)}`);
+    lines.forEach(line => this.logger.log(`  ${line}`));
+  }
+
+  // ---------- questions ----------
+
+  private async pickFlow(fromFlag?: Flow): Promise<Flow> {
+    if (fromFlag) return fromFlag;
+    if (!this.interactive) {
+      this.logger.log(this.chalk.grey('  (non-interactive — defaulting to demo data)'));
+
+      return 'demo';
+    }
+
+    const { flow } = await this.ask({
+      type: 'list',
+      name: 'flow',
+      message: 'How will you run Forest?',
+      choices: [
+        { name: 'Try it with demo data', value: 'demo' },
+        { name: 'Standalone — dedicated server on my database (recommended)', value: 'standalone' },
+        { name: 'In-app — add Forest to my existing app', value: 'inapp' },
+      ],
+    });
+
+    return flow;
+  }
+
+  private async pickStack(fromFlag?: 'rails' | 'node'): Promise<'rails' | 'node'> {
+    if (fromFlag) return fromFlag;
+    if (detectRails()) return 'rails';
+    if (!this.interactive) return 'node';
+
+    const { stack } = await this.ask({
+      type: 'list',
+      name: 'stack',
+      message: 'Your stack?',
+      choices: [
+        { name: 'Ruby on Rails', value: 'rails' },
+        { name: 'Node.js (Express / NestJS / Fastify / Koa)', value: 'node' },
+      ],
+    });
+
+    return stack;
+  }
+
+  /** One prompt for every flow. `createsDir` is the only difference that ever mattered: standalone
+   *  scaffolds ./<name>, so a collision is fatal; in-app writes nothing to disk. */
+  private async promptName(
+    fromFlag?: string,
+    { def = 'my-back-office', createsDir = false } = {},
+  ): Promise<string> {
+    if (fromFlag) return fromFlag;
+    if (!this.interactive) return def;
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      // eslint-disable-next-line no-await-in-loop -- a retry loop is sequential by nature
+      const { name } = await this.ask({
+        type: 'input',
+        name: 'name',
+        message: 'Project name:',
+        default: def,
+      });
+      if (!createsDir || this.dryRun || !fs.existsSync(name)) return name;
+      this.logger.warn(`./${name} already exists — pick another name.`);
+    }
+  }
+
+  // ---------- flows ----------
+
+  private async flowDemo(): Promise<void> {
+    const name = `forest-demo-${Math.random().toString(36).slice(2, 6)}`;
+
+    await this.forest([
+      'projects:create:demo',
+      name,
+      '-l',
+      'typescript',
+      '-H',
+      'http://localhost',
+      '-P',
+      String(DEMO_PORT),
+    ]);
+    await this.installAndBuild(name);
+
+    // The demo ships a curated layout; applying it needs the schema pushed first, so boot once.
+    const layout = [
+      'layout:apply',
+      'forest-layout.json',
+      '--with-workflows',
+      '-e',
+      'Development',
+      '-t',
+      'Operations',
+      '-f',
+    ];
+
+    let child: ChildProcess | undefined;
+
+    if (this.dryRun) {
+      this.logger.log(this.chalk.grey('\n$ npm start   (background — wait for schema push)'));
+    } else {
+      const booted = this.boot('npm', ['start'], { cwd: name });
+      child = booted.child;
+      this.logger.log(this.chalk.grey('\n$ npm start   (booting — waiting for the schema push…)'));
+      await booted.ready;
+      this.logger.success('Schema pushed — applying curated layout + workflows');
+    }
+
+    await this.forest(layout, name);
+    this.doneDemo(name);
+
+    // One tail for both modes: --dry-run exists to review the flow, and skipping its ending would
+    // hide the part most worth reviewing.
+    if (this.interactive) {
+      await this.demoMenu(child, name);
+
+      return;
+    }
+
+    stopProcess(child);
+    this.logger.log(this.chalk.grey(`  Launch it anytime: cd ${name} && npm start`));
+    this.logger.log(this.chalk.grey('  Connect real data: forest projects:create:sql'));
+  }
+
+  private async flowStandalone(flags: Record<string, string | undefined>): Promise<void> {
+    const name = await this.promptName(flags.name, { createsDir: true });
+    // `create:sql` prompts for the database itself — including the connection URL — so nothing
+    // about the user's credentials ever passes through this wrapper.
+    const args = ['projects:create:sql', name];
+    if (flags.db) args.push('--databaseConnectionURL', flags.db, '-s', 'public');
+    args.push('-l', 'typescript', '-H', 'http://localhost', '-P', String(DEMO_PORT));
+
+    await this.forest(args);
+    await this.installAndBuild(name);
+    this.logger.success(`Setup complete — booting your back-end on :${DEMO_PORT}…`);
+
+    const tail: Tail = {
+      name,
+      stack: "standalone Forest agent (TypeScript) on the user's own database",
+      url: `http://localhost:${DEMO_PORT}`,
+    };
+
+    if (this.dryRun) {
+      this.logger.log(this.chalk.grey(`\n$ npm start   (back-end stays live on :${DEMO_PORT})`));
+      this.doneStandalone(name);
+      await this.handoff({ ...tail, name }, name);
+
+      return;
+    }
+
+    const { child, ready } = this.boot('npm', ['start'], { cwd: name });
+    this.logger.log(this.chalk.grey('  (waiting for the schema push…)'));
+    await ready;
+    this.doneStandalone(name);
+    await this.handoff({ ...tail, child }, name);
+  }
+
+  private async flowInAppRails(flags: Record<string, string | undefined>): Promise<void> {
+    const name = await this.promptName(flags.name);
+    const output = await this.forestCapture([
+      'projects:create:in-app',
+      name,
+      '-H',
+      'http://localhost',
+      '-P',
+      String(RAILS_PORT),
+      '--format',
+      'json',
+    ]);
+    const secrets = StartCommand.parseSecrets(output);
+
+    // Five gems, not the three the docs list: forest_admin_rails alone installs but fails to boot,
+    // because it does not declare its companions as runtime dependencies.
+    await this.run$('bundle', [
+      'add',
+      'forest_admin_agent',
+      'forest_admin_rails',
+      'forest_admin_datasource_active_record',
+      'forest_admin_datasource_toolkit',
+      'forest_admin_datasource_customizer',
+    ]);
+    await this.run$('bin/rails', [
+      'g',
+      'forest_admin_rails:install',
+      secrets.envSecret ?? '<FOREST_ENV_SECRET>',
+    ]);
+
+    const tail: Tail = {
+      name,
+      stack: "Forest mounted inside the user's Ruby on Rails app",
+      url: `http://localhost:${RAILS_PORT}`,
+    };
+
+    if (this.dryRun) {
+      this.logger.log(this.chalk.grey(`\n$ bin/rails server -p ${RAILS_PORT}`));
+      this.doneInApp(name, RAILS_PORT);
+      await this.handoff(tail, name);
+
+      return;
+    }
+
+    const { child, ready } = this.boot('bin/rails', ['server', '-p', String(RAILS_PORT)], {
+      ready: /Listening on http|schema was updated/i,
+    });
+    this.logger.log(this.chalk.grey(`\n$ bin/rails server -p ${RAILS_PORT}   (booting…)`));
+    await ready;
+    this.doneInApp(name, RAILS_PORT);
+    await this.handoff({ ...tail, child }, name);
+  }
+
+  private async flowInAppNode(flags: Record<string, string | undefined>): Promise<void> {
+    const name = await this.promptName(flags.name);
+    const output = await this.forestCapture([
+      'projects:create:in-app',
+      name,
+      '-H',
+      'http://localhost',
+      '-P',
+      String(NODE_PORT),
+      '--format',
+      'json',
+    ]);
+    const secrets = StartCommand.parseSecrets(output);
+
+    const stack = detectNodeStack();
+    await this.run$('npm', ['install', '@forestadmin/agent', NODE_DATASOURCE[stack.orm]]);
+
+    const mount = await this.pickMount(flags.mount as string | undefined);
+    if (mount === 'standalone') {
+      this.logger.log(
+        this.chalk.grey(
+          '\n→ Mount on standalone: Forest runs as its own back-end on your DB (no code change).',
+        ),
+      );
+
+      await this.flowStandalone(flags);
+
+      return;
+    }
+
+    this.explainMount(mount, stack);
+
+    const tail: Tail = {
+      name,
+      stack: "Forest mounted inside the user's Node.js app",
+      url: `http://localhost:${NODE_PORT}`,
+    };
+
+    if (this.dryRun) {
+      this.logger.log(
+        this.chalk.grey('\n$ npm start   (with FOREST_ENV_SECRET / FOREST_AUTH_SECRET)'),
+      );
+      this.doneInApp(name, NODE_PORT);
+      await this.handoff(tail, name);
+
+      return;
+    }
+
+    if (!this.interactive) {
+      this.logger.log(
+        this.chalk.grey(
+          `\n  Then run:  FOREST_ENV_SECRET=${secrets.envSecret} FOREST_AUTH_SECRET=${secrets.authSecret} PORT=${NODE_PORT} npm start`,
+        ),
+      );
+
+      return;
+    }
+
+    await this.ask({
+      type: 'input',
+      name: 'go',
+      message: 'Once Forest is mounted in your server, press Enter to boot it',
+    });
+    const { child, ready } = this.boot('npm', ['start'], {
+      env: {
+        FOREST_ENV_SECRET: secrets.envSecret ?? '',
+        FOREST_AUTH_SECRET: secrets.authSecret ?? '',
+        PORT: String(NODE_PORT),
+      },
+    });
+    this.logger.log(this.chalk.grey('\n$ npm start   (booting…)'));
+    await ready;
+    this.doneInApp(name, NODE_PORT);
+    await this.handoff({ ...tail, child }, name);
+  }
+
+  private async pickMount(fromFlag?: string): Promise<string> {
+    if (fromFlag) return fromFlag;
+    if (!this.interactive) return 'ai';
+
+    const { mount } = await this.ask({
+      type: 'list',
+      name: 'mount',
+      message: 'How do you want to mount Forest?',
+      choices: [
+        { name: 'Wire it in with your coding agent', value: 'ai' },
+        { name: 'Mount it manually (snippet)', value: 'manual' },
+        { name: 'Mount on standalone', value: 'standalone' },
+      ],
+    });
+
+    return mount;
+  }
+
+  private explainMount(mount: string, stack: NodeStack): void {
+    if (mount === 'ai') {
+      this.instruct(
+        'Your coding agent will wire the mount (the Forest skills get installed at the end):',
+        [
+          `in your repo, ask it: ${this.chalk.cyan('"mount the Forest agent in my server"')}`,
+          this.chalk.grey('→ it reads your server, inserts the mount, shows you the diff.'),
+        ],
+      );
+
+      return;
+    }
+
+    const datasource =
+      stack.orm === 'sql'
+        ? 'createSqlDataSource(process.env.DATABASE_URL)'
+        : 'createSequelizeDataSource(sequelize)';
+    this.instruct('Add to your server (after your ORM is ready, before app.listen):', [
+      this.chalk.cyan("import { createAgent } from '@forestadmin/agent';"),
+      this.chalk.cyan(
+        'createAgent({ authSecret: process.env.FOREST_AUTH_SECRET, envSecret: process.env.FOREST_ENV_SECRET, isProduction: false })',
+      ),
+      this.chalk.cyan(
+        `  .addDataSource(${datasource}).mountOn${mountHelper(stack.framework)}(app).start();`,
+      ),
+      this.chalk.grey(`Exact per-stack snippet → ${DOCS_URL}/…/in-app/${stack.framework}`),
+    ]);
+  }
+
+  /** The generated project pins typescript ^4.9, which cannot parse recent `.d.cts` typings. */
+  private async installAndBuild(dir: string): Promise<void> {
+    await this.run$('npm', ['install'], dir);
+    await this.run$('npm', ['install', '--save-dev', 'typescript@^5.5'], dir);
+    await this.run$('npm', ['run', 'build'], dir);
+  }
+
+  // ---------- tails ----------
+
+  /** The demo is a TRAMPOLINE: its menu exists to nudge you towards connecting real data. */
+  private async demoMenu(child: ChildProcess | undefined, name: string): Promise<void> {
+    const { next } = await this.ask({
+      type: 'list',
+      name: 'next',
+      message: `Your demo back-end is live on :${DEMO_PORT}. What next?`,
+      choices: [
+        { name: 'Connect my real database (create a real project)', value: 'db' },
+        { name: 'Keep exploring — leave the back-end running', value: 'stay' },
+        { name: 'Stop', value: 'stop' },
+      ],
+    });
+    // No "invite a developer": the first production deploy is what creates the project's first
+    // role, so inviting before it silently invites into nothing.
+
+    if (next === 'db') {
+      stopProcess(child); // free the port for the real back-end
+      this.logger.log(
+        this.chalk.grey('\n  (demo back-end stopped — setting up your real project)\n'),
+      );
+
+      await this.flowStandalone({});
+
+      return;
+    }
+
+    if (next === 'stay') {
+      if (child) await this.keepAlive(child, name);
+
+      return;
+    }
+
+    stopProcess(child);
+    this.logger.log(
+      this.chalk.grey(`\n  Stopped. Relaunch the demo anytime: cd ${name} && npm start`),
+    );
+  }
+
+  /**
+   * The end of every real flow. A loop, like the demo's, because these are steps you chain — teach
+   * the agent, then deploy — not a one-shot question.
+   */
+  private async handoff(tail: Tail, name: string): Promise<void> {
+    if (!this.interactive) {
+      if (tail.child) {
+        stopProcess(tail.child);
+        this.logger.log(this.chalk.grey(`  Launch it anytime: cd ${name} && npm start`));
+      }
+
+      return;
+    }
+
+    let done = false;
+    while (!done) {
+      // eslint-disable-next-line no-await-in-loop -- a menu loop is sequential by nature
+      const { next } = await this.ask({
+        type: 'list',
+        name: 'next',
+        message: 'Your back-office is live. What next?',
+        choices: [
+          { name: 'Teach your coding agent about Forest', value: 'skills' },
+          { name: 'Deploy to production', value: 'deploy' },
+          { name: `Get started guide (${DOCS_URL})`, value: 'docs' },
+          { name: 'Keep exploring — leave the back-end running', value: 'stay' },
+        ],
+      });
+
+      // eslint-disable-next-line no-await-in-loop -- sequential by nature
+      const handedOver = await this.handoffChoice(next, tail, name);
+      if (handedOver) return; // the coding agent owns the terminal now
+      done = next === 'stay';
+    }
+
+    if (tail.child) await this.keepAlive(tail.child, name);
+  }
+
+  /** One menu choice. Returns true when the terminal was handed to a coding agent. */
+  private async handoffChoice(choice: string, tail: Tail, name: string): Promise<boolean> {
+    if (choice === 'docs') {
+      this.instruct('Get started guide:', [this.chalk.cyan(DOCS_URL)]);
+
+      return false;
+    }
+
+    if (choice === 'skills') {
+      // No --agent: `skills:init` asks which agents this repo uses, with the full list and its own
+      // repo-aware detection. One question, asked once, where the answer belongs.
+      await this.forest(['skills:init'], tail.child ? name : undefined);
+
+      return this.offerLaunch(tail, StartCommand.seed('customise', tail));
+    }
+
+    if (choice === 'deploy') {
+      // Deploying lives in the `deploy-heroku` SKILL, so it needs the skills installed first —
+      // `forest deploy` ships layout changes, it does not deploy the app.
+      if (await this.launch(tail, StartCommand.seed('deploy', tail))) return true;
+
+      this.instruct('Deploying needs your coding agent set up first:', [
+        `Pick ${this.chalk.cyan(
+          '"Teach your coding agent about Forest"',
+        )} above, then come back here.`,
+        this.chalk.grey(`Prefer to do it by hand? ${DOCS_URL}`),
+      ]);
+    }
+
+    return false;
+  }
+
+  private async offerLaunch(tail: Tail, seed: string): Promise<boolean> {
+    const [agent] = StartCommand.launchableAgents(tail.child ? tail.name : '.');
+    if (!agent) return false;
+    if (!(await this.confirm(`Launch ${agent.label} here now?`))) return false;
+
+    return this.launch(tail, seed);
+  }
+
+  /** Hand the terminal to a coding agent, seeded with a task. False when none was set up. */
+  private async launch(tail: Tail, seed: string): Promise<boolean> {
+    const cwd = tail.child ? tail.name : '.';
+    const [agent] = StartCommand.launchableAgents(cwd);
+    if (!agent) return false;
+
+    this.logger.log(
+      this.chalk.grey(
+        `\n  (your Forest back-end keeps running underneath — opening ${agent.label}…)`,
+      ),
+    );
+    await this.run$(agent.bin, [seed], cwd);
+    stopProcess(tail.child, 'SIGINT');
+    this.logger.log(
+      this.chalk.grey(
+        `\n  Forest back-end stopped. Restart it: cd ${tail.name} && npm run start:watch`,
+      ),
+    );
+
+    return true;
+  }
+
+  /** Hold the back-end in the foreground so a closed window is never a dead end. */
+  private keepAlive(child: ChildProcess, name: string): Promise<void> {
+    this.logger.log(
+      this.chalk.grey(
+        '\n  ▸ This terminal now runs your back-end (live logs below). Keep it open.',
+      ),
+    );
+    this.logger.log(
+      this.chalk.grey(`     Ctrl-C to stop  ·  restart later: cd ${name} && npm start`),
+    );
+
+    return new Promise(resolve => {
+      let stopped = false;
+      const stop = () => {
+        if (stopped) return;
+        stopped = true;
+        this.logger.log(
+          `\n\n${this.chalk.yellow('■')} Back-end stopped. Restart it anytime → ${this.chalk.cyan(
+            `cd ${name} && npm start`,
+          )}`,
+        );
+        stopProcess(child, 'SIGINT');
+        resolve();
+      };
+      process.on('SIGINT', stop);
+      child.on('exit', () => resolve());
+    });
+  }
+
+  // ---------- seeds & helpers ----------
+
+  /**
+   * What the CLI knows and the coding agent would otherwise have to guess — or guess wrong. Two
+   * facts earn their place: the back-end is ALREADY running (a fresh agent's first reflex is to
+   * boot it, which collides on the port or kills the live one), and nothing is deployed yet, so no
+   * role exists and inviting anyone is premature. Everything durable belongs in the skills.
+   */
+  private static seed(intent: 'customise' | 'deploy', tail: Tail): string {
+    const situation = [
+      `Stack: ${tail.stack}.`,
+      `Its back-end is already running on ${tail.url} — it is live, don't start it.`,
+      tail.demo
+        ? "The records are Forest sample data, not the user's own database."
+        : 'Development only: no production environment exists yet, so no role exists either.',
+      'The Forest skills and the Forest docs MCP are installed in this repo.',
+    ].join(' ');
+
+    const task =
+      intent === 'customise'
+        ? 'Help me customise my back-office — e.g. add a segment to a collection, a Smart Action, or an approval workflow.'
+        : "Deploy it to production, then invite my team — the first deploy is what creates the project's first role, so inviting only works once it has succeeded.";
+
+    return `You're in a Forest project. ${situation} ${task}`;
+  }
+
+  /**
+   * Which coding agents `skills:init` actually set up, read back from the manifest it just wrote.
+   * We deliberately do not detect them here: the toolbelt already does it, better — from the repo's
+   * own marks, and knowing Cursor and OpenCode too — and asking twice makes a flow feel like a form.
+   */
+  private static launchableAgents(cwd: string): { bin: string; label: string }[] {
+    const labels: Record<string, string> = { claude: 'Claude Code', codex: 'Codex' };
+    try {
+      const manifest = JSON.parse(
+        fs.readFileSync(`${cwd}/.forest/skills-manifest.json`, 'utf8'),
+      ) as { agents?: string[] };
+
+      return (manifest.agents ?? [])
+        .filter(agent => labels[agent])
+        .map(agent => ({ bin: agent, label: labels[agent] }));
+    } catch {
+      return []; // no manifest → skills were never installed here
+    }
+  }
+
+  private static parseSecrets(output: string): { envSecret?: string; authSecret?: string } {
+    try {
+      return JSON.parse(output);
+    } catch {
+      return {};
+    }
+  }
+
+  private doneDemo(name: string): void {
+    this.logger.success(
+      `Demo back-office live. Open ${this.chalk.cyan(`https://app.forestadmin.com/${name}`)}`,
+    );
+  }
+
+  private doneStandalone(name: string): void {
+    this.logger.success('Your back-office is live!');
+    this.logger.log(
+      `  ${this.chalk.bold('Open it →')} ${this.chalk.cyan(`https://app.forestadmin.com/${name}`)}`,
+    );
+    this.logger.log(
+      `  ${this.chalk.bold('Served by →')} http://localhost:${DEMO_PORT}   (this terminal)`,
+    );
+  }
+
+  private doneInApp(name: string, port: number): void {
+    this.logger.success('Forest is live in your app!');
+    this.logger.log(`  ${this.chalk.bold('Local /forest →')} http://localhost:${port}/forest`);
+    this.logger.log(
+      `  ${this.chalk.bold('Dashboard →')} ${this.chalk.cyan(
+        `https://app.forestadmin.com/${name}`,
+      )}`,
+    );
+  }
+}

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -202,11 +202,13 @@ export default class StartCommand extends AbstractCommand {
       this.logger.log(
         this.chalk.grey('  (this CLI has no --format json — reading the printed secrets)'),
       );
-      const { stdout, stderr } = await runCapture(
-        process.execPath,
-        [process.argv[1], ...withoutFormat],
-        { onProgress },
-      );
+      // NO onProgress here, unlike above: this retry captures the human output precisely because
+      // that is where the secrets are printed. Echoing it would put a long-lived credential in
+      // the terminal, the scrollback and — on the non-interactive path — a retained CI log.
+      const { stdout, stderr } = await runCapture(process.execPath, [
+        process.argv[1],
+        ...withoutFormat,
+      ]);
 
       return `${stdout}\n${stderr}`;
     }
@@ -549,12 +551,15 @@ export default class StartCommand extends AbstractCommand {
       // Written, never printed: this path is where CI logs are produced, and `FOREST_ENV_SECRET`
       // is a long-lived credential — anyone who can read the retained log gets the project. A
       // warning next to the value would not have stopped that.
-      const envFile = StartCommand.writeSecrets(secrets);
-      this.logger.success(`Secrets written to ${envFile} — do not commit it.`);
+      this.reportSecrets(StartCommand.writeSecrets(secrets));
       this.logger.log(this.chalk.grey(`  Then run:  PORT=${NODE_PORT} npm start`));
 
       return;
     }
+
+    // Persisted before booting, not just passed to this one process: everything the user is told
+    // afterwards — the restart hint, `npm start` — runs without our environment.
+    this.reportSecrets(StartCommand.writeSecrets(secrets));
 
     await this.ask({
       type: 'input',
@@ -890,20 +895,77 @@ export default class StartCommand extends AbstractCommand {
    * are left alone: overwriting a secret the user already configured would be worse than not
    * writing at all.
    */
-  private static writeSecrets(secrets: { envSecret?: string; authSecret?: string }): string {
+  private static writeSecrets(secrets: { envSecret?: string; authSecret?: string }): {
+    file: string;
+    written: string[];
+    conflicts: string[];
+  } {
     const file = '.env';
     const current = fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '';
-    const missing = Object.entries({
+    const written: string[] = [];
+    const conflicts: string[] = [];
+    const appended: string[] = [];
+    let content = current;
+
+    Object.entries({
       FOREST_ENV_SECRET: secrets.envSecret,
       FOREST_AUTH_SECRET: secrets.authSecret,
-    }).filter(([key, value]) => value && !new RegExp(`^${key}=`, 'm').test(current));
+    }).forEach(([key, value]) => {
+      if (!value) return;
 
-    if (missing.length) {
-      const separator = current && !current.endsWith('\n') ? '\n' : '';
-      fs.appendFileSync(file, `${separator}${missing.map(([k, v]) => `${k}=${v}`).join('\n')}\n`);
+      const assignment = new RegExp(`^${key}=(.*)$`, 'm');
+      const existing = assignment.exec(content)?.[1]?.trim();
+
+      if (existing === undefined) {
+        appended.push(`${key}=${value}`);
+        written.push(key);
+      } else if (existing === '') {
+        // A placeholder, not a configured value. Filled IN PLACE: appending would leave the file
+        // with the same key twice, which reads as a mistake even though dotenv takes the last.
+        content = content.replace(assignment, `${key}=${value}`);
+        written.push(key);
+      } else if (existing !== value) {
+        // A DIFFERENT secret is already there: overwriting it would break whatever it belongs to,
+        // and staying silent would leave the app pointing at another project while we report
+        // success. Neither is acceptable, so it is surfaced.
+        conflicts.push(key);
+      }
+    });
+
+    if (content !== current || appended.length) {
+      const separator = content && !content.endsWith('\n') ? '\n' : '';
+      fs.writeFileSync(
+        file,
+        appended.length ? `${content}${separator}${appended.join('\n')}\n` : content,
+      );
     }
 
-    return file;
+    return { file, written, conflicts };
+  }
+
+  /** Say what actually happened to the secrets — never the values themselves. */
+  private reportSecrets({
+    file,
+    written,
+    conflicts,
+  }: {
+    file: string;
+    written: string[];
+    conflicts: string[];
+  }): void {
+    if (written.length)
+      this.logger.success(`${written.join(' and ')} written to ${file} — do not commit it.`);
+    if (conflicts.length) {
+      this.logger.warn(
+        `${conflicts.join(
+          ' and ',
+        )} already set to a different value in ${file} — left untouched. ` +
+          'Your app will keep using the existing project until you replace it.',
+      );
+    }
+    if (!written.length && !conflicts.length) {
+      this.logger.warn(`No secret was returned, so nothing was written to ${file}.`);
+    }
   }
 
   private static parseSecrets(output: string): { envSecret?: string; authSecret?: string } {

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -23,7 +23,19 @@ const NODE_PORT = 3001;
 const READY = /Successfully mounted on|schema was (updated|not updated)|Listening on http/i;
 
 type Flow = 'demo' | 'standalone' | 'inapp';
-type Tail = { child?: ChildProcess; name: string; stack: string; url: string; demo?: boolean };
+type Tail = {
+  child?: ChildProcess;
+  /** Forest project name — a label, not necessarily a directory. */
+  name: string;
+  /** Where the repo lives: the scaffolded dir for standalone/demo, the user's own dir for in-app.
+   *  Derived from the FLOW, never from whether a process happens to be running. */
+  dir: string;
+  stack: string;
+  url: string;
+  demo?: boolean;
+  /** Stops streaming the back-end's logs — they would otherwise be drawn into a full-screen TUI. */
+  mute?: () => void;
+};
 
 /**
  * `forest start` — the whole onboarding, from an empty terminal to a running back-office.
@@ -52,12 +64,13 @@ export default class StartCommand extends AbstractCommand {
       default: false,
     }),
     flow: Flags.string({
-      description: 'Skip the first question. Required in non-interactive runs.',
+      description: 'Skip the first question. Without it, a non-interactive run defaults to demo.',
       options: ['demo', 'standalone', 'inapp'],
     }),
     stack: Flags.string({ description: 'In-app stack.', options: ['rails', 'node'] }),
     name: Flags.string({ description: 'Project name (skips the prompt).' }),
     db: Flags.string({ description: 'Database connection URL (skips the database prompts).' }),
+    schema: Flags.string({ description: 'Database schema, with --db (default: public).' }),
     mount: Flags.string({
       description: 'How to mount Forest in a Node app.',
       options: ['ai', 'manual', 'standalone'],
@@ -114,6 +127,12 @@ export default class StartCommand extends AbstractCommand {
     return runStep(process.execPath, [process.argv[1], ...args], { cwd });
   }
 
+  /**
+   * Invoke one of our own commands and read its stdout back. `--format json` is only understood by
+   * newer CLIs, so a rejection mentioning it is retried without: the flow must not die on a flag.
+   * stderr is streamed rather than swallowed — this command prints the secrets and the next steps
+   * there, and a silent terminal during project creation reads as a hang.
+   */
   private async forestCapture(args: string[]): Promise<string> {
     this.logger.log(this.chalk.grey(`\n$ forest ${args.join(' ')}`));
     if (this.dryRun) {
@@ -122,7 +141,33 @@ export default class StartCommand extends AbstractCommand {
       return '';
     }
 
-    return runCapture(process.execPath, [process.argv[1], ...args]);
+    const onProgress = (chunk: string) =>
+      this.logger.log(this.chalk.grey(chunk.replace(/\n$/, '')));
+
+    try {
+      const { stdout } = await runCapture(process.execPath, [process.argv[1], ...args], {
+        onProgress,
+      });
+
+      return stdout;
+    } catch (error) {
+      if (!/--format|Nonexistent flag/.test((error as Error).message) || !args.includes('--format'))
+        throw error;
+
+      const withoutFormat = args.filter(
+        (arg, index) => arg !== '--format' && args[index - 1] !== '--format',
+      );
+      this.logger.log(
+        this.chalk.grey('  (this CLI has no --format json — reading the printed secrets)'),
+      );
+      const { stdout, stderr } = await runCapture(
+        process.execPath,
+        [process.argv[1], ...withoutFormat],
+        { onProgress },
+      );
+
+      return `${stdout}\n${stderr}`;
+    }
   }
 
   /** Boot a back-end, streaming its logs, and wait until its schema reached Forest. */
@@ -178,13 +223,17 @@ export default class StartCommand extends AbstractCommand {
 
   private async pickStack(fromFlag?: 'rails' | 'node'): Promise<'rails' | 'node'> {
     if (fromFlag) return fromFlag;
-    if (detectRails()) return 'rails';
-    if (!this.interactive) return 'node';
+
+    // Detection picks the DEFAULT, never the answer: a Rails repo can still host the Node app the
+    // user means, and a guess that cannot be overridden is worse than no guess.
+    const detected = detectRails() ? 'rails' : 'node';
+    if (!this.interactive) return detected;
 
     const { stack } = await this.ask({
       type: 'list',
       name: 'stack',
       message: 'Your stack?',
+      default: detected,
       choices: [
         { name: 'Ruby on Rails', value: 'rails' },
         { name: 'Node.js (Express / NestJS / Fastify / Koa)', value: 'node' },
@@ -279,8 +328,23 @@ export default class StartCommand extends AbstractCommand {
     // `create:sql` prompts for the database itself — including the connection URL — so nothing
     // about the user's credentials ever passes through this wrapper.
     const args = ['projects:create:sql', name];
-    if (flags.db) args.push('--databaseConnectionURL', flags.db, '-s', 'public');
-    args.push('-l', 'typescript', '-H', 'http://localhost', '-P', String(DEMO_PORT));
+
+    // Without a --db, `create:sql` asks for everything itself — language and hostname included.
+    // Forcing them here would quietly take away the choice of JavaScript or of a free port.
+    if (flags.db) {
+      args.push(
+        '--databaseConnectionURL',
+        flags.db,
+        '-s',
+        flags.schema ?? 'public',
+        '-l',
+        'typescript',
+        '-H',
+        'http://localhost',
+        '-P',
+        String(DEMO_PORT),
+      );
+    }
 
     await this.forest(args);
     await this.installAndBuild(name);
@@ -288,6 +352,7 @@ export default class StartCommand extends AbstractCommand {
 
     const tail: Tail = {
       name,
+      dir: name, // `create:sql` scaffolded ./<name>
       stack: "standalone Forest agent (TypeScript) on the user's own database",
       url: `http://localhost:${DEMO_PORT}`,
     };
@@ -295,16 +360,16 @@ export default class StartCommand extends AbstractCommand {
     if (this.dryRun) {
       this.logger.log(this.chalk.grey(`\n$ npm start   (back-end stays live on :${DEMO_PORT})`));
       this.doneStandalone(name);
-      await this.handoff({ ...tail, name }, name);
+      await this.handoff(tail);
 
       return;
     }
 
-    const { child, ready } = this.boot('npm', ['start'], { cwd: name });
+    const booted = this.boot('npm', ['start'], { cwd: name });
     this.logger.log(this.chalk.grey('  (waiting for the schema push…)'));
-    await ready;
+    await booted.ready;
     this.doneStandalone(name);
-    await this.handoff({ ...tail, child }, name);
+    await this.handoff({ ...tail, child: booted.child, mute: booted.mute });
   }
 
   private async flowInAppRails(flags: Record<string, string | undefined>): Promise<void> {
@@ -331,6 +396,15 @@ export default class StartCommand extends AbstractCommand {
       'forest_admin_datasource_toolkit',
       'forest_admin_datasource_customizer',
     ]);
+    // Without it the generator writes a literal placeholder into the Rails initializer, on disk,
+    // and the app boots against nothing. Fail here instead, while nothing has been generated.
+    if (!secrets.envSecret && !this.dryRun) {
+      throw new Error(
+        'Could not read FOREST_ENV_SECRET from `projects:create:in-app`. Nothing was generated — ' +
+          'run it by hand and pass the secret to `bin/rails g forest_admin_rails:install`.',
+      );
+    }
+
     await this.run$('bin/rails', [
       'g',
       'forest_admin_rails:install',
@@ -339,6 +413,7 @@ export default class StartCommand extends AbstractCommand {
 
     const tail: Tail = {
       name,
+      dir: '.', // in-app scaffolds nothing: the repo is the user's own
       stack: "Forest mounted inside the user's Ruby on Rails app",
       url: `http://localhost:${RAILS_PORT}`,
     };
@@ -346,37 +421,24 @@ export default class StartCommand extends AbstractCommand {
     if (this.dryRun) {
       this.logger.log(this.chalk.grey(`\n$ bin/rails server -p ${RAILS_PORT}`));
       this.doneInApp(name, RAILS_PORT);
-      await this.handoff(tail, name);
+      await this.handoff(tail);
 
       return;
     }
 
-    const { child, ready } = this.boot('bin/rails', ['server', '-p', String(RAILS_PORT)], {
+    const booted = this.boot('bin/rails', ['server', '-p', String(RAILS_PORT)], {
       ready: /Listening on http|schema was updated/i,
     });
     this.logger.log(this.chalk.grey(`\n$ bin/rails server -p ${RAILS_PORT}   (booting…)`));
-    await ready;
+    await booted.ready;
     this.doneInApp(name, RAILS_PORT);
-    await this.handoff({ ...tail, child }, name);
+    await this.handoff({ ...tail, child: booted.child, mute: booted.mute });
   }
 
   private async flowInAppNode(flags: Record<string, string | undefined>): Promise<void> {
-    const name = await this.promptName(flags.name);
-    const output = await this.forestCapture([
-      'projects:create:in-app',
-      name,
-      '-H',
-      'http://localhost',
-      '-P',
-      String(NODE_PORT),
-      '--format',
-      'json',
-    ]);
-    const secrets = StartCommand.parseSecrets(output);
-
-    const stack = detectNodeStack();
-    await this.run$('npm', ['install', '@forestadmin/agent', NODE_DATASOURCE[stack.orm]]);
-
+    // Asked FIRST, and on purpose: "mount on standalone" abandons this flow, and everything below
+    // has side effects — a Forest project created server-side, and packages written into the
+    // user's own package.json. Asking after would leave both behind.
     const mount = await this.pickMount(flags.mount as string | undefined);
     if (mount === 'standalone') {
       this.logger.log(
@@ -390,10 +452,34 @@ export default class StartCommand extends AbstractCommand {
       return;
     }
 
+    const name = await this.promptName(flags.name);
+    const output = await this.forestCapture([
+      'projects:create:in-app',
+      name,
+      '-H',
+      'http://localhost',
+      '-P',
+      String(NODE_PORT),
+      '--format',
+      'json',
+    ]);
+    const secrets = StartCommand.parseSecrets(output);
+
+    if (!secrets.envSecret && !this.dryRun) {
+      throw new Error(
+        'Could not read FOREST_ENV_SECRET from `projects:create:in-app`. Nothing was installed — ' +
+          'run it by hand and set FOREST_ENV_SECRET / FOREST_AUTH_SECRET on your app.',
+      );
+    }
+
+    const stack = detectNodeStack();
+    await this.run$('npm', ['install', '@forestadmin/agent', NODE_DATASOURCE[stack.orm]]);
+
     this.explainMount(mount, stack);
 
     const tail: Tail = {
       name,
+      dir: '.', // in-app scaffolds nothing: the repo is the user's own
       stack: "Forest mounted inside the user's Node.js app",
       url: `http://localhost:${NODE_PORT}`,
     };
@@ -403,15 +489,18 @@ export default class StartCommand extends AbstractCommand {
         this.chalk.grey('\n$ npm start   (with FOREST_ENV_SECRET / FOREST_AUTH_SECRET)'),
       );
       this.doneInApp(name, NODE_PORT);
-      await this.handoff(tail, name);
+      await this.handoff(tail);
 
       return;
     }
 
     if (!this.interactive) {
+      // The secrets are what the app needs to boot, so they have to be shown — but they are
+      // long-lived credentials and this path is where CI logs are written, hence the warning.
+      this.logger.warn('The value below is a SECRET — do not commit it or paste it into logs.');
       this.logger.log(
         this.chalk.grey(
-          `\n  Then run:  FOREST_ENV_SECRET=${secrets.envSecret} FOREST_AUTH_SECRET=${secrets.authSecret} PORT=${NODE_PORT} npm start`,
+          `  Then run:  FOREST_ENV_SECRET=${secrets.envSecret} FOREST_AUTH_SECRET=${secrets.authSecret} PORT=${NODE_PORT} npm start`,
         ),
       );
 
@@ -423,7 +512,7 @@ export default class StartCommand extends AbstractCommand {
       name: 'go',
       message: 'Once Forest is mounted in your server, press Enter to boot it',
     });
-    const { child, ready } = this.boot('npm', ['start'], {
+    const booted = this.boot('npm', ['start'], {
       env: {
         FOREST_ENV_SECRET: secrets.envSecret ?? '',
         FOREST_AUTH_SECRET: secrets.authSecret ?? '',
@@ -431,9 +520,9 @@ export default class StartCommand extends AbstractCommand {
       },
     });
     this.logger.log(this.chalk.grey('\n$ npm start   (booting…)'));
-    await ready;
+    await booted.ready;
     this.doneInApp(name, NODE_PORT);
-    await this.handoff({ ...tail, child }, name);
+    await this.handoff({ ...tail, child: booted.child, mute: booted.mute });
   }
 
   private async pickMount(fromFlag?: string): Promise<string> {
@@ -467,10 +556,15 @@ export default class StartCommand extends AbstractCommand {
       return;
     }
 
-    const datasource =
-      stack.orm === 'sql'
-        ? 'createSqlDataSource(process.env.DATABASE_URL)'
-        : 'createSequelizeDataSource(sequelize)';
+    // Must match the package just installed: telling a mongoose app to call
+    // `createSequelizeDataSource` sends the user straight into an import that does not exist.
+    const datasource = {
+      sql: 'createSqlDataSource(process.env.DATABASE_URL)',
+      sequelize: 'createSequelizeDataSource(sequelize)',
+      mongoose: 'createMongooseDataSource(connection)',
+      typeorm: 'createTypeOrmDataSource(dataSource)',
+      prisma: 'createPrismaDataSource(prisma)',
+    }[stack.orm];
     this.instruct('Add to your server (after your ORM is ready, before app.listen):', [
       this.chalk.cyan("import { createAgent } from '@forestadmin/agent';"),
       this.chalk.cyan(
@@ -534,11 +628,11 @@ export default class StartCommand extends AbstractCommand {
    * The end of every real flow. A loop, like the demo's, because these are steps you chain — teach
    * the agent, then deploy — not a one-shot question.
    */
-  private async handoff(tail: Tail, name: string): Promise<void> {
+  private async handoff(tail: Tail): Promise<void> {
     if (!this.interactive) {
       if (tail.child) {
         stopProcess(tail.child);
-        this.logger.log(this.chalk.grey(`  Launch it anytime: cd ${name} && npm start`));
+        this.logger.log(this.chalk.grey(`  Launch it anytime: cd ${tail.dir} && npm start`));
       }
 
       return;
@@ -560,16 +654,16 @@ export default class StartCommand extends AbstractCommand {
       });
 
       // eslint-disable-next-line no-await-in-loop -- sequential by nature
-      const handedOver = await this.handoffChoice(next, tail, name);
+      const handedOver = await this.handoffChoice(next, tail);
       if (handedOver) return; // the coding agent owns the terminal now
       done = next === 'stay';
     }
 
-    if (tail.child) await this.keepAlive(tail.child, name);
+    if (tail.child) await this.keepAlive(tail.child, tail.dir);
   }
 
   /** One menu choice. Returns true when the terminal was handed to a coding agent. */
-  private async handoffChoice(choice: string, tail: Tail, name: string): Promise<boolean> {
+  private async handoffChoice(choice: string, tail: Tail): Promise<boolean> {
     if (choice === 'docs') {
       this.instruct('Get started guide:', [this.chalk.cyan(DOCS_URL)]);
 
@@ -579,7 +673,7 @@ export default class StartCommand extends AbstractCommand {
     if (choice === 'skills') {
       // No --agent: `skills:init` asks which agents this repo uses, with the full list and its own
       // repo-aware detection. One question, asked once, where the answer belongs.
-      await this.forest(['skills:init'], tail.child ? name : undefined);
+      await this.forest(['skills:init'], tail.dir);
 
       return this.offerLaunch(tail, StartCommand.seed('customise', tail));
     }
@@ -601,7 +695,7 @@ export default class StartCommand extends AbstractCommand {
   }
 
   private async offerLaunch(tail: Tail, seed: string): Promise<boolean> {
-    const [agent] = StartCommand.launchableAgents(tail.child ? tail.name : '.');
+    const [agent] = StartCommand.launchableAgents(tail.dir);
     if (!agent) return false;
     if (!(await this.confirm(`Launch ${agent.label} here now?`))) return false;
 
@@ -610,8 +704,7 @@ export default class StartCommand extends AbstractCommand {
 
   /** Hand the terminal to a coding agent, seeded with a task. False when none was set up. */
   private async launch(tail: Tail, seed: string): Promise<boolean> {
-    const cwd = tail.child ? tail.name : '.';
-    const [agent] = StartCommand.launchableAgents(cwd);
+    const [agent] = StartCommand.launchableAgents(tail.dir);
     if (!agent) return false;
 
     this.logger.log(
@@ -619,12 +712,10 @@ export default class StartCommand extends AbstractCommand {
         `\n  (your Forest back-end keeps running underneath — opening ${agent.label}…)`,
       ),
     );
-    await this.run$(agent.bin, [seed], cwd);
+    await this.run$(agent.bin, [seed], tail.dir);
     stopProcess(tail.child, 'SIGINT');
     this.logger.log(
-      this.chalk.grey(
-        `\n  Forest back-end stopped. Restart it: cd ${tail.name} && npm run start:watch`,
-      ),
+      this.chalk.grey(`\n  Forest back-end stopped. Restart it: cd ${tail.dir} && npm start`),
     );
 
     return true;
@@ -690,6 +781,11 @@ export default class StartCommand extends AbstractCommand {
    * We deliberately do not detect them here: the toolbelt already does it, better — from the repo's
    * own marks, and knowing Cursor and OpenCode too — and asking twice makes a flow feel like a form.
    */
+  /** Whether `skills:init` ran here at all — regardless of which agent it set up. */
+  private static hasSkills(dir: string): boolean {
+    return fs.existsSync(`${dir}/.forest/skills-manifest.json`);
+  }
+
   private static launchableAgents(cwd: string): { bin: string; label: string }[] {
     const labels: Record<string, string> = { claude: 'Claude Code', codex: 'Codex' };
     try {
@@ -705,12 +801,26 @@ export default class StartCommand extends AbstractCommand {
     }
   }
 
+  /**
+   * Read the secrets `projects:create:in-app` printed.
+   *
+   * Two shapes on purpose: the `--format json` document when the CLI supports it, and otherwise
+   * the human output, which prints `FOREST_ENV_SECRET=…` ungated for exactly this consumer. The
+   * fallback is what makes this work against a CLI that predates the flag rather than dying on
+   * `Nonexistent flag: --format`.
+   */
   private static parseSecrets(output: string): { envSecret?: string; authSecret?: string } {
     try {
-      return JSON.parse(output);
+      const parsed = JSON.parse(output.trim());
+      if (parsed?.envSecret) return parsed;
     } catch {
-      return {};
+      // Not JSON — fall through to the human output.
     }
+
+    return {
+      envSecret: /FOREST_ENV_SECRET=([0-9a-fA-F]+)/.exec(output)?.[1],
+      authSecret: /FOREST_AUTH_SECRET=([0-9a-fA-F]+)/.exec(output)?.[1],
+    };
   }
 
   private doneDemo(name: string): void {

--- a/src/services/onboarding/detect.ts
+++ b/src/services/onboarding/detect.ts
@@ -1,0 +1,86 @@
+import fs from 'fs';
+
+/**
+ * Reading what an existing application is built with, to install the right packages when Forest is
+ * mounted inside it (the "in-app" flows).
+ *
+ * Detection is deliberately silent and never blocking: it only picks a datasource package and a
+ * mount helper. Whatever it gets wrong, the user still sees the snippet and can correct it — so a
+ * wrong guess costs an edit, never a failed setup.
+ */
+
+export type NodeStack = {
+  framework: 'express' | 'nestJs' | 'fastify' | 'koa';
+  orm: 'sequelize' | 'mongoose' | 'typeorm' | 'prisma' | 'sql';
+  typescript: boolean;
+  /** False when there is no package.json at all — nothing was detected, we only have defaults. */
+  detected: boolean;
+};
+
+/** The Forest datasource package matching each ORM. */
+export const NODE_DATASOURCE: Record<NodeStack['orm'], string> = {
+  sequelize: '@forestadmin/datasource-sequelize',
+  mongoose: '@forestadmin/datasource-mongoose',
+  typeorm: '@forestadmin/datasource-typeorm',
+  prisma: '@forestadmin/datasource-prisma',
+  sql: '@forestadmin/datasource-sql',
+};
+
+function readJson(file: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/** Guess a Node application's framework and ORM from its declared dependencies. */
+export function detectNodeStack(): NodeStack {
+  const pkg = readJson('package.json') ?? {};
+  const dependencies = {
+    ...((pkg.dependencies as Record<string, string>) ?? {}),
+    ...((pkg.devDependencies as Record<string, string>) ?? {}),
+  };
+  const has = (name: string) => Object.prototype.hasOwnProperty.call(dependencies, name);
+
+  // Ordered by specificity: a NestJS app also depends on express, and a Prisma one often keeps a
+  // raw SQL driver around, so the most specific match has to win.
+  const framework = (
+    [
+      ['@nestjs/core', 'nestJs'],
+      ['fastify', 'fastify'],
+      ['koa', 'koa'],
+    ] as const
+  ).find(([dependency]) => has(dependency))?.[1];
+
+  const orm = (
+    [
+      ['sequelize', 'sequelize'],
+      ['mongoose', 'mongoose'],
+      ['typeorm', 'typeorm'],
+      ['@prisma/client', 'prisma'],
+      ['prisma', 'prisma'],
+    ] as const
+  ).find(([dependency]) => has(dependency))?.[1];
+
+  return {
+    framework: framework ?? 'express',
+    orm: orm ?? 'sql',
+    typescript: has('typescript') || fs.existsSync('tsconfig.json'),
+    detected: Boolean(pkg.name),
+  };
+}
+
+/** True when the current directory holds a Rails application. */
+export function detectRails(): boolean {
+  try {
+    return /gem\s+['"]rails['"]/.test(fs.readFileSync('Gemfile', 'utf8'));
+  } catch {
+    return false;
+  }
+}
+
+/** The mount helper name for a framework — `mountOnNestJs`, `mountOnExpress`, … */
+export function mountHelper(framework: NodeStack['framework']): string {
+  return framework === 'nestJs' ? 'NestJs' : framework.charAt(0).toUpperCase() + framework.slice(1);
+}

--- a/src/services/onboarding/detect.ts
+++ b/src/services/onboarding/detect.ts
@@ -74,7 +74,10 @@ export function detectNodeStack(): NodeStack {
 /** True when the current directory holds a Rails application. */
 export function detectRails(): boolean {
   try {
-    return /gem\s+['"]rails['"]/.test(fs.readFileSync('Gemfile', 'utf8'));
+    // Anchored per line and excluding comments: `# gem 'rails'` is how a Gemfile records that
+    // Rails was considered and NOT used, so matching it sends a Node repo down the Rails flow —
+    // installing Rails gems and calling `bin/rails` in a project that has neither.
+    return /^(?!\s*#).*gem\s+['"]rails['"]/m.test(fs.readFileSync('Gemfile', 'utf8'));
   } catch {
     return false;
   }

--- a/test/commands/start.test.js
+++ b/test/commands/start.test.js
@@ -1,0 +1,161 @@
+const StartCommand = require('../../src/commands/start').default;
+const testCli = require('./test-cli-helper/test-cli');
+
+// `--dry-run` prints every command instead of running it, so the whole orchestration can be
+// asserted with no project created, no package installed and no process spawned. It is also what
+// the flow is reviewed with, so testing it keeps the reviewed thing and the tested thing the same.
+//
+// stdin is not a TTY under the harness, so the interactive tails are skipped — each test asserts
+// one flow's command sequence, deterministically.
+
+describe('start', () => {
+  describe('demo flow', () => {
+    it('creates a demo project, builds it and applies the curated layout', async () => {
+      expect.hasAssertions();
+
+      await testCli({
+        commandClass: StartCommand,
+        commandArgs: ['--dry-run', '--flow', 'demo'],
+        std: [
+          { out: 'Welcome to Forest' },
+          { out: '$ forest login' },
+          { out: '$ forest projects:create:demo forest-demo-' },
+          { out: '-l typescript -H http://localhost -P 3310' },
+          { out: '$ npm install' },
+          { out: '$ npm run build' },
+          { out: '$ forest layout:apply forest-layout.json --with-workflows' },
+          { out: 'Demo back-office live.' },
+          // Non-interactive: no menu, but never a dead end either.
+          { out: 'Connect real data: forest projects:create:sql' },
+        ],
+      });
+    });
+  });
+
+  describe('standalone flow', () => {
+    it('passes the connection URL through to create:sql and reports both URLs', async () => {
+      expect.hasAssertions();
+
+      await testCli({
+        commandClass: StartCommand,
+        commandArgs: [
+          '--dry-run',
+          '--flow',
+          'standalone',
+          '--name',
+          'my-back-office',
+          '--db',
+          'postgres://u:p@h:5432/d',
+        ],
+        std: [
+          {
+            out: '$ forest projects:create:sql my-back-office --databaseConnectionURL postgres://u:p@h:5432/d',
+          },
+          { out: 'Setup complete — booting your back-end on :3310' },
+          { out: 'Your back-office is live!' },
+          { out: 'Open it → https://app.forestadmin.com/my-back-office' },
+          { out: 'Served by → http://localhost:3310' },
+        ],
+      });
+    });
+
+    it('leaves the database prompts to create:sql when no URL is given', async () => {
+      expect.hasAssertions();
+
+      await testCli({
+        commandClass: StartCommand,
+        commandArgs: ['--dry-run', '--flow', 'standalone', '--name', 'x'],
+        // No --databaseConnectionURL: credentials are typed into `create:sql` itself and never
+        // pass through this command.
+        std: [{ out: '$ forest projects:create:sql x -l typescript' }],
+      });
+    });
+  });
+
+  describe('in-app Rails flow', () => {
+    it('registers an in-app project then installs the five gems the boot actually needs', async () => {
+      expect.hasAssertions();
+
+      await testCli({
+        commandClass: StartCommand,
+        commandArgs: ['--dry-run', '--flow', 'inapp', '--stack', 'rails', '--name', 'app'],
+        std: [
+          { out: '$ forest projects:create:in-app app -H http://localhost -P 3002 --format json' },
+          // Five, not the three the docs list: forest_admin_rails alone installs but fails to boot.
+          { out: '$ bundle add forest_admin_agent forest_admin_rails' },
+          { out: 'forest_admin_datasource_customizer' },
+          { out: '$ bin/rails g forest_admin_rails:install' },
+          { out: 'Forest is live in your app!' },
+          { out: 'Local /forest → http://localhost:3002/forest' },
+        ],
+      });
+    });
+  });
+
+  describe('in-app Node flow', () => {
+    it('installs the datasource matching the detected ORM and prints the mount snippet', async () => {
+      expect.hasAssertions();
+
+      await testCli({
+        commandClass: StartCommand,
+        commandArgs: [
+          '--dry-run',
+          '--flow',
+          'inapp',
+          '--stack',
+          'node',
+          '--name',
+          'app',
+          '--mount',
+          'manual',
+        ],
+        files: [
+          { name: 'package.json', content: JSON.stringify({ name: 'app', dependencies: {} }) },
+        ],
+        std: [
+          { out: '$ forest projects:create:in-app app -H http://localhost -P 3001 --format json' },
+          // Nothing detected → the defaults, and the snippet matches them.
+          { out: '$ npm install @forestadmin/agent @forestadmin/datasource-sql' },
+          { out: 'Add to your server' },
+          { out: 'mountOnExpress(app).start();' },
+        ],
+      });
+    });
+
+    it('falls back to the standalone flow when the user declines to mount anything', async () => {
+      expect.hasAssertions();
+
+      await testCli({
+        commandClass: StartCommand,
+        commandArgs: [
+          '--dry-run',
+          '--flow',
+          'inapp',
+          '--stack',
+          'node',
+          '--name',
+          'app',
+          '--mount',
+          'standalone',
+        ],
+        std: [
+          { out: 'Forest runs as its own back-end on your DB (no code change).' },
+          // The standalone flow takes over — a real project, not a dead end.
+          { out: '$ forest projects:create:sql' },
+        ],
+      });
+    });
+  });
+
+  describe('--dry-run', () => {
+    it('runs nothing at all', async () => {
+      expect.hasAssertions();
+
+      await testCli({
+        commandClass: StartCommand,
+        commandArgs: ['--dry-run', '--flow', 'demo'],
+        std: [{ out: '(dry-run — not executed)' }],
+      });
+    });
+  });
+});

--- a/test/commands/start.test.js
+++ b/test/commands/start.test.js
@@ -1,4 +1,6 @@
 const fs = require('fs');
+const os = require('os');
+const path = require('path');
 
 const StartCommand = require('../../src/commands/start').default;
 const testCli = require('./test-cli-helper/test-cli');
@@ -11,6 +13,77 @@ const testCli = require('./test-cli-helper/test-cli');
 // one flow's command sequence, deterministically.
 
 describe('start', () => {
+  // `writeSecrets` is where a long-lived credential meets the user's own file, so its outcomes are
+  // asserted directly: what it wrote, what it refused to touch, and what it claims afterwards.
+  describe('writeSecrets', () => {
+    function inTempDir(run) {
+      const previous = process.cwd();
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'secrets-'));
+      process.chdir(dir);
+      try {
+        run();
+      } finally {
+        process.chdir(previous);
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    }
+
+    it('creates the file when it is absent, and says what it wrote', () => {
+      expect.assertions(2);
+      inTempDir(() => {
+        const result = StartCommand.writeSecrets({ envSecret: 'AAA', authSecret: 'BBB' });
+
+        expect(result).toStrictEqual({
+          file: '.env',
+          written: ['FOREST_ENV_SECRET', 'FOREST_AUTH_SECRET'],
+          conflicts: [],
+        });
+        expect(fs.readFileSync('.env', 'utf8')).toBe(
+          'FOREST_ENV_SECRET=AAA\nFOREST_AUTH_SECRET=BBB\n',
+        );
+      });
+    });
+
+    it('fills an empty placeholder in place rather than adding the key twice', () => {
+      expect.assertions(2);
+      inTempDir(() => {
+        fs.writeFileSync('.env', 'PORT=3001\nFOREST_ENV_SECRET=\n');
+        const result = StartCommand.writeSecrets({ envSecret: 'AAA' });
+
+        expect(result.written).toStrictEqual(['FOREST_ENV_SECRET']);
+        // A file carrying the same key twice reads as a mistake, even though dotenv takes the last.
+        expect(fs.readFileSync('.env', 'utf8')).toBe('PORT=3001\nFOREST_ENV_SECRET=AAA\n');
+      });
+    });
+
+    it('never overwrites a different secret, and reports the conflict instead of claiming success', () => {
+      expect.assertions(2);
+      inTempDir(() => {
+        fs.writeFileSync('.env', 'FOREST_ENV_SECRET=SOMEONE_ELSE\n');
+        const result = StartCommand.writeSecrets({ envSecret: 'AAA' });
+
+        // Silently reporting success here would leave the app on another project's credentials.
+        expect(result).toStrictEqual({
+          file: '.env',
+          written: [],
+          conflicts: ['FOREST_ENV_SECRET'],
+        });
+        expect(fs.readFileSync('.env', 'utf8')).toBe('FOREST_ENV_SECRET=SOMEONE_ELSE\n');
+      });
+    });
+
+    it('reports nothing written when no secret came back', () => {
+      expect.assertions(1);
+      inTempDir(() => {
+        expect(StartCommand.writeSecrets({})).toStrictEqual({
+          file: '.env',
+          written: [],
+          conflicts: [],
+        });
+      });
+    });
+  });
+
   describe('demo flow', () => {
     it('creates a demo project, builds it and applies the curated layout', async () => {
       expect.hasAssertions();

--- a/test/commands/start.test.js
+++ b/test/commands/start.test.js
@@ -48,8 +48,9 @@ describe('start', () => {
           'postgres://u:p@h:5432/d',
         ],
         std: [
+          // The URL carries credentials: echoed redacted, passed through intact.
           {
-            out: '$ forest projects:create:sql my-back-office --databaseConnectionURL postgres://u:p@h:5432/d',
+            out: '$ forest projects:create:sql my-back-office --databaseConnectionURL <redacted>',
           },
           { out: 'Setup complete — booting your back-end on :3310' },
           { out: 'Your back-office is live!' },
@@ -69,6 +70,25 @@ describe('start', () => {
         // of a hostname, or of a free port. Credentials never pass through this command either.
         // The trailing newline is the assertion: nothing follows the project name on that line.
         std: [{ out: '$ forest projects:create:sql x\n' }],
+      });
+    });
+
+    it('never echoes the database credentials it was given', async () => {
+      expect.hasAssertions();
+
+      await testCli({
+        commandClass: StartCommand,
+        commandArgs: [
+          '--dry-run',
+          '--flow',
+          'standalone',
+          '--name',
+          'x',
+          '--db',
+          'postgres://user:hunter2@host:5432/db',
+        ],
+        // A terminal, a scrollback and a CI log all keep what is printed.
+        std: [{ out: '--databaseConnectionURL <redacted>' }],
       });
     });
 

--- a/test/commands/start.test.js
+++ b/test/commands/start.test.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+
 const StartCommand = require('../../src/commands/start').default;
 const testCli = require('./test-cli-helper/test-cli');
 
@@ -114,6 +116,20 @@ describe('start', () => {
   });
 
   describe('in-app Rails flow', () => {
+    it('checks the secret before touching the Gemfile, so a failure installs nothing', async () => {
+      expect.hasAssertions();
+
+      // The create is mocked away by --dry-run, so no secret comes back; the guard must fire
+      // before `bundle add`, or five gems and a lockfile change are left in the user's repo
+      // while the error claims nothing was installed.
+      const source = fs.readFileSync('src/commands/start.ts', 'utf8');
+      const guard = source.indexOf('Checked before `bundle add`');
+      const bundle = source.indexOf("this.run$('bundle'");
+
+      expect(guard).toBeGreaterThan(-1);
+      expect(guard).toBeLessThan(bundle);
+    });
+
     it('registers an in-app project then installs the five gems the boot actually needs', async () => {
       expect.hasAssertions();
 
@@ -189,8 +205,10 @@ describe('start', () => {
         std: [
           { out: '@forestadmin/datasource-mongoose' },
           // Telling a mongoose app to call createSequelizeDataSource sends it into an import that
-          // does not exist.
+          // does not exist…
           { out: 'createMongooseDataSource(connection)' },
+          // …and calling a factory that is never imported does not compile either.
+          { out: "import { createMongooseDataSource } from '@forestadmin/datasource-mongoose';" },
         ],
       });
     });

--- a/test/commands/start.test.js
+++ b/test/commands/start.test.js
@@ -59,15 +59,36 @@ describe('start', () => {
       });
     });
 
-    it('leaves the database prompts to create:sql when no URL is given', async () => {
+    it('leaves every prompt to create:sql when no URL is given', async () => {
       expect.hasAssertions();
 
       await testCli({
         commandClass: StartCommand,
         commandArgs: ['--dry-run', '--flow', 'standalone', '--name', 'x'],
-        // No --databaseConnectionURL: credentials are typed into `create:sql` itself and never
-        // pass through this command.
-        std: [{ out: '$ forest projects:create:sql x -l typescript' }],
+        // Bare on purpose: forcing -l/-H/-P here would silently remove the choice of JavaScript,
+        // of a hostname, or of a free port. Credentials never pass through this command either.
+        // The trailing newline is the assertion: nothing follows the project name on that line.
+        std: [{ out: '$ forest projects:create:sql x\n' }],
+      });
+    });
+
+    it('honours --schema alongside --db', async () => {
+      expect.hasAssertions();
+
+      await testCli({
+        commandClass: StartCommand,
+        commandArgs: [
+          '--dry-run',
+          '--flow',
+          'standalone',
+          '--name',
+          'x',
+          '--db',
+          'postgres://u:p@h:5432/d',
+          '--schema',
+          'analytics',
+        ],
+        std: [{ out: '-s analytics' }],
       });
     });
   });
@@ -117,7 +138,65 @@ describe('start', () => {
           // Nothing detected → the defaults, and the snippet matches them.
           { out: '$ npm install @forestadmin/agent @forestadmin/datasource-sql' },
           { out: 'Add to your server' },
+          { out: 'createSqlDataSource(process.env.DATABASE_URL)' },
           { out: 'mountOnExpress(app).start();' },
+        ],
+      });
+    });
+
+    it('names the datasource the snippet uses after the one it installs', async () => {
+      expect.hasAssertions();
+
+      await testCli({
+        commandClass: StartCommand,
+        commandArgs: [
+          '--dry-run',
+          '--flow',
+          'inapp',
+          '--stack',
+          'node',
+          '--name',
+          'app',
+          '--mount',
+          'manual',
+        ],
+        files: [
+          {
+            name: 'package.json',
+            content: JSON.stringify({ name: 'app', dependencies: { mongoose: '^8.0.0' } }),
+          },
+        ],
+        std: [
+          { out: '@forestadmin/datasource-mongoose' },
+          // Telling a mongoose app to call createSequelizeDataSource sends it into an import that
+          // does not exist.
+          { out: 'createMongooseDataSource(connection)' },
+        ],
+      });
+    });
+
+    it('asks how to mount BEFORE creating anything, so declining leaves no stray project', async () => {
+      expect.hasAssertions();
+
+      await testCli({
+        commandClass: StartCommand,
+        commandArgs: [
+          '--dry-run',
+          '--flow',
+          'inapp',
+          '--stack',
+          'node',
+          '--name',
+          'app',
+          '--mount',
+          'standalone',
+        ],
+        // The two lines are adjacent in the output, which proves nothing ran in between — no
+        // in-app project created, no package written into the user's own app.
+        std: [
+          {
+            out: 'Forest runs as its own back-end on your DB (no code change).\n\n$ forest projects:create:sql',
+          },
         ],
       });
     });

--- a/test/services/onboarding/detect.unit.test.ts
+++ b/test/services/onboarding/detect.unit.test.ts
@@ -117,6 +117,20 @@ describe('onboarding detect', () => {
     });
   });
 
+  describe('detectRails, commented declarations', () => {
+    it('ignores a commented gem line, which records that Rails was NOT used', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.writeFileSync('Gemfile', "source 'x'\n# gem 'rails', '~> 8.0'\ngem 'sinatra'\n");
+        expect(detectRails()).toBe(false);
+
+        // …while an indented but live declaration still counts.
+        fs.writeFileSync('Gemfile', "group :default do\n  gem 'rails'\nend\n");
+        expect(detectRails()).toBe(true);
+      });
+    });
+  });
+
   describe('mountHelper', () => {
     it('capitalises the framework for mountOn<Framework>, keeping NestJs casing', () => {
       expect.assertions(3);

--- a/test/services/onboarding/detect.unit.test.ts
+++ b/test/services/onboarding/detect.unit.test.ts
@@ -1,0 +1,128 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  NODE_DATASOURCE,
+  detectNodeStack,
+  detectRails,
+  mountHelper,
+} from '../../../src/services/onboarding/detect';
+
+// Run `fn` inside a throwaway temp dir (cwd), restoring + cleaning up afterwards.
+// A helper (not a jest hook) — this repo forbids beforeEach/afterEach (jest/no-hooks).
+function withTempDir(run: () => void): void {
+  const previousCwd = process.cwd();
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'detect-test-'));
+  process.chdir(tmp);
+  try {
+    run();
+  } finally {
+    process.chdir(previousCwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+const writePkg = (dependencies: Record<string, string>) =>
+  fs.writeFileSync('package.json', JSON.stringify({ name: 'app', dependencies }));
+
+describe('onboarding detect', () => {
+  describe('detectNodeStack', () => {
+    it('falls back to express + sql when there is nothing to read', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        const stack = detectNodeStack();
+        expect(stack).toMatchObject({ framework: 'express', orm: 'sql' });
+        // Nothing was actually detected — the caller can tell defaults from findings.
+        expect(stack.detected).toBe(false);
+      });
+    });
+
+    it('prefers the most specific framework, since a NestJS app also depends on express', () => {
+      expect.assertions(1);
+      withTempDir(() => {
+        writePkg({ '@nestjs/core': '^10.0.0', express: '^4.0.0' });
+        expect(detectNodeStack().framework).toBe('nestJs');
+      });
+    });
+
+    it.each([
+      ['fastify', 'fastify'],
+      ['koa', 'koa'],
+      ['express', 'express'],
+    ])('detects %s', (dependency, framework) => {
+      expect.assertions(1);
+      withTempDir(() => {
+        writePkg({ [dependency]: '^1.0.0' });
+        expect(detectNodeStack().framework).toBe(framework);
+      });
+    });
+
+    it.each([
+      ['sequelize', 'sequelize'],
+      ['mongoose', 'mongoose'],
+      ['typeorm', 'typeorm'],
+      ['@prisma/client', 'prisma'],
+      ['prisma', 'prisma'],
+    ])('maps %s to the right datasource package', (dependency, orm) => {
+      expect.assertions(2);
+      withTempDir(() => {
+        writePkg({ [dependency]: '^1.0.0' });
+        expect(detectNodeStack().orm).toBe(orm);
+        expect(NODE_DATASOURCE[orm]).toContain('@forestadmin/datasource-');
+      });
+    });
+
+    it('reads devDependencies too, where typescript usually lives', () => {
+      expect.assertions(2);
+      withTempDir(() => {
+        fs.writeFileSync(
+          'package.json',
+          JSON.stringify({ name: 'app', devDependencies: { typescript: '^5.0.0' } }),
+        );
+        expect(detectNodeStack().typescript).toBe(true);
+        expect(detectNodeStack().detected).toBe(true);
+      });
+    });
+
+    it('treats a tsconfig.json as TypeScript even without the dependency', () => {
+      expect.assertions(1);
+      withTempDir(() => {
+        fs.writeFileSync('tsconfig.json', '{}');
+        expect(detectNodeStack().typescript).toBe(true);
+      });
+    });
+
+    it('survives an unreadable package.json instead of crashing the onboarding', () => {
+      expect.assertions(1);
+      withTempDir(() => {
+        fs.writeFileSync('package.json', '{ not json');
+        expect(detectNodeStack()).toMatchObject({ framework: 'express', detected: false });
+      });
+    });
+  });
+
+  describe('detectRails', () => {
+    it('recognises a Gemfile declaring rails, and ignores anything else', () => {
+      expect.assertions(3);
+      withTempDir(() => {
+        expect(detectRails()).toBe(false); // no Gemfile at all
+
+        fs.writeFileSync('Gemfile', "source 'https://rubygems.org'\ngem 'sinatra'\n");
+        expect(detectRails()).toBe(false);
+
+        fs.writeFileSync('Gemfile', "source 'https://rubygems.org'\ngem \"rails\", '~> 8.0'\n");
+        expect(detectRails()).toBe(true);
+      });
+    });
+  });
+
+  describe('mountHelper', () => {
+    it('capitalises the framework for mountOn<Framework>, keeping NestJs casing', () => {
+      expect.assertions(3);
+      expect(mountHelper('nestJs')).toBe('NestJs');
+      expect(mountHelper('express')).toBe('Express');
+      expect(mountHelper('fastify')).toBe('Fastify');
+    });
+  });
+});


### PR DESCRIPTION
> **Stacked on #816** (the process runner). Review that one first — this PR's diff is against it.

## What

`forest start` — the whole onboarding, from an empty terminal to a running back-office, in the package that owns the commands it drives.

```
npx forest-cli@latest start
```

Four flows, sharing a head (log in → pick how you run Forest):

| | |
| :-- | :-- |
| **Demo** | `create:demo` → boot → `layout:apply` → **trampoline** (connect real data) |
| **Standalone** | `create:sql` → boot → **handoff** |
| **In-app Rails** | `create:in-app` → gems → generator → boot → **handoff** |
| **In-app Node** | `create:in-app` → install → mount → boot → **handoff** |

Both tails are interactive loops over a live back-end — never a dead-end wall of text. Neither offers to invite teammates: the first production deploy is what creates the project's first role, so an invite before it lands nowhere.

## Why here rather than a separate repo

This replaces `ForestAdmin/forest-start`, which depended on a *published* `forest-cli`. That gap is what let a call to `skills:init --yes` ship with a flag no version has ever had — the wrapper could not be tested against unreleased CLI changes. It also had no tests, no lint and no CI. The repo gets archived once this ships.

## Adaptations from the original

- Sibling commands are invoked **through this executable**, not a `forest` on the PATH: under `npx forest-cli@latest start` there may be none installed.
- Long-running processes go through #816, so stopping a back-end stops the server the package manager spawned.
- Detection (framework, ORM, Rails) moves to a service, unit-testable without spawning anything.

## Findings folded in

Three independent reviews, one of which built a harness hosting the real command with its self-invocations intercepted — so the scenarios below were **executed**, not read.

The worst had a conceptual root: the handoff derived its working directory from *whether a process was running* (`tail.child ? name : '.'`), conflating "is something live" with "where do the files live". In-app scaffolds nothing, so `name` is a project label — yet in-app also boots a child, so the first menu action ran `skills:init` in a directory that does not exist and the user got `spawn ENOENT` right after a **successful** setup. The tail carries the directory now, decided by the flow.

- `--format json` only exists on #806, so both in-app flows died on `Nonexistent flag`. Secrets are read from the JSON document when available and from the printed output otherwise — so this works against today's CLI and after #806 lands.
- **Losing the secret is no longer silent**: Rails was writing a literal `<FOREST_ENV_SECRET>` into the generated initializer, on disk; Node booted empty and hung two minutes.
- **"Mount on standalone" is asked before anything is created.** It used to be offered after a project existed server-side and packages had been written into the user's own `package.json`, then created a second project.
- The mount snippet named `createSequelizeDataSource` for every non-SQL ORM — a mongoose app was told to import something that does not exist. It follows the package actually installed now.
- Without `--db`, `create:sql` gets no forced `-l/-H/-P`, so the choice of JavaScript, hostname and port stays the user's. `--schema` is back.
- **Cursor and OpenCode users had no way out**: skills installed, no launchable agent, so "Deploy" looped on "set up your agent first" forever.
- Back-end logs were drawn into the coding agent's full-screen TUI; the stream is muted before handing the terminal over.
- Rails detection sets the **default** rather than overriding the question.

## Tested

**25 tests** covering each flow's command sequence and the detection matrix, run against `--dry-run` — so the reviewed thing and the tested thing are the same, and no project, package or process is created.

The earlier version's tests asserted the broken `--format json` argv and the forced flags, **locking both in**: they only exercised `--dry-run`, the one mode where none of these bugs can appear. That is the lesson worth carrying — absence is now proven positively, since the `not` helper lands with #806.

Verified interactively in a pty for what a non-TTY harness cannot reach: all three menus, the loop-back after "Get started guide", the fallback when no agent is set up, and the mount snippet for a detected NestJS + Sequelize app.

## Note for review

The command is ~600 lines, where the repo prefers thin commands with logic in services. It is kept whole so the diff reads **as a port**, comparable line by line with the original. Extracting the flows into services is a good follow-up — mixed into the port it would make review much harder.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `forest start` CLI command for onboarding flows
> - Introduces the `forest start` command in [start.ts](https://github.com/ForestAdmin/toolbelt/pull/817/files#diff-fad98b12cdbc949be417ed9f456c26c2c5066dc9351e0f79506a9cd3900351e1) to guide users through onboarding via demo, standalone SQL, or in-app (Rails/Node) flows.
> - Adds [detect.ts](https://github.com/ForestAdmin/toolbelt/pull/817/files#diff-c01325acecb3ff3b5063e205197814c0a1ac66feb32a1c83bb15f2e37aff2b58) to automatically identify the host app's stack (frameworks, ORMs) and choose the correct datasource and mount helper.
> - Supports `--dry-run` mode, non-interactive defaults, safe writing of secrets to `.env`, and clean background process teardown on errors or exit.
> - Risk: `writeSecrets` in `start.ts` refuses to overwrite existing `FOREST_ENV_SECRET` or `FOREST_AUTH_SECRET` values in `.env` if they differ, which may block automated re-onboarding without manual `.env` cleanup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90bc848.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->