### PR TITLE
chore(security): resolution hygiene — remove 4 stale/redundant yarn resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,10 +142,6 @@
     "fast-xml-parser": ">=5.7.0",
     "uuid": "^11.1.1",
     "inquirer/**/tmp": "^0.2.6",
-    "brace-expansion": "^1.1.16 || ^2.1.2",
-    "@oclif/core/js-yaml": "^3.15.1",
-    "**/@istanbuljs/load-nyc-config/js-yaml": "^3.15.1",
-    "eslint/**/js-yaml": "^4.3.1",
-    "cosmiconfig/**/js-yaml": "^4.3.1"
+    "brace-expansion": "^1.1.16 || ^2.1.2"
   }
 }


### PR DESCRIPTION
> 👋 First-level support: see [Handling automated security PRs](https://forest.slite.com/app/docs/rmjdwFgmV2RzUp) for how to triage and merge this PR.

## Summary
0 fixed, 0 ignored, 0 deferred, 0 resolutions added, 4 resolutions removed. | label: :lock: security applied

No open Dependabot alerts on `ForestAdmin/toolbelt` at run time — this PR only cleans up stale/redundant Yarn `resolutions` entries. Resolution hygiene is worth shipping on its own.

## Fixed
_None — no open Dependabot alerts._

## Ignored
_None._

## Deferred
_None._

## Resolutions added
_None._

## Resolutions removed
| File | Pinned entry | Reason |
| --- | --- | --- |
| `package.json` | `@oclif/core/js-yaml: "^3.15.1"` | **Redundant.** With the pin removed, `yarn install` still resolves `@oclif/core#js-yaml@3.15.1` (verified via `yarn why js-yaml`), which satisfies the original `^3.15.1` range. |
| `package.json` | `**/@istanbuljs/load-nyc-config/js-yaml: "^3.15.1"` | **Redundant.** With the pin removed, `@istanbuljs/load-nyc-config#js-yaml` still resolves to `3.15.1`, satisfying `^3.15.1`. |
| `package.json` | `eslint/**/js-yaml: "^4.3.1"` | **Stale.** No `eslint#js-yaml` node appears in the resolved dependency tree — `eslint` no longer depends on `js-yaml` transitively. |
| `package.json` | `cosmiconfig/**/js-yaml: "^4.3.1"` | **Stale.** No `cosmiconfig#js-yaml` node appears in the resolved dependency tree — `cosmiconfig` no longer depends on `js-yaml` transitively. |

## Risks
No behaviour change. The four removed pins were only for `js-yaml` in dev/build tooling paths:

- The redundant `@oclif/core` and `@istanbuljs/load-nyc-config` scopes continue to resolve to the same `js-yaml@3.15.1` version they had with the pin in place (verified with a fresh `yarn install` — `yarn.lock` was unchanged).
- The stale `eslint` and `cosmiconfig` scopes matched no node in the tree; removing them can't shift any version.

Root `js-yaml` stays at `4.3.1`, `@oclif/core#js-yaml` and `@istanbuljs/load-nyc-config#js-yaml` stay at `3.15.1` — same as before this PR.

The six remaining resolutions (`@azure/core-tracing`, `jws`, `fast-xml-parser`, `uuid`, `inquirer/**/tmp`, `brace-expansion`) were each verified as still load-bearing: removing any of them lets a lower/vulnerable version leak back into the tree, so they were kept.

## Manual testing
Covered by CI.

## Validation
✅ CI green
